### PR TITLE
Add skip_metadata flag to get_cover_page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
       comicbox.process.iter_process_files() and
       comicbox.process.aread_metadata() for reading large batches of files at
       once.
+    - `Comicbox.get_cover_page(skip_metadata=True)` skips metadata parsing for
+      callers that just need the first archive image as a thumbnail. Removes
+      per-call schema instantiation and Union resolution overhead.
 - Security against suspicious archive paths when extracting pages and metadata
   to the filesystem.
 - Add Age Rating conversion function

--- a/comicbox/box/pages/covers.py
+++ b/comicbox/box/pages/covers.py
@@ -54,7 +54,21 @@ class ComicboxPagesCovers(ComicboxMetadata):
             self._cover_paths = self._get_cover_paths()
         return self._cover_paths  # pyright: ignore[reportReturnType], #ty: ignore[invalid-return-type]
 
-    def _get_cover_page(self, pdf_format: str = "") -> bytes:
+    def _get_cover_page_skip_metadata(self, pdf_format: str = "") -> bytes:
+        first_pagename = self.get_pagename(0)
+        if not first_pagename:
+            return b""
+        try:
+            return self._archive_readfile(first_pagename, pdf_format=pdf_format)
+        except Exception as exc:
+            logger.warning(f"{self._path} reading first page: {first_pagename}: {exc}")
+            return b""
+
+    def _get_cover_page(
+        self, pdf_format: str = "", *, skip_metadata: bool = False
+    ) -> bytes:
+        if skip_metadata:
+            return self._get_cover_page_skip_metadata(pdf_format=pdf_format)
         data = b""
         cover_paths = self.generate_cover_paths()
         bad_cover_paths = set()
@@ -69,6 +83,15 @@ class ComicboxPagesCovers(ComicboxMetadata):
                 bad_cover_paths.add(cover_path)
         return data
 
-    def get_cover_page(self, pdf_format: str = "") -> bytes:
-        """Return cover image data."""
-        return self._get_cover_page(pdf_format=pdf_format)
+    def get_cover_page(
+        self, pdf_format: str = "", *, skip_metadata: bool = False
+    ) -> bytes:
+        """
+        Return cover image data.
+
+        When skip_metadata is True, bypass cover-hint metadata parsing and
+        return the bytes of the first archive page directly. Useful for
+        callers that only need a thumbnail and want to avoid the cost of
+        schema instantiation and Union resolution.
+        """
+        return self._get_cover_page(pdf_format=pdf_format, skip_metadata=skip_metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "LGPL-3.0-only"
 name = "comicbox"
-version = "3.0.0a1"
+version = "3.0.0a2"
 [[project.authors]]
 name = "AJ Slater"
 email = "aj@slater.net"

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,6 +1,7 @@
 """Test getting pages."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 from comicbox.box import Comicbox
 from tests.const import TEST_FILES_DIR
@@ -21,6 +22,28 @@ def test_get_covers() -> None:
     with Comicbox(ARCHIVE_PATH) as car:
         page = car.get_cover_page()
     assert image == page
+
+
+def test_get_cover_skip_metadata() -> None:
+    """Skip-metadata path returns the first archive image."""
+    with COVER_IMAGE.open("rb") as cif:
+        image = cif.read()
+    with Comicbox(ARCHIVE_PATH) as car:
+        page = car.get_cover_page(skip_metadata=True)
+    assert image == page
+
+
+def test_get_cover_skip_metadata_does_not_read_metadata() -> None:
+    """Skip-metadata path must not call get_internal_metadata."""
+    with (
+        Comicbox(ARCHIVE_PATH) as car,
+        patch.object(
+            car, "get_internal_metadata", wraps=car.get_internal_metadata
+        ) as spy,
+    ):
+        page = car.get_cover_page(skip_metadata=True)
+    assert page
+    assert spy.call_count == 0
 
 
 def test_get_random_page() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -626,7 +626,7 @@ wheels = [
 
 [[package]]
 name = "comicbox"
-version = "3.0.0a1"
+version = "3.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "ansicolors" },


### PR DESCRIPTION
## Summary

- Adds `Comicbox.get_cover_page(skip_metadata=True)` that bypasses
  `generate_cover_paths()` and reads archive index 0 directly.
- Skips per-call schema instantiation, Union resolution, and path
  normalization for callers that just need a thumbnail.
- Bumps version to `3.0.0a2` and adds a NEWS entry.

## Why

Cover-extraction-heavy workloads (e.g. codex's CoverThread regenerating
hundreds of thumbnails on startup) currently parse the full metadata
on every comic just to look for a `<PageType=\"FrontCover\">` hint that
the vast majority of archives don't carry. The default path stays
unchanged; only callers that opt in get the shortcut.

It also silences the debug-bucket `ValidationError - {'_schema': ['Invalid input type.']}`
log spam from Marshmallow Union resolution on the skip path — those
errors are normal variant-matching but read like real failures at
DEBUG.

## Test plan

- [x] New `test_get_cover_skip_metadata` asserts the page-0 bytes
      come back when `skip_metadata=True`.
- [x] New `test_get_cover_skip_metadata_does_not_read_metadata`
      patches `get_internal_metadata` and asserts it's never called
      on the skip path.
- [x] Full suite: 307 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)