### PR TITLE
Fix Mapping config args silently dropped under config_default.yaml

### DIFF
--- a/comicbox/config/read.py
+++ b/comicbox/config/read.py
@@ -35,9 +35,12 @@ def read_config_sources(
     # Env vars
     config.set_env()
 
-    # Args
+    # Args (highest priority — must override config files and env vars).
+    # Mapping uses .set() so it lands on top of the source stack like
+    # set_args() does for Namespace; .add() would put it BELOW the
+    # config_default.yaml loaded by .read() above.
     if args:
         if isinstance(args, Mapping):
-            config.add(args)
+            config.set(args)
         elif isinstance(args, Namespace):  # pyright: ignore[reportUnnecessaryIsInstance]
             config.set_args(args)

--- a/tests/unit/test_config_layering.py
+++ b/tests/unit/test_config_layering.py
@@ -1,0 +1,38 @@
+"""Layering / priority tests for get_config()."""
+
+from argparse import Namespace
+
+from comicbox.config import get_config
+
+
+def test_default_no_args() -> None:
+    """No args => the bundled config_default.yaml drives the result."""
+    cfg = get_config()
+    assert cfg.compute_pages is False  # default
+
+
+def test_namespace_overrides_default() -> None:
+    """Namespace args override config_default.yaml."""
+    cfg = get_config(Namespace(comicbox=Namespace(compute_pages=True)))
+    assert cfg.compute_pages is True
+
+
+def test_mapping_overrides_default() -> None:
+    """
+    Mapping args must land at top priority — same as Namespace.
+
+    Regression: read_config_sources used to call config.add() for the
+    Mapping branch, which puts the source at the BOTTOM of the priority
+    stack — below config_default.yaml — so user overrides were silently
+    ignored. Must use config.set().
+    """
+    cfg = get_config({"comicbox": {"compute_pages": True}})
+    assert cfg.compute_pages is True
+
+
+def test_mapping_and_namespace_agree() -> None:
+    """Same overrides via Mapping and Namespace produce equivalent settings."""
+    via_map = get_config({"comicbox": {"compute_pages": True, "dry_run": True}})
+    via_ns = get_config(Namespace(comicbox=Namespace(compute_pages=True, dry_run=True)))
+    assert via_map.compute_pages == via_ns.compute_pages is True
+    assert via_map.dry_run == via_ns.dry_run is True


### PR DESCRIPTION
## Summary

`read_config_sources` used `config.add()` for the Mapping branch, which appends a source to the **bottom** of confuse's priority stack — below the `config_default.yaml` loaded by `config.read()` at the top of the function. So any caller passing a dict / Mapping override (e.g. `get_config({"comicbox": {"compute_pages": True}})`) silently got the default instead.

The Namespace branch uses `set_args()`, which correctly inserts at the top of the stack — that path has always worked. Switching the Mapping branch to `config.set()` aligns the two.

Surfaced by a downstream Codex migration that hit dead Mapping overrides.

## Repro (before the fix)

```python
from argparse import Namespace
from comicbox.config import get_config

get_config({"comicbox": {"compute_pages": True}}).compute_pages
# False — the default-yaml value wins (BUG)

get_config(Namespace(comicbox=Namespace(compute_pages=True))).compute_pages
# True — Namespace path correctly overrides
```

## Test plan

- [x] New `tests/unit/test_config_layering.py` covers four cases:
  - default no-args produces `compute_pages=False`
  - Namespace overrides default
  - Mapping overrides default (regression — this was the silently-broken case)
  - Mapping and Namespace produce equivalent settings for the same overrides
- [x] `make fix && make lint && make ty` — all clean (the two `make` warnings about `target 'all'` predate this change and exist on `develop`; flagging separately as a workflow issue)
- [x] Full suite: 290 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)