### PR TITLE
Drop DEBUG-bucket logging of ignored validation errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,11 @@
     - `Comicbox.get_cover_page(skip_metadata=True)` skips metadata parsing for
       callers that just need the first archive image as a thumbnail. Removes
       per-call schema instantiation and Union resolution overhead.
+    - Drop the DEBUG-level emission of intentionally-ignored Marshmallow
+      validation errors (`Invalid input type.` from Union variant misses,
+      `Field may not be null.` from sparse fields). These were context-free
+      noise — ~50 lines per archive at DEBUG that read like real failures. Real
+      schema errors still log at WARNING with full context.
 - Security against suspicious archive paths when extracting pages and metadata
   to the filesystem.
 - Add Age Rating conversion function

--- a/comicbox/schemas/error_store.py
+++ b/comicbox/schemas/error_store.py
@@ -128,27 +128,18 @@ class ClearingErrorStoreSchema(Schema):
             )
         super()._invoke_schema_validators(error_store=error_store, **kwargs)
 
-    def _split_list_errors(self, error_list: list) -> tuple:
-        error_set = frozenset(error_list)
-        debug_error_set = error_set & self._ignore_errors
-        debug_errors = sorted(debug_error_set)
-        warning_errors = sorted(error_set - debug_error_set)
-        return debug_errors, warning_errors
+    def _filter_list(self, error_list: list) -> list:
+        return sorted(frozenset(error_list) - self._ignore_errors)
 
-    def _split_mapping_errors(self, error: Mapping) -> tuple[dict, dict]:
-        debug_errors = {}
-        warning_errors = {}
-        for key, error_list in error.items():
-            debug_error_list, warning_error_list = self._split_list_errors(error_list)
-            if debug_error_list:
-                debug_errors[key] = debug_error_list
-            if warning_error_list:
-                warning_errors[key] = warning_error_list
-        return debug_errors, warning_errors
+    def _filter_mapping(self, error: Mapping) -> dict:
+        return {
+            key: filtered
+            for key, error_list in error.items()
+            if (filtered := self._filter_list(error_list))
+        }
 
-    def _log_errors(
+    def _log_warnings(
         self,
-        loglevel: str,
         error_class: type | None,
         errors: Mapping | list,
     ) -> None:
@@ -157,7 +148,7 @@ class ClearingErrorStoreSchema(Schema):
         path = f"{self._path}: " if self._path else ""
         error_name = f"{error_class.__name__} - " if error_class else ""
         message = f"{path}{error_name}{errors}"
-        logger.log(loglevel, message)
+        logger.warning(message)
 
     @override
     def handle_error(
@@ -166,7 +157,7 @@ class ClearingErrorStoreSchema(Schema):
         *_args: Any,
         **_kwargs: Any,
     ) -> None:
-        """Log errors by severity."""
+        """Log unignored errors at WARNING; ignored errors are dropped."""
         if hasattr(error, "normalized_messages"):
             error_class = type(error)
             error = error.normalized_messages()
@@ -177,12 +168,9 @@ class ClearingErrorStoreSchema(Schema):
             error_class = None
 
         if isinstance(error, Mapping):
-            debug_errors, warning_errors = self._split_mapping_errors(error)
+            warning_errors = self._filter_mapping(error)
         else:
             error_list = error if isinstance(error, list) else [error]
-            debug_errors, warning_errors = self._split_list_errors(error_list)
+            warning_errors = self._filter_list(error_list)
 
-        logs = {"WARNING": warning_errors, "DEBUG": debug_errors}
-
-        for loglevel, errors in logs.items():
-            self._log_errors(loglevel, error_class, errors)
+        self._log_warnings(error_class, warning_errors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "LGPL-3.0-only"
 name = "comicbox"
-version = "3.0.0a2"
+version = "3.0.0a3"
 [[project.authors]]
 name = "AJ Slater"
 email = "aj@slater.net"

--- a/uv.lock
+++ b/uv.lock
@@ -626,7 +626,7 @@ wheels = [
 
 [[package]]
 name = "comicbox"
-version = "3.0.0a2"
+version = "3.0.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "ansicolors" },


### PR DESCRIPTION
## Summary

- Stop emitting intentionally-ignored Marshmallow errors at DEBUG.
- Collapse the dual-bucket `_split_*_errors` methods into `_filter_*` +
  `_log_warnings`.

## Why

\`ClearingErrorStoreSchema.handle_error\` was logging two buckets:
- WARNING for real schema failures (kept).
- DEBUG for errors that match \`_ignore_errors\` — by construction
  only \`Field may not be null.\` and \`Invalid input type.\` (Union
  variant misses).

Those DEBUG lines were context-free and per-Union-variant per-field
per-archive — \~50 lines per import that read like real failures and
drowned out the genuinely useful per-source DEBUG messages already
emitted by \`_except_on_load\` (e.g. \"Parsed Archive Comment with
ComicBookInfo\", \"X metadata is not JSON\").

If a real schema validation fails, it goes to WARNING with full
context (path, schema class, normalized message) — that path is
unchanged.

## Test plan

- [x] Full suite: 307 passed locally.
- [x] \`make fix\` / \`make lint\` clean.
- [ ] On a real DEBUG-level codex import, confirm the per-archive
      \`ValidationError - {'_schema': ['Invalid input type.']}\` line
      count drops to zero while \"Parsed X with Y\" / \"Unable to load
      X:Y\" lines remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)