### PR TITLE
forward hide_text through archive read path to PDFFile

### DIFF
--- a/comicbox/box/archive/archive.py
+++ b/comicbox/box/archive/archive.py
@@ -67,10 +67,19 @@ class Archive:
         factory: None | BytesIOFactory,
         pdf_format: str = "",
         props: dict | None = None,
+        *,
+        hide_text: bool = False,
     ) -> bytes:
-        """Read one file in the archive's data."""
+        """
+        Read one file in the archive's data.
+
+        ``hide_text`` only applies to ``PDFFile`` archives; on every
+        other archive type it's silently ignored.
+        """
         if PDF_ENABLED and isinstance(archive, PDFFile):
-            return archive.read(filename, fmt=pdf_format, props=props)
+            return archive.read(
+                filename, fmt=pdf_format, props=props, hide_text=hide_text
+            )
         match archive:
             case TarFile():
                 data = cls._read_tarfile(archive, filename)

--- a/comicbox/box/archive/pages.py
+++ b/comicbox/box/archive/pages.py
@@ -8,22 +8,50 @@ from comicbox.box.archive.filenames import ComicboxArchiveFilenames
 class ComicboxArchivePages(ComicboxArchiveFilenames):
     """Pages methods."""
 
-    def get_page_by_filename(self, filename: str, pdf_format: str = "") -> bytes:
-        """Return data for a single page by filename."""
-        return self._archive_readfile(filename, pdf_format=pdf_format)
+    def get_page_by_filename(
+        self, filename: str, pdf_format: str = "", *, hide_text: bool = False
+    ) -> bytes:
+        """
+        Return data for a single page by filename.
+
+        ``hide_text=True`` is forwarded to the PDF backend; non-PDF
+        archives ignore it.
+        """
+        return self._archive_readfile(
+            filename, pdf_format=pdf_format, hide_text=hide_text
+        )
 
     def get_pages(
-        self, page_from: int = 0, page_to: int = -1, pdf_format: str = ""
+        self,
+        page_from: int = 0,
+        page_to: int = -1,
+        pdf_format: str = "",
+        *,
+        hide_text: bool = False,
     ) -> Iterator:
-        """Generate all pages starting with page number."""
+        """
+        Generate all pages starting with page number.
+
+        ``hide_text=True`` is forwarded to the PDF backend; non-PDF
+        archives ignore it.
+        """
         if pagenames := self.get_pagenames_from(page_from, page_to):
             for pagename in pagenames:
-                yield self._archive_readfile(pagename, pdf_format=pdf_format)
+                yield self._archive_readfile(
+                    pagename, pdf_format=pdf_format, hide_text=hide_text
+                )
 
-    def get_page_by_index(self, index: int, pdf_format: str = "") -> bytes | None:
-        """Get the page data by index."""
+    def get_page_by_index(
+        self, index: int, pdf_format: str = "", *, hide_text: bool = False
+    ) -> bytes | None:
+        """
+        Get the page data by index.
+
+        ``hide_text=True`` is forwarded to the PDF backend; non-PDF
+        archives ignore it.
+        """
         if pages_generator := self.get_pages(
-            page_from=index, page_to=index, pdf_format=pdf_format
+            page_from=index, page_to=index, pdf_format=pdf_format, hide_text=hide_text
         ):
             return next(pages_generator)
         return None

--- a/comicbox/box/archive/read.py
+++ b/comicbox/box/archive/read.py
@@ -82,7 +82,12 @@ class ComicboxArchiveRead(ComicboxArchiveInit):
         return pdf_format or (self._config.pdf_page_format or default)
 
     def _archive_readfile(
-        self, filename: str, pdf_format: str = "", props: dict | None = None
+        self,
+        filename: str,
+        pdf_format: str = "",
+        props: dict | None = None,
+        *,
+        hide_text: bool = False,
     ) -> bytes:
         """Read an archive file to memory."""
         # Consider chunking files by 4096 bytes and streaming them.
@@ -95,7 +100,12 @@ class ComicboxArchiveRead(ComicboxArchiveInit):
         pdf_format = self._get_pdf_format(pdf_format)
         try:
             data = Archive.read(
-                archive, filename, factory, pdf_format=pdf_format, props=props
+                archive,
+                filename,
+                factory,
+                pdf_format=pdf_format,
+                props=props,
+                hide_text=hide_text,
             )
         except BadRarFile:
             self.check_unrar_executable()

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from comicbox.box import Comicbox
-from tests.const import TEST_FILES_DIR
+from tests.const import PDF_SOURCE_PATH, TEST_FILES_DIR
 
 ARCHIVE_PATH = TEST_FILES_DIR / "Captain Science #001.cbz"
 IMAGE_DIR = TEST_FILES_DIR / "Captain Science 001"
@@ -74,3 +74,31 @@ def test_ignore_macos_resource_forks() -> None:
     with Comicbox(RESOURCE_FORK_ARCHIVE) as car:
         page_count = car.get_page_count()
     assert page_count == RESOURCE_FORK_ARCHIVE_PAGE_COUNT
+
+
+def test_pdf_hide_text_forwards_to_backend() -> None:
+    """``hide_text`` reaches the PDF backend and changes the rendered page."""
+    # Page 0 of the fixture is intentionally blank — use page 1 which
+    # has text.
+    with Comicbox(PDF_SOURCE_PATH) as car:
+        baseline = car.get_page_by_index(1, pdf_format="pixmap")
+        hidden = car.get_page_by_index(1, pdf_format="pixmap", hide_text=True)
+    assert baseline is not None
+    assert hidden is not None
+    assert baseline != hidden
+
+
+def test_pdf_hide_text_default_off() -> None:
+    """Default ``hide_text=False`` matches the legacy behavior."""
+    with Comicbox(PDF_SOURCE_PATH) as car:
+        default = car.get_page_by_index(1, pdf_format="pixmap")
+        explicit_off = car.get_page_by_index(1, pdf_format="pixmap", hide_text=False)
+    assert default == explicit_off
+
+
+def test_non_pdf_archive_ignores_hide_text() -> None:
+    """Non-PDF archives must accept ``hide_text`` and silently ignore it."""
+    with Comicbox(ARCHIVE_PATH) as car:
+        baseline = car.get_page_by_index(0)
+        with_kwarg = car.get_page_by_index(0, hide_text=True)
+    assert baseline == with_kwarg


### PR DESCRIPTION
## Summary

Plumbs the new ``hide_text`` knob from comicbox-pdffile (ajslater/pdffile#19) through the comicbox read path so callers — codex in particular — can request invisible-text rendering on PDF pages without bypassing comicbox's archive abstraction.

- ``get_page_by_index``, ``get_pages``, ``get_page_by_filename`` accept ``hide_text: bool = False`` and forward it.
- ``_archive_readfile`` (in ``ComicboxArchiveRead``) and ``Archive.read`` (the dispatcher) accept it too.
- PDF archives forward it to ``PDFFile.read(..., hide_text=...)``; non-PDF archive types accept the kwarg and silently ignore it (it has no meaning for image-pages-in-zip layouts).

Requires `comicbox-pdffile > 0.5.0` once that PR ships.

## Test plan

- [x] New `tests/test_pages.py` cases: PDF hide_text changes the page (pixmap differs from baseline), `hide_text=False` matches the legacy default, non-PDF archive accepts and ignores the kwarg.
- [x] Full suite passes (310 tests).
- [x] Lint (ruff, ty) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)