### PR TITLE
Fix CBR open failure from rarfile sub-second timestamp overflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,9 @@ ComicboxInit → ComicboxArchive* (read/write/pages) → ComicboxSources
 - `comicbox/_pdf.py` — Optional `pdffile` integration flag. Lives at the top
   level (not under `comicbox/formats/pdf/`) so importing the flag doesn't
   trigger the PDF format-package init.
-- `comicbox/_rar.py` — Lazy `rarfile` import that applies comicbox's
-  sub-second timestamp patch. The only sanctioned way to import rarfile for
-  archive construction; never imports it at module scope.
+- `comicbox/_rar.py` — Lazy `rarfile` import that applies comicbox's sub-second
+  timestamp patch. The only sanctioned way to import rarfile for archive
+  construction; never imports it at module scope.
 
 ## Testing, Linting & Type Checking
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ ComicboxInit → ComicboxArchive* (read/write/pages) → ComicboxSources
 - `comicbox/_pdf.py` — Optional `pdffile` integration flag. Lives at the top
   level (not under `comicbox/formats/pdf/`) so importing the flag doesn't
   trigger the PDF format-package init.
+- `comicbox/_rar.py` — Lazy `rarfile` import that applies comicbox's
+  sub-second timestamp patch. The only sanctioned way to import rarfile for
+  archive construction; never imports it at module scope.
 
 ## Testing, Linting & Type Checking
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,11 @@
 
 - Fixes
     - CBR files whose RAR3 extended timestamps carry a sub-second remainder of a
-      second or more no longer fail to open with `ValueError: microsecond must be
-      in 0..999999`. rarfile <= 4.5 overflows parsing these, which some
-      third-party packers write; comicbox now carries the excess into whole
-      seconds. The patch deactivates itself if a future rarfile fixes the
-      overflow.
+      second or more no longer fail to open with
+      `ValueError: microsecond must be in 0..999999`. rarfile <= 4.5 overflows
+      parsing these, which some third-party packers write; comicbox now carries
+      the excess into whole seconds. The patch deactivates itself if a future
+      rarfile fixes the overflow.
     - Content based archive detection tries formats in observed frequency order
       (zip, rar, pdf, 7z, tar) when the file extension hint misses, instead of
       trying the rarest formats first.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,10 @@
       rarfile fixes the overflow.
     - Content based archive detection tries formats in observed frequency order
       (zip, rar, pdf, 7z, tar) when the file extension hint misses, instead of
-      trying the rarest formats first.
+      trying the rarest formats first. Every detector in that order now requires
+      leading magic — zip included — so a pdf or 7z with zip data appended can
+      no longer be claimed by the zip tail scan; zips with prepended data
+      (self-extractors) are still detected by a terminal loose pass.
 
 ## v4.8.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # 📰 News
 
+## v4.8.3
+
+- Fixes
+    - CBR files whose RAR3 extended timestamps carry a sub-second remainder of a
+      second or more no longer fail to open with `ValueError: microsecond must be
+      in 0..999999`. rarfile <= 4.5 overflows parsing these, which some
+      third-party packers write; comicbox now carries the excess into whole
+      seconds. The patch deactivates itself if a future rarfile fixes the
+      overflow.
+    - Content based archive detection tries formats in observed frequency order
+      (zip, rar, pdf, 7z, tar) when the file extension hint misses, instead of
+      trying the rarest formats first.
+
 ## v4.8.2
 
 - Features

--- a/comicbox/_rar.py
+++ b/comicbox/_rar.py
@@ -1,0 +1,76 @@
+"""
+Lazy rarfile import with comicbox's sub-second timestamp patch.
+
+rarfile <= 4.5 raises ``ValueError: microsecond must be in 0..999999`` from
+``RarFile.__init__`` when a RAR3 extended timestamp carries a sub-second
+remainder of one second or more, which some third-party packers write. Its
+``_parse_xtime`` builds the remainder from three bytes (up to 1.68 seconds
+in 100ns units) and hands it to ``to_nsdatetime`` unclamped. Nothing in the
+parse chain catches the error, so the archive cannot be opened at all.
+
+``import_rarfile()`` is the sanctioned way to import rarfile for archive
+construction. It wraps ``to_nsdatetime`` to carry whole seconds out of the
+nanosecond argument.
+
+Never import rarfile at module scope here. Reading a CBZ must not load
+rarfile at all (tests/unit/test_archive_read.py::
+test_cbz_read_does_not_load_py7zr_or_rarfile).
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from functools import cache, wraps
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+__all__ = ("import_rarfile",)
+
+_NS_PER_SECOND = 1_000_000_000
+_PROBE_DATETIME = datetime(2020, 1, 1, tzinfo=timezone.utc)
+# Any remainder of a second or more trips the bug. The value is arbitrary.
+_PROBE_NSEC = 1_500_000_000
+# Guards against stacking wrappers when threads detect archives concurrently.
+_PATCH_LOCK = threading.Lock()
+
+
+def _is_nsec_overflow_broken(rarfile: ModuleType) -> bool:
+    """Report whether this rarfile still crashes on an overlong remainder."""
+    try:
+        rarfile.to_nsdatetime(_PROBE_DATETIME, _PROBE_NSEC)
+    except ValueError:
+        return True
+    return False
+
+
+def _patch_nsec_overflow(rarfile: ModuleType) -> None:
+    """Carry whole seconds out of to_nsdatetime's nanosecond argument."""
+    with _PATCH_LOCK:
+        # Probing behavior instead of marking the module makes this a no-op
+        # both when already patched and when a future rarfile fixes the bug.
+        if not _is_nsec_overflow_broken(rarfile):
+            return
+        original = rarfile.to_nsdatetime
+
+        @wraps(original)
+        def to_nsdatetime(dttm: datetime, nsec: int) -> datetime:
+            if nsec >= _NS_PER_SECOND:
+                extra_seconds, nsec = divmod(nsec, _NS_PER_SECOND)
+                dttm = dttm + timedelta(seconds=extra_seconds)
+            return original(dttm, nsec)
+
+        # Patching a module attribute is valid at runtime, but ModuleType
+        # declares no such attribute for basedpyright to check against.
+        rarfile.to_nsdatetime = to_nsdatetime  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@cache
+def import_rarfile() -> ModuleType:
+    """Import rarfile, patched for the sub-second timestamp overflow."""
+    import rarfile
+
+    _patch_nsec_overflow(rarfile)
+    return rarfile

--- a/comicbox/box/init.py
+++ b/comicbox/box/init.py
@@ -195,10 +195,14 @@ class ComicboxInit:
     def _try_detect_rar(self, path: Path) -> bool:
         # rarfile is imported lazily — defers the heavy package init for
         # workers that only see CBZs (the common case at bulk-read scale).
-        from rarfile import RarFile, is_rarfile
+        # import_rarfile also applies comicbox's sub-second timestamp patch.
+        # Every RarFile is constructed from the class bound here, so patching
+        # at detection time covers them all.
+        from comicbox._rar import import_rarfile
 
-        if is_rarfile(path):
-            self._archive_cls = RarFile
+        rarfile = import_rarfile()
+        if rarfile.is_rarfile(path):
+            self._archive_cls = rarfile.RarFile
             self._file_type = FileTypeEnum.CBR
             return True
         return False
@@ -210,8 +214,12 @@ class ComicboxInit:
             return True
         return False
 
-    # Full detection order (default when no extension hint)
-    _FULL_DETECT_ORDER: tuple[str, ...] = ("pdf", "7z", "zip", "rar", "tar")
+    # Full detection order (default when no extension hint), by observed
+    # archive frequency: cbz dominates, then cbr, then pdf; cb7 is very rare
+    # and cbt rarer still. Common types first also rules out most files
+    # before the heavy py7zr import, and leaves tar — the weakest magic,
+    # "ustar" at offset 257 — last.
+    _FULL_DETECT_ORDER: tuple[str, ...] = ("zip", "rar", "pdf", "7z", "tar")
 
     # Extension → which types to try first (saves disk reads)
     _EXTENSION_HINT: ClassVar[dict[str, tuple[str, ...]]] = {

--- a/comicbox/box/init.py
+++ b/comicbox/box/init.py
@@ -185,12 +185,35 @@ class ComicboxInit:
             return True
         return False
 
-    def _try_detect_zip(self, path: Path) -> bool:
+    # Every zip record signature starts with these two bytes.
+    _ZIP_LEADING_MAGIC = b"PK"
+
+    def _detect_zip(self, path: Path, *, strict: bool) -> bool:
+        # is_zipfile only scans the tail for an end-of-central-directory
+        # record, so a pdf or 7z with zip data appended matches it too.
+        # The strict pass also requires zip leading magic, making every
+        # detector lead-magic based so none can shadow another. The loose
+        # terminal pass still accepts zips the format allows to start with
+        # other data (self-extractors, prepended junk).
+        if strict:
+            # Swallow OSError like is_zipfile does, so an unreadable path
+            # falls through detection instead of raising here.
+            leading = b""
+            with suppress(OSError), path.open("rb") as archive_file:
+                leading = archive_file.read(2)
+            if leading != self._ZIP_LEADING_MAGIC:
+                return False
         if is_zipfile(path):
             self._archive_cls = ZipFile
             self._file_type = FileTypeEnum.CBZ
             return True
         return False
+
+    def _try_detect_zip(self, path: Path) -> bool:
+        return self._detect_zip(path, strict=True)
+
+    def _try_detect_zip_loose(self, path: Path) -> bool:
+        return self._detect_zip(path, strict=False)
 
     def _try_detect_rar(self, path: Path) -> bool:
         # rarfile is imported lazily — defers the heavy package init for
@@ -218,8 +241,17 @@ class ComicboxInit:
     # archive frequency: cbz dominates, then cbr, then pdf; cb7 is very rare
     # and cbt rarer still. Common types first also rules out most files
     # before the heavy py7zr import, and leaves tar — the weakest magic,
-    # "ustar" at offset 257 — last.
-    _FULL_DETECT_ORDER: tuple[str, ...] = ("zip", "rar", "pdf", "7z", "tar")
+    # "ustar" at offset 257 — near last. Frequency ordering is safe because
+    # every detector here requires leading magic; the loose tail-scan zip
+    # detector runs terminally so it can never shadow another format.
+    _FULL_DETECT_ORDER: tuple[str, ...] = (
+        "zip",
+        "rar",
+        "pdf",
+        "7z",
+        "tar",
+        "zip_loose",
+    )
 
     # Extension → which types to try first (saves disk reads)
     _EXTENSION_HINT: ClassVar[dict[str, tuple[str, ...]]] = {
@@ -238,6 +270,7 @@ class ComicboxInit:
             "zip": self._try_detect_zip,
             "rar": self._try_detect_rar,
             "tar": self._try_detect_tar,
+            "zip_loose": self._try_detect_zip_loose,
         }
         return detectors[key](path)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "LGPL-3.0-only"
 name = "comicbox"
-version = "4.8.2"
+version = "4.8.3"
 [[project.authors]]
 name = "AJ Slater"
 email = "aj@slater.net"

--- a/tests/unit/test_archive_errors.py
+++ b/tests/unit/test_archive_errors.py
@@ -9,7 +9,7 @@ import pytest
 
 from comicbox.box import Comicbox
 from comicbox.exceptions import ComicboxError, UnsupportedArchiveTypeError
-from tests.const import CIX_CBZ_SOURCE_PATH
+from tests.const import CB7_SOURCE_PATH, CIX_CBZ_SOURCE_PATH, PDF_SOURCE_PATH
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -78,6 +78,44 @@ def test_truncated_cbz_failure_is_a_comicbox_error(tmp_path: Path) -> None:
     truncated.write_bytes(data[: len(data) // 2])
     with pytest.raises(ComicboxError):
         Comicbox(truncated)
+
+
+@pytest.mark.parametrize(
+    ("source_path", "expected_type"),
+    [(PDF_SOURCE_PATH, "PDF"), (CB7_SOURCE_PATH, "CB7")],
+)
+def test_zip_tail_cannot_shadow_leading_magic_format(
+    tmp_path: Path, source_path: Path, expected_type: str
+) -> None:
+    """
+    A pdf or 7z with zip data appended detects as its leading-magic type.
+
+    is_zipfile only scans the tail for an end-of-central-directory record,
+    so such a polyglot matches the zip detector too. The strict zip
+    detector requires zip leading magic, so with no extension hint the
+    real format still wins despite zip running first in the full order.
+    """
+    polyglot = tmp_path / "no_extension_hint"
+    polyglot.write_bytes(source_path.read_bytes() + CIX_CBZ_SOURCE_PATH.read_bytes())
+    with Comicbox(polyglot) as cb:
+        assert cb.get_file_type() == expected_type
+
+
+def test_zip_with_prepended_data_still_opens_as_cbz(tmp_path: Path) -> None:
+    """
+    A zip that starts with other data is still detected, last.
+
+    The zip format allows prepended data (self-extractors). The strict
+    leading-magic zip detector rejects it, no other format matches, and
+    the loose terminal zip detector accepts it.
+    """
+    prepended = tmp_path / "self_extracting.cbz"
+    prepended.write_bytes(
+        b"#!/bin/sh\necho fake sfx stub\n" + CIX_CBZ_SOURCE_PATH.read_bytes()
+    )
+    with Comicbox(prepended) as cb:
+        assert cb.get_file_type() == "CBZ"
+        assert cb.namelist()
 
 
 def test_directory_path_raises_is_a_directory(tmp_path: Path) -> None:

--- a/tests/unit/test_rar_time_overflow.py
+++ b/tests/unit/test_rar_time_overflow.py
@@ -1,0 +1,191 @@
+"""
+Unit tests for the rarfile sub-second timestamp overflow patch.
+
+rarfile <= 4.5 crashes opening a RAR3 archive whose extended timestamp
+carries a sub-second remainder of a second or more. See comicbox/_rar.py.
+
+The patch mutates the rarfile module, so no test here may assert the
+unpatched behavior in process — test_fixture_crashes_pristine_rarfile
+uses a subprocess for that.
+"""
+
+from __future__ import annotations
+
+import struct
+import subprocess
+import sys
+from binascii import crc32
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox._rar import import_rarfile
+from comicbox.box import Comicbox
+from comicbox.box.archive.archiveinfo import ArchiveInfo
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+rarfile = import_rarfile()
+
+_S_BLOCK_HEADER = struct.Struct("<HBHH")  # crc, type, flags, size
+_S_FILE_HEADER = struct.Struct("<LLBLLBBHL")
+_RAR3_MARKER = b"Rar!\x1a\x07\x00"
+_BLOCK_MAIN = 0x73
+_BLOCK_FILE = 0x74
+_FLAG_EXTTIME = 0x1000
+_FLAG_LONG_BLOCK = 0x8000
+# mtime nibble of the exttime flags word: present, with 3 remainder bytes.
+_EXTTIME_MTIME_3_BYTES = 0xB000
+_FIXTURE_NAME = b"0001.jpg"
+
+# Sub-second remainder in 100ns units. 12_320_760 * 100 = 1_232_076_000ns,
+# which is the value from the codex #820 traceback: unpatched rarfile turns
+# it into 1232076 microseconds and datetime rejects it.
+_OVERFLOW_REMAINDER = 12_320_760
+_OVERFLOW_NSEC = _OVERFLOW_REMAINDER * 100
+_UPSTREAM_ERROR = "microsecond must be in 0..999999"
+
+_FIXTURE_DTTM = datetime(2020, 3, 15, 10, 30, 24)  # noqa: DTZ001
+_FIXTURE_DOSTIME = (
+    ((2020 - 1980) << 25) | (3 << 21) | (15 << 16) | (10 << 11) | (30 << 5) | (24 // 2)
+)
+# The remainder carries a whole second out, leaving 232076 microseconds.
+_FIXTURE_MTIME = datetime(2020, 3, 15, 10, 30, 25, 232076)  # noqa: DTZ001
+
+_NS_PER_SECOND = 1_000_000_000
+_MAX_RAR3_NSEC = 0xFFFFFF * 100  # widest remainder three bytes can encode
+
+
+def _rar3_block(block_type: int, flags: int, body: bytes) -> bytes:
+    """Frame a RAR3 block, checksumming everything after the crc field."""
+    size = _S_BLOCK_HEADER.size + len(body)
+    raw = _S_BLOCK_HEADER.pack(0, block_type, flags, size) + body
+    crc = crc32(raw[2:]) & 0xFFFF
+    return _S_BLOCK_HEADER.pack(crc, block_type, flags, size) + body
+
+
+def _write_overflow_cbr(path: Path, remainder: int = _OVERFLOW_REMAINDER) -> Path:
+    """
+    Write a minimal RAR3 archive whose mtime remainder exceeds a second.
+
+    One stored, empty member. The remainder bytes are little endian:
+    rarfile accumulates them as ``rem = (b << 16) | (rem >> 8)``.
+    """
+    exttime = struct.pack("<H", _EXTTIME_MTIME_3_BYTES) + bytes(
+        (remainder & 0xFF, (remainder >> 8) & 0xFF, (remainder >> 16) & 0xFF)
+    )
+    file_body = (
+        _S_FILE_HEADER.pack(
+            0,  # pack size
+            0,  # unpacked size
+            0,  # host os: msdos
+            0,  # file crc of no data
+            _FIXTURE_DOSTIME,
+            20,  # version needed
+            0x30,  # method: stored
+            len(_FIXTURE_NAME),
+            0x20,  # attributes: archive
+        )
+        + _FIXTURE_NAME
+        + exttime
+    )
+    path.write_bytes(
+        _RAR3_MARKER
+        + _rar3_block(_BLOCK_MAIN, 0, bytes(6))
+        + _rar3_block(_BLOCK_FILE, _FLAG_LONG_BLOCK | _FLAG_EXTTIME, file_body)
+    )
+    return path
+
+
+def test_to_nsdatetime_carries_the_reported_overflow() -> None:
+    """The remainder from codex #820 becomes a whole second plus the rest."""
+    assert rarfile.to_nsdatetime(_FIXTURE_DTTM, _OVERFLOW_NSEC) == _FIXTURE_MTIME
+
+
+@pytest.mark.parametrize(
+    ("nsec", "expected_seconds", "expected_nsec"),
+    [
+        (0, 0, 0),
+        (_NS_PER_SECOND - 1, 0, _NS_PER_SECOND - 1),
+        (_NS_PER_SECOND, 1, 0),
+        (_OVERFLOW_NSEC, 1, 232_076_000),
+        (_MAX_RAR3_NSEC, 1, _MAX_RAR3_NSEC - _NS_PER_SECOND),
+    ],
+)
+def test_to_nsdatetime_boundaries(
+    nsec: int, expected_seconds: int, expected_nsec: int
+) -> None:
+    """Only a remainder of a second or more carries, and it carries exactly."""
+    result = rarfile.to_nsdatetime(_FIXTURE_DTTM, nsec)
+
+    assert result.second == _FIXTURE_DTTM.second + expected_seconds
+    assert rarfile.to_nsecs(result) % _NS_PER_SECOND == expected_nsec
+
+
+def test_to_nsdatetime_carry_rolls_over_the_year() -> None:
+    """Carrying a second out of the last second of the year rolls the date."""
+    new_years_eve = datetime(2020, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+    result = rarfile.to_nsdatetime(new_years_eve, 1_500_000_000)
+
+    assert result == datetime(2021, 1, 1, 0, 0, 0, 500000, tzinfo=timezone.utc)
+
+
+def test_import_rarfile_does_not_stack_patches() -> None:
+    """Importing again leaves the already patched function in place."""
+    patched = rarfile.to_nsdatetime
+
+    assert import_rarfile() is rarfile
+    assert rarfile.to_nsdatetime is patched
+
+
+def test_parse_xtime_reads_the_overflowing_remainder() -> None:
+    """The patch holds on rarfile's own RAR3 extended time parse path."""
+    remainder_bytes = bytes(
+        (
+            _OVERFLOW_REMAINDER & 0xFF,
+            (_OVERFLOW_REMAINDER >> 8) & 0xFF,
+            (_OVERFLOW_REMAINDER >> 16) & 0xFF,
+        )
+    )
+
+    mtime, pos = rarfile._parse_xtime(0xB, remainder_bytes, 0, _FIXTURE_DTTM)
+
+    assert mtime == _FIXTURE_MTIME
+    assert pos == len(remainder_bytes)
+
+
+def test_fixture_crashes_pristine_rarfile(tmp_path: Path) -> None:
+    """
+    The fixture really does provoke codex #820 on unpatched rarfile.
+
+    Run in a fresh subprocess that never imports comicbox, so the patch
+    this module applied at import can't mask the upstream bug. Without
+    this the fix could keep passing against a fixture that stopped
+    reproducing the crash.
+    """
+    cbr_path = _write_overflow_cbr(tmp_path / "overflow.cbr")
+    script = f"import rarfile; rarfile.RarFile({str(cbr_path)!r})"
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], check=False, capture_output=True, text=True
+    )
+
+    assert result.returncode != 0
+    assert _UPSTREAM_ERROR in result.stderr
+
+
+def test_comicbox_opens_a_cbr_with_an_overflowing_timestamp(tmp_path: Path) -> None:
+    """The archive opens and its mtime survives as a plain utc datetime."""
+    cbr_path = _write_overflow_cbr(tmp_path / "overflow.cbr")
+
+    with Comicbox(cbr_path) as car:
+        assert car.get_file_type() == "CBR"
+        assert _FIXTURE_NAME.decode() in car.namelist()
+        mtime = ArchiveInfo.mtime(car.infolist()[0])
+
+    # A plain datetime, not rarfile's unpicklable nsdatetime subclass.
+    assert type(mtime) is datetime
+    assert mtime == _FIXTURE_MTIME.replace(tzinfo=timezone.utc)

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "comicbox"
-version = "4.8.2"
+version = "4.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "bidict" },


### PR DESCRIPTION
Fixes the CBR import failure reported in ajslater/codex#820.

## The bug

Some `.cbr` files could not be opened at all, raising `ValueError: microsecond must be in 0..999999, not 1232076` from inside `RarFile.__init__`.

rarfile's `_parse_xtime` builds a RAR3 extended-timestamp remainder from up to three bytes — a maximum of 16,777,215 100ns units, or about 1.68 seconds — and passes `rem * 100` to `to_nsdatetime` without clamping it to sub-second range. `nsdatetime.__new__` divides that into microseconds and hands the result to `datetime`, which rejects anything at or over one second. Nothing in rarfile's parse chain catches `ValueError` (`CommonParser._parse_header` catches `struct.error` only), so the exception escapes `RarFile.__init__` and the archive is unreadable. Some third-party packers write these timestamps.

rarfile 4.5 is the current release and upstream has no fix, so comicbox patches at its own boundary. An upstream issue draft is prepared for markokr/rarfile.

## The fix

New `comicbox/_rar.py` — a lazy rarfile import that wraps `to_nsdatetime` to carry whole seconds out of the nanosecond argument, per the fix the reporter proposed:

```python
if nsec >= _NS_PER_SECOND:
    extra_seconds, nsec = divmod(nsec, _NS_PER_SECOND)
    dttm = dttm + timedelta(seconds=extra_seconds)
```

Notes on the approach:

- **Feature-detected, not flagged.** It probes whether `to_nsdatetime` still raises before patching, so it's a no-op both when already applied and if a future rarfile fixes the overflow — no stale patch riding on top of a fixed library.
- **Still lazy.** No module-scope `import rarfile`, so the CBZ lazy-import contract (`test_cbz_read_does_not_load_py7zr_or_rarfile`) still holds. `import_rarfile()` is `@cache`d, so the probe runs once per process.
- **Covers every construction.** `_try_detect_rar` is the only place `RarFile` is bound, and `_get_archive` constructs from that binding, so patching at detection time covers all opens. It also covers RAR5's theoretical variant of the same overflow (the `UNIXTIME_NS` LE32 path).

## Detection order

Fallback archive detection (when the extension hint misses) now runs in observed frequency order: `zip, rar, pdf, 7z, tar` instead of `pdf, 7z, zip, rar, tar`.

The old pdf/7z-first ordering was quietly load-bearing: `is_zipfile` only scans the tail for an end-of-central-directory record, so a pdf or 7z with zip data appended matches the zip detector too, and running the strict formats first shielded them. Rather than keep ordering around the loose detector, the strict zip pass now requires zip leading magic (`PK`), making every detector in the order lead-magic based so none can shadow another. Zips the format allows to start with other data — self-extractors, prepended junk — are still detected by a terminal loose pass, so nothing that previously opened stops opening. Correctly-named files are unaffected throughout since extension hints run first.

## Testing

New `tests/unit/test_rar_time_overflow.py` builds a 65-byte synthetic RAR3 archive in `tmp_path` whose mtime remainder overflows, so no binary fixture or `rar` tool is needed. It covers the patched carry on the exact value from the report, the boundaries (no carry below a second, exact carry at one second, the widest three-byte remainder, year rollover), idempotency, rarfile's own `_parse_xtime` path, and an end-to-end open through `Comicbox` asserting the mtime is a plain picklable `datetime`.

One test deliberately runs a **subprocess** that imports pristine rarfile and asserts the fixture still provokes the original crash — without it, the fix could keep passing against a fixture that had quietly stopped reproducing the bug.

`tests/unit/test_archive_errors.py` gains detection tests: a pdf+zip and 7z+zip polyglot with no extension hint resolve to PDF/CB7, and a zip with a prepended sfx-style stub still opens as CBZ.

Full suite: 1287 passed, 7 failed. All 7 failures are the missing `unrar` binary in my sandbox (`RarCannotExec` / "Cannot find working tool") and fail identically on a clean `main`. Ruff, ruff format, basedpyright, vulture, complexity, codespell, prettier, eslint, and remark are all clean.