### PR TITLE
Metron auto engage cv only

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # 📰 News
 
+## v4.0.5
+
+- Performance
+    - Metron online tagging now identifies an issue in far fewer API requests —
+      often one or two instead of dozens — so tagging is faster and more
+      reliable. Courtesy of @bpepple.
+
 ## v4.0.4
 
 - Fixes

--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ comicbox --online all --recurse --prompts never -j 4 ./comics/
 ```
 
 `--match` controls how confidently comicbox writes without asking (`ask` ·
-`careful` · `auto` · `eager`), and credentials come from `--auth`, `COMICBOX_*`
-environment variables, the config file, or your system keyring. See
-`comicbox -h` for the full set of online, caching, and tuning options.
+`careful` · `auto` · `eager`), and `--effort` (`minimal` · `balanced` ·
+`thorough`) trades matching accuracy for fewer API calls on fan-out sources like
+ComicVine — Metron doesn't fan out, so it ignores effort and always searches at
+full strength. Credentials come from `--auth`, `COMICBOX_*` environment
+variables, the config file, or your system keyring. See `comicbox -h` for the
+full set of online, caching, and tuning options.
 
 ### 🖼️ Pages, Covers & Conversion
 

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -562,9 +562,10 @@ def _add_online_tuning_group(parser: ArgumentParser) -> None:
         metavar="MODE",
         dest="effort",
         help=(
-            "Per-comic API effort: [green]minimal[/green], [green]balanced[/green] "
-            "(default), [green]thorough[/green]. Controls how aggressively pre-call "
-            "algorithms trade accuracy for API throughput. Per-source overrides via YAML only."
+            "Per-comic API effort for fan-out sources: [green]minimal[/green], "
+            "[green]balanced[/green] (default), [green]thorough[/green]. Trades "
+            "accuracy for fewer API calls on ComicVine; Metron doesn't fan out, so "
+            "it ignores this. Per-source overrides via YAML only."
         ),
     )
 

--- a/comicbox/config/settings.py
+++ b/comicbox/config/settings.py
@@ -59,11 +59,13 @@ class Prompts(str, Enum):
 
 class Effort(str, Enum):
     """
-    API-call effort per comic.
+    API-call effort per comic, for fan-out sources.
 
     Orthogonal to ``MatchMode`` (which controls how the matcher's
     verdict is applied). ``Effort`` controls how aggressively pre-call
-    algorithms trade accuracy for API throughput.
+    algorithms trade accuracy for API throughput — it only bites on
+    sources that fan out per candidate (ComicVine). Single-call sources
+    (Metron since PR #143) have no fan-out to throttle and ignore it.
 
     - ``MINIMAL``: aggressive pre-filtering; trade accuracy for throughput.
     - ``BALANCED``: today's behavior; the default.

--- a/comicbox/config_default.yaml
+++ b/comicbox/config_default.yaml
@@ -95,7 +95,8 @@ comicbox:
     tuning:
       # Auto-write threshold (0-1) — top match must clear this to auto-write.
       auto_threshold: 0.95
-      # Per-comic API effort: minimal, balanced, thorough.
+      # Per-comic API effort for fan-out sources (ComicVine): minimal,
+      # balanced, thorough. Metron doesn't fan out, so it ignores this.
       effort: balanced
       # Retry budget for transient API failures.
       retry_budget: 5

--- a/comicbox/formats/base/online/auto_engage.py
+++ b/comicbox/formats/base/online/auto_engage.py
@@ -3,8 +3,18 @@ Auto-engagement of `api_budget=fast` for large unattended runs.
 
 Comicbox's online lookup is fast enough on small libraries that the
 default `balanced` budget is the right pick. At scale — hundreds of
-comics on ComicVine, thousands on Metron — `balanced` blows past the
-documented rate caps and stretches into multi-hour or multi-day waits.
+comics against ComicVine — `balanced` fans out enough per-comic API
+calls to blow past the documented rate caps and stretch into
+multi-hour waits.
+
+`fast` (`Effort.MINIMAL`) only cuts cost for sources that FAN OUT per
+comic — it caps discovery breadth and name-filters candidates before
+their per-item API call. ComicVine works that way. Metron does NOT:
+since PR #143 it resolves a comic in a single
+`issues_list(series_name=...)` call whose cost is effort-invariant, so
+auto-engaging `fast` for it would be a no-op. Auto-engagement therefore
+targets fan-out sources only (see `_UNATTENDED_THRESHOLDS`); single-call
+sources rely on the rate limiter + retry for pacing, not on effort.
 
 This module's `resolve_auto_engaged_budget` watches for two signals,
 both of which indicate the user is unlikely to want a multi-hour
@@ -42,19 +52,19 @@ if TYPE_CHECKING:
 
 
 # Batch-size threshold at which to auto-engage `fast` for a source
-# under `--unattended`. Per-source because each source's rate cap is
-# different (CV: 200/hr; Metron: 1,200/hr + 5,000/day daily cap).
+# under `--unattended`. Keyed by source and intentionally listing only
+# FAN-OUT sources — the ones where `fast` actually reduces per-comic API
+# calls. Metron is excluded: its single-call search (PR #143) costs the
+# same at any effort, so auto-engaging `fast` for it would be a
+# misleading no-op.
 #
 # Rationale:
 # - ComicVine: at ~10 calls/comic under `balanced` (post-Watchmen fixes),
 #   200/hr → ~20 comics/hr. Threshold 50 ≈ 2.5 hours of waiting; a
 #   tolerable upper bound on attended use.
-# - Metron: at ~6 calls/comic, 1,200/hr → ~200 comics/hr. Threshold
-#   500 ≈ 2.5 hours. Day cap (5,000) starts to matter beyond ~800.
 _UNATTENDED_THRESHOLDS: Final[MappingProxyType[str, int]] = MappingProxyType(
     {
         "comicvine": 50,
-        "metron": 500,
     }
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "LGPL-3.0-only"
 name = "comicbox"
-version = "4.0.4"
+version = "4.0.5"
 [[project.authors]]
 name = "AJ Slater"
 email = "aj@slater.net"

--- a/tests/unit/test_auto_engage.py
+++ b/tests/unit/test_auto_engage.py
@@ -122,27 +122,23 @@ def test_unattended_below_cv_threshold_does_not_engage_cv(
     assert "comicvine" not in result.tuning.per_source
 
 
-def test_unattended_metron_threshold_higher_than_cv(
+def test_metron_never_auto_engages_unattended(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CV engages at 50; Metron only at 500 (more forgiving rate cap)."""
+    """
+    Metron never auto-engages, at any batch size.
+
+    Its single-call search costs the same at every effort (PR #143), so
+    `fast` can't reduce it — auto-engaging would be a misleading no-op.
+    Only fan-out sources (ComicVine) are eligible.
+    """
     _force_tty(monkeypatch, is_tty=True)
     settings = _settings(unattended=True)
-    # Batch 100 — over CV's 50, under Metron's 500.
-    result = resolve_auto_engaged_budget(settings, batch_size=100)
+    # A batch far past any historical Metron threshold.
+    result = resolve_auto_engaged_budget(settings, batch_size=100_000)
     assert _cv_effort(result) == Effort.MINIMAL
+    assert _metron_effort(result) is None
     assert "metron" not in result.tuning.per_source
-
-
-def test_unattended_engages_metron_at_threshold(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """`--prompts never` + batch ≥ 500 → engage minimal for Metron too."""
-    _force_tty(monkeypatch, is_tty=True)
-    settings = _settings(unattended=True)
-    result = resolve_auto_engaged_budget(settings, batch_size=500)
-    assert _cv_effort(result) == Effort.MINIMAL
-    assert _metron_effort(result) == Effort.MINIMAL
 
 
 # --------------------------------------------------------- non-TTY trigger
@@ -163,12 +159,13 @@ def test_non_tty_uses_stricter_thresholds(
     assert _cv_effort(result) == Effort.MINIMAL
 
 
-def test_non_tty_engages_metron_at_2000(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Metron's non-TTY threshold is 500*4 = 2000."""
+def test_metron_never_auto_engages_non_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Metron stays out of auto-engagement on the non-TTY path too."""
     _force_tty(monkeypatch, is_tty=False)
     settings = _settings(unattended=False)
-    result = resolve_auto_engaged_budget(settings, batch_size=2000)
-    assert _metron_effort(result) == Effort.MINIMAL
+    result = resolve_auto_engaged_budget(settings, batch_size=100_000)
+    assert _cv_effort(result) == Effort.MINIMAL
+    assert _metron_effort(result) is None
 
 
 # --------------------------------------------------------- user overrides
@@ -191,8 +188,8 @@ def test_per_source_override_blocks_engagement(
     result = resolve_auto_engaged_budget(settings, batch_size=500)
     # CV override is preserved (not bumped to minimal).
     assert _cv_effort(result) == Effort.BALANCED
-    # Metron still engages (no per-source override blocks it).
-    assert _metron_effort(result) == Effort.MINIMAL
+    # Metron is never a candidate for auto-engagement.
+    assert _metron_effort(result) is None
 
 
 def test_logs_engagement_decision(
@@ -215,7 +212,8 @@ def test_logs_engagement_decision(
         loguru_logger.remove(handler_id)
     messages = "\n".join(rec.getMessage() for rec in caplog.records)
     assert "auto-engaging effort=minimal for comicvine" in messages
-    assert "auto-engaging effort=minimal for metron" in messages
+    # Metron never auto-engages, so it's never logged.
+    assert "for metron" not in messages
     # Override hint is present.
     assert "online.tuning.per_source.comicvine.effort" in messages
 

--- a/uv.lock
+++ b/uv.lock
@@ -758,7 +758,7 @@ wheels = [
 
 [[package]]
 name = "comicbox"
-version = "4.0.4"
+version = "4.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "bidict" },
@@ -1339,7 +1339,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1591,7 +1591,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -3208,7 +3208,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/45/bfaaab38545a33a9f06c61211fc3bea2e23e8a8e00fedeb8e57feda722ff/pywavelets-1.8.0.tar.gz", hash = "sha256:f3800245754840adc143cbc29534a1b8fc4b8cff6e9d403326bd52b7bb5c35aa", size = 3935274, upload-time = "2024-12-04T19:54:20.593Z" }
 wheels = [
@@ -3261,7 +3261,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/75/50581633d199812205ea8cdd0f6d52f12a624886b74bf1486335b67f01ff/pywavelets-1.9.0.tar.gz", hash = "sha256:148d12203377772bea452a59211d98649c8ee4a05eff019a9021853a36babdc8", size = 3938340, upload-time = "2025-08-04T16:20:04.978Z" }
@@ -4148,7 +4148,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4207,7 +4207,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4282,7 +4282,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
## Auto-engage fast budget for fan-out sources only (ComicVine)
    
    Metron's single-call issues_list search (PR #143) costs the same at any
    effort, so auto-engaging api_budget=fast for it was a no-op with a
    misleading INFO log. Drop Metron from the auto-engagement thresholds so
    engagement only fires for sources where lowering effort actually cuts
    per-comic API calls; Metron paces via the rate limiter + retry instead.
 
## Docs: clarify --effort applies to fan-out sources (ComicVine), not Metron
    
    Reflect the single-call Metron search (PR #143): effort/api-budget only
    throttles per-candidate fan-out, so it affects ComicVine but has no effect
    on Metron. Update the --effort CLI help, the README online-tagging section,
    the config_default.yaml comment, and the Effort enum docstring.
