### PR TITLE
Fix path traversal vulnerability in archive extraction

### DIFF
--- a/comicbox/box/dump_files.py
+++ b/comicbox/box/dump_files.py
@@ -23,6 +23,9 @@ class ComicboxDumpToFiles(ComicboxDump):
         dest_path = Path(dest_path)
         fn = fmt.value.filename
         path = dest_path / fn
+        if not path.resolve().is_relative_to(dest_path.resolve()):
+            reason = f"Unsafe path escapes destination: {path}"
+            raise ValueError(reason)
         try:
             schema, denormalized_metadata = self._to_dict(fmt)
             schema.dumpf(denormalized_metadata, path, **kwargs)

--- a/comicbox/box/pages/extract.py
+++ b/comicbox/box/pages/extract.py
@@ -7,6 +7,13 @@ from loguru import logger
 from comicbox.box.pages.covers import ComicboxPagesCovers
 
 
+def _validate_extract_path(path: Path, dest_dir: Path) -> None:
+    """Validate that the extract path doesn't escape the destination directory."""
+    if not path.resolve().is_relative_to(dest_dir.resolve()):
+        reason = f"Unsafe archive path escapes destination: {path}"
+        raise ValueError(reason)
+
+
 class ComicboxExtractPages(ComicboxPagesCovers):
     """Methods for extracting files from the archive."""
 
@@ -22,6 +29,8 @@ class ComicboxExtractPages(ComicboxPagesCovers):
         data = self._archive_readfile(fn, props=props)
         if ext := props.get("ext", ""):
             path = path.with_suffix("." + ext)
+        dest_dir = dest_path if dest_path.is_dir() else dest_path.parent
+        _validate_extract_path(path, dest_dir)
         path.write_bytes(data)
 
     def _extract_all_pagenames(self, pagenames, path) -> None:


### PR DESCRIPTION
## Summary

- Add path traversal (zip-slip) validation to `extract.py` before `write_bytes()` — resolves the output path and verifies it stays within the destination directory
- Add equivalent validation to `dump_files.py` before `dumpf()` — ensures exported metadata files can't escape `dest_path`
- Uses `Path.resolve()` + `is_relative_to()` as a second layer of defense behind the existing `Path(fn).name` stripping in `_extract_page_get_path`

## Test plan

- [x] All 259 existing tests pass
- [ ] Verify manually with a crafted archive containing `../../etc/passwd` as a member name

🤖 Generated with [Claude Code](https://claude.com/claude-code)