### PR TITLE
v0.10.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # 📰 News
 
+## v0.10.1
+
+- Change --metadata cli syntax to use key=[a,b,c] for arrays and key=a for simple values.
+
 ## v0.10.0
 
 - WARNING: Breaking API, CLI & Config changes.

--- a/comicbox/cli.py
+++ b/comicbox/cli.py
@@ -31,9 +31,13 @@ class KeyValueDictAction(Action):
         """Parse comma delimited key value pairs."""
         if not values:
             return
-        key, values_list = values.split("=")
-        values_array = values_list.split(",")
-        values_dict = {key: values_array}
+        key, value_str = values.split("=")
+        if value_str.startswith("[") and value_str.endswith("]"):
+            values_list_str = value_str[1:-1]
+            val = values_list_str.split(",")
+        else:
+            val = value_str
+        values_dict = {key: val}
         dest_dict = getattr(namespace, self.dest, {})
         if dest_dict is None:
             dest_dict = {}
@@ -156,7 +160,7 @@ def get_args(params=None) -> Namespace:
         "-m",
         "--metadata",
         action=KeyValueDictAction,
-        help="Set metadata fields key=value,key=value",
+        help="Set metadata fields key=value or key=[valueA,valueB,valueC] for lists",
     )
 
     ###########

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "comicbox"
-version = "0.10.0"
+version = "0.10.1"
 description = "An API for reading comic archives"
 license = "LGPL-3.0-only"
 authors = ["AJ Slater <aj@slater.net>"]


### PR DESCRIPTION
- Change --metadata cli syntax to use key=[a,b,c] for arrays and key=a for simple values.
