### PR TITLE
Re-export to_metron_age_rating from comicbox.enums.maps

### DIFF
--- a/comicbox/enums/maps/__init__.py
+++ b/comicbox/enums/maps/__init__.py
@@ -1,1 +1,5 @@
 """Enum Maps."""
+
+from comicbox.enums.maps.age_rating import to_metron_age_rating
+
+__all__ = ("to_metron_age_rating",)


### PR DESCRIPTION
## Summary

- Re-exports `to_metron_age_rating` from `comicbox.enums.maps` so callers can `from comicbox.enums.maps import to_metron_age_rating` instead of drilling into `comicbox.enums.maps.age_rating`.

## Why

The helper is a public utility (used externally and covered by `tests/unit/test_to_metron_age_rating.py`), but its existing import path was awkwardly deep. Re-exporting one level up trims the path without making `comicbox/__init__.py` the de-facto API surface — that file is intentionally bare in this project and even `Comicbox` lives at `comicbox.box.Comicbox`.

## Test plan

- [x] `from comicbox.enums.maps import to_metron_age_rating` resolves and returns expected enum
- [x] `pytest tests/unit/test_to_metron_age_rating.py` — 45 passed