### PR TITLE
Add short options for common CLI flags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # 📰 News
 
+## v4.8.4
+
+- Features
+    - Short options for more common flags. See `--help`.
+
 ## v4.8.3
 
 - Fixes

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ writes the best result.
 
 ```sh
 # Interactive: prompts only when the match isn't clear.
-comicbox --online metron "GI Joe #007 (1952).cbz"
+comicbox -o metron "GI Joe #007 (1952).cbz"
 
 # Tag by an exact database id (skips searching).
-comicbox --id metron:42 "comic.cbz"
+comicbox -I metron:42 "comic.cbz"
 
 # Unattended batch run: never prompts, 4 files at a time.
 comicbox --online all --recurse --prompts never -j 4 ./comics/
@@ -116,13 +116,13 @@ the full set of online, caching, and tuning options.
 
 ```sh
 # Extract the cover image.
-comicbox --extract-covers --dest-path ./out "comic.cbz"
+comicbox -X --dest-path ./out "comic.cbz"
 
 # Extract a range of pages (zero-based) by index.
-comicbox --extract-pages 0:5 --dest-path ./out "comic.cbz"
+comicbox -x 0:5 --dest-path ./out "comic.cbz"
 
 # Convert a CBR to a CBZ, carrying metadata across.
-comicbox --cbz "comic.cbr"
+comicbox -z "comic.cbr"
 
 # Convert a single-image-per-page comic PDF to CBZ without re-encoding.
 comicbox --cbz --pdf-pages image "comic.pdf"
@@ -187,8 +187,8 @@ comicbox -m "{publisher: SmallComics}" -w cix "comic.cbz"
 comicbox --recurse -m "{publisher: 'SC Comics'}" -w cix ./comics/
 
 # Export and re-import metadata as a file.
-comicbox --export cix "comic.cbz"
-comicbox --import ComicInfo.xml -w cix "comic.cbz"
+comicbox -e cix "comic.cbz"
+comicbox -i ComicInfo.xml -w cix "comic.cbz"
 ```
 
 `-m`/`--metadata` accepts a compact "linear YAML" using tag names from any of

--- a/comicbox/cli/epilog.py
+++ b/comicbox/cli/epilog.py
@@ -24,7 +24,7 @@ _TABLE_ARGS = MappingProxyType(
 # (phase char, description, optional short flag alias)
 _PRINT_PHASES_DESC = MappingProxyType(
     {
-        "v": ("Software version", "-v"),
+        "v": ("Software version", "-v, --version"),
         "t": ("File type", ""),
         "f": ("File names", ""),
         "s": ("Source metadata", ""),
@@ -32,7 +32,7 @@ _PRINT_PHASES_DESC = MappingProxyType(
         "n": ("Loaded metadata normalized to comicbox schema", ""),
         "m": ("Merged normalized intermediate metadata", ""),
         "c": ("Computed metadata sources", ""),
-        "p": ("Final metadata merged with computed sources", "-p"),
+        "p": ("Final metadata merged with computed sources", "-p, --print-metadata"),
     }
 )
 _METADATA_EXAMPLES = Styled(

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -208,6 +208,7 @@ def _add_general_group(parser: ArgumentParser) -> None:
 def _add_read_group(parser: ArgumentParser) -> None:
     group = parser.add_argument_group("read")
     group.add_argument(
+        "-f",
         "--read",
         action=CSVAction,
         metavar="FORMATS",
@@ -278,6 +279,7 @@ def _add_write_group(parser: ArgumentParser) -> None:
 def _add_print_group(parser: ArgumentParser) -> None:
     group = parser.add_argument_group("print")
     group.add_argument(
+        "-P",
         "--print",
         action="store",
         default=None,
@@ -290,6 +292,7 @@ def _add_print_group(parser: ArgumentParser) -> None:
     )
     group.add_argument(
         "-p",
+        "--print-metadata",
         action="store_true",
         default=None,
         dest="print_metadata",
@@ -319,6 +322,7 @@ def _add_print_group(parser: ArgumentParser) -> None:
 def _add_convert_group(parser: ArgumentParser) -> None:
     group = parser.add_argument_group("convert")
     group.add_argument(
+        "-z",
         "--cbz",
         action="store_true",
         default=None,
@@ -338,6 +342,7 @@ def _add_convert_group(parser: ArgumentParser) -> None:
         help="Rename the file with comicbox's filename format.",
     )
     group.add_argument(
+        "-x",
         "--extract-pages",
         action=PageRangeAction,
         default=None,
@@ -349,6 +354,7 @@ def _add_convert_group(parser: ArgumentParser) -> None:
         ),
     )
     group.add_argument(
+        "-X",
         "--extract-covers",
         action="store_true",
         default=None,
@@ -356,6 +362,7 @@ def _add_convert_group(parser: ArgumentParser) -> None:
         help="Extract cover pages.",
     )
     group.add_argument(
+        "-i",
         "--import",
         action="append",
         default=None,
@@ -364,6 +371,7 @@ def _add_convert_group(parser: ArgumentParser) -> None:
         help="Import metadata from external files. Accepts quoted globs. Repeatable.",
     )
     group.add_argument(
+        "-e",
         "--export",
         action=CSVAction,
         default=None,
@@ -386,6 +394,7 @@ def _add_convert_group(parser: ArgumentParser) -> None:
 def _add_online_lookup_group(parser: ArgumentParser) -> None:
     group = parser.add_argument_group("online: lookup")
     group.add_argument(
+        "-o",
         "--online",
         action=CSVAction,
         dest="online_sources",
@@ -402,6 +411,7 @@ def _add_online_lookup_group(parser: ArgumentParser) -> None:
         ),
     )
     group.add_argument(
+        "-I",
         "--id",
         action="append",
         dest="explicit_ids",
@@ -489,6 +499,7 @@ def _add_online_lookup_group(parser: ArgumentParser) -> None:
 def _add_online_auth_group(parser: ArgumentParser) -> None:
     group = parser.add_argument_group("online: auth")
     group.add_argument(
+        "-a",
         "--auth",
         action=AuthAction,
         default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = "LGPL-3.0-only"
 name = "comicbox"
-version = "4.8.3"
+version = "4.8.4"
 [[project.authors]]
 name = "AJ Slater"
 email = "aj@slater.net"

--- a/uv.lock
+++ b/uv.lock
@@ -858,7 +858,7 @@ wheels = [
 
 [[package]]
 name = "comicbox"
-version = "4.8.3"
+version = "4.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "bidict" },


### PR DESCRIPTION
## Summary

The CLI had one short-only option (`-p`) and 29 long-only options, with no consistent rule about which frequently-used actions got a short form. This adds shorts to the high-traffic subset and gives `-p` a long form.

| Long | New short | | Long | New short |
|---|---|---|---|---|
| `--cbz` | `-z` | | `--extract-covers` | `-X` |
| `--print` | `-P` | | `--import` | `-i` |
| `--read` | `-f` | | `--online` | `-o` |
| `--export` | `-e` | | `--id` | `-I` |
| `--extract-pages` | `-x` | | `--auth` | `-a` |

Plus `-p` → `-p, --print-metadata`.

## Notes on what was deliberately left out

Rare, dangerous, and tuning-knob options stay long-only so they must be typed deliberately: `--delete-orig`, `--read-except`, `--replace`, `--stamp`, `--no-stamp-notes`, `--delete-all-tags`, `--validate`, `--pdf-pages`, `--series-id`, `--match`, `--prompts`, `--rematch`, `--all-sources`, `--cache*`, `--auto-threshold`, `--effort`.

Two letter choices avoid case-slip footguns:

- **`--rename` gets no short.** Its only plausible short is `-N`, one shift-key from `-n --dry-run` — a slip would rename a file instead of suppressing all writes.
- **`--read` gets `-f`, not `-R`.** `-R` sits one shift-key from `-r --recurse`, where a slip would silently change which metadata formats get parsed. `-f` reads off the `FORMATS` metavar and pairs with `-w --write FORMATS`.

## Why `-p` and `--print` stay separate

Merging them into one option with `nargs="?"` / `const="p"` looks tempting but breaks the most common invocation. argparse greedily consumes the following positional, so `comicbox -p comic.cbz` would parse as `print_phases='comic.cbz'` with `paths=[]`. Instead both flags keep their own `dest` and each gained the form it was missing.

All `dest=` values are unchanged, so `_reshape_print` in `comicbox/cli/__init__.py` needed no edit and the additive phase fold still works — `--print slc -p` still yields `slcp`.

## Test plan

- `comicbox -h` renders each new short beside its long form in the right group (a duplicate short would raise `argparse.ArgumentError` on any invocation).
- Every new short parses to the same `dest` as its long form.
- `comicbox -p comic.cbz` → `print_metadata=True, paths=['comic.cbz']` — the path is not swallowed.
- `--print slc -p` → phases `slcp`; `-P slcm -p -v` → `slcmvp`.
- `--cb` still abbreviates to `--cbz`.
- Full suite: **1287 passed**. The 7 failures are pre-existing and environmental — `unrar` is not installed in this container, so all CBR tests fail identically on the base commit (verified by stashing).
- `ruff check`, `ruff format --check`, `basedpyright`, `prettier`, and `remark` all clean.

Version bumped to 4.8.4 with a NEWS entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBPr5Kych4dEMXi9tLXE68)_