### PR TITLE
require comicbox-pdffile 0.6.x for image-dominant page detection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,10 @@
 
 ## v3.0.1
 
-- Require new comicbox-pdffile that doesn't corrupt PDF pages.
+- Require new comicbox-pdffile that doesn't corrupt PDF pages. Includes
+  image-dominant page detection (`PDFFile.classify_page`,
+  `PDFFile.read_image_if_dominant`, `PDFFile.read_full_pixmap_jpeg`) used by
+  browser readers to serve scanned-comic PDF pages as plain `<img>`.
 
 ## v3.0.0 - Config Dataclass & Parallel Reads
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,6 @@ ci = ["requests~=2.32"]
 requires = ["uv_build~=0.11.2"]
 build-backend = "uv_build"
 
-# Track the in-flight ``comicbox-pdffile`` 0.6 PR
-# (https://github.com/ajslater/pdffile/pull/22). Drop this block once
-# 0.6.x lands on PyPI.
-[tool.uv.sources]
-comicbox-pdffile = { git = "https://github.com/ajslater/pdffile.git", branch = "pdf-image-detection" }
-
 [tool.uv.build-backend]
 module-root = ""
 source-include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ Documentation = "https://comicbox.readthedocs.io"
 Source = "https://github.com/ajslater/comicbox"
 
 [project.optional-dependencies]
-pdf = ["comicbox-pdffile>=0.5.1,<0.6"]
+pdf = ["comicbox-pdffile>=0.6,<0.7"]
 
 [project.scripts]
 comicbox = "comicbox.cli:main"
@@ -106,6 +106,12 @@ ci = ["requests~=2.32"]
 [build-system]
 requires = ["uv_build~=0.11.2"]
 build-backend = "uv_build"
+
+# Track the in-flight ``comicbox-pdffile`` 0.6 PR
+# (https://github.com/ajslater/pdffile/pull/22). Drop this block once
+# 0.6.x lands on PyPI.
+[tool.uv.sources]
+comicbox-pdffile = { git = "https://github.com/ajslater/pdffile.git", branch = "pdf-image-detection" }
 
 [tool.uv.build-backend]
 module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -696,7 +696,7 @@ requires-dist = [
     { name = "ansicolors", specifier = "~=1.1.8" },
     { name = "bidict", specifier = "~=0.23" },
     { name = "case-converter", specifier = "~=1.2" },
-    { name = "comicbox-pdffile", marker = "extra == 'pdf'", specifier = ">=0.5.1,<0.6" },
+    { name = "comicbox-pdffile", marker = "extra == 'pdf'", git = "https://github.com/ajslater/pdffile.git?branch=pdf-image-detection" },
     { name = "comicfn2dict", specifier = ">=0.2.4,<1.0.0" },
     { name = "confuse", specifier = "~=2.2.0" },
     { name = "deepdiff", specifier = "~=9.0" },
@@ -765,17 +765,13 @@ test = [
 
 [[package]]
 name = "comicbox-pdffile"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.6.0"
+source = { git = "https://github.com/ajslater/pdffile.git?branch=pdf-image-detection#83c05f2e7ccc5c65f00ea974d636b0d300124bcb" }
 dependencies = [
     { name = "filetype" },
     { name = "pymupdf" },
     { name = "python-dateutil" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/75/0e/4593ecd880842c952a216134e37b2f6ada33473b6f7cd54caa4f3e701cd6/comicbox_pdffile-0.5.1.tar.gz", hash = "sha256:6a14000dd2511da07426326425e843b12665a2414e965bf1f5671ca5c4449327", size = 176423, upload-time = "2026-05-09T01:52:37.188Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/00/da2794ce34757651c7df9033b77e1c1e83f92dbb5289e1f9d627e37a39b1/comicbox_pdffile-0.5.1-py3-none-any.whl", hash = "sha256:2f048d3172f22065b5c6e0c6c2a0d2a957b1b19977e919c8d7a36178d4a3eef8", size = 7580, upload-time = "2026-05-09T01:52:36.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Widens the optional `[pdf]` extra to require `comicbox-pdffile` 0.6.x. The new minor release ([ajslater/pdffile#22](https://github.com/ajslater/pdffile/pull/22)) adds image-dominant page detection so browser readers can serve scanned-comic PDF pages as plain `<img>` instead of routing every page through pdf.js on the client.

comicbox itself doesn't use the new API — the bump is purely a pin update so downstream callers (Codex, OPDS readers) can adopt it.

## Changes

- `[project.optional-dependencies]` — `comicbox-pdffile>=0.5.1,<0.6` → `comicbox-pdffile>=0.6,<0.7`
- `NEWS.md` — folded into the in-flight v3.0.1 entry
- `[tool.uv.sources]` — temporarily points at the pdffile PR branch so CI can resolve before 0.6.x publishes. **Drop this block once 0.6.x lands on PyPI.**

## Sequencing

1. Land [ajslater/pdffile#22](https://github.com/ajslater/pdffile/pull/22) and publish 0.6.0.
2. Drop the `[tool.uv.sources]` block from this PR.
3. Merge.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 304/307 pass; the 3 PDF byte-equality failures (`test_extract_cover_pdf`, `test_codex_api::test_cover_page[PDF]`, `test_codex_api::test_random_access_page[PDF]`) **fail on develop pre-PR** as well, so they're pre-existing and not caused by this change.
- [x] uv resolves the dependency tree against the pdffile PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)