### PR TITLE
feat: predict_filename(), correct rename extensions, and conversion write safety

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # 📰 News
 
+## v4.8.6
+
+- Features
+    - `Comicbox.predict_filename()` returns the scheme name `rename_file()`
+      would rename to, without renaming. `rename_file()` now uses it, so a
+      caller can show or check the destination first.
+
+- Fixes
+    - Renaming keeps the archive's own file extension. The name ends in `ext`, a
+      metadata field, so a config that skips it fell back to "cbz" and a stale
+      value embedded by another tagger overrode the real one — either way
+      renaming a PDF or CBT to a name claiming to be a zip.
+    - Converting no longer writes the pre-conversion `ext` into the new
+      archive's metadata, which is what left those stale values behind.
+    - Archives differing only by suffix no longer destroy each other when
+      converted in one bulk write. They all convert to the same `.cbz`, and the
+      loser could replace the winner's finished file while `delete_orig`
+      unlinked both originals; it now fails cleanly instead.
+
 ## v4.8.5
 
 - Features

--- a/comicbox/box/archive/write.py
+++ b/comicbox/box/archive/write.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Mapping
 from pathlib import Path
+from threading import Lock
 
 from loguru import logger
 from zipremove import ZIP_DEFLATED, ZIP_STORED, ZipFile
@@ -14,6 +15,32 @@ from comicbox.formats.sources import MetadataSources
 
 _RECOMPRESS_SUFFIX = ".comicbox_tmp_zip"
 _CBZ_SUFFIX = ".cbz"
+# Destinations a conversion is currently writing to. Archives differing
+# only by suffix ("Foo.cbr" and "Foo.cbt", a common way for a library to
+# carry one issue twice) both convert to "Foo.cbz", and bulk writes run on
+# a thread pool: without this the second writer replaces the first's
+# finished file and, under ``delete_orig``, both originals are unlinked —
+# one archive's contents gone for good. Claiming the destination turns the
+# loser into an ordinary per-file error instead.
+_INFLIGHT_DESTINATIONS: set[Path] = set()
+_INFLIGHT_GUARD = Lock()
+
+
+def _claim_destination(path: Path) -> None:
+    """Take a conversion destination, refusing one already in flight."""
+    with _INFLIGHT_GUARD:
+        if path in _INFLIGHT_DESTINATIONS:
+            reason = f"{path} is already being written by another archive."
+            raise ArchiveWriteError(reason)
+        _INFLIGHT_DESTINATIONS.add(path)
+
+
+def _release_destination(path: Path) -> None:
+    """Release a claimed conversion destination."""
+    with _INFLIGHT_GUARD:
+        _INFLIGHT_DESTINATIONS.discard(path)
+
+
 _ALL_ARCHIVE_METADATA_FILENAMES = frozenset(
     {
         fmt.value.filename.lower()
@@ -153,18 +180,27 @@ class ComicboxArchiveWrite(ComicboxArchiveRead):
         if not self._path:
             reason = "Cannot write zipfile metadata without a path."
             raise ArchiveWriteError(reason)
-        new_path = self._get_new_archive_path()
-        tmp_path = self._path.with_suffix(_RECOMPRESS_SUFFIX)
-        tmp_path.unlink(missing_ok=True)
-        logger.info(f"Creating {new_path}...")
-        with ZipFile(tmp_path, "x") as zf:
-            self._archive_write_metadata_files(zf, files)
-            self._copy_archive_files_to_new_archive(zf)
-            zf.comment = comment
+        # Keep the whole source name in the temp file's. Sharing one temp
+        # path between archives that differ only by suffix let concurrent
+        # writers unlink each other's in-progress file and then replace a
+        # half-written one onto the destination.
+        tmp_path = self._path.with_name(self._path.name + _RECOMPRESS_SUFFIX)
+        destination = self._path.with_suffix(_CBZ_SUFFIX)
+        _claim_destination(destination)
+        try:
+            new_path = self._get_new_archive_path()
+            tmp_path.unlink(missing_ok=True)
+            logger.info(f"Creating {new_path}...")
+            with ZipFile(tmp_path, "x") as zf:
+                self._archive_write_metadata_files(zf, files)
+                self._copy_archive_files_to_new_archive(zf)
+                zf.comment = comment
 
-        # Cleanup
-        self.close()
-        self._cleanup_tmp_archive(tmp_path, new_path)
+            # Cleanup
+            self.close()
+            self._cleanup_tmp_archive(tmp_path, new_path)
+        finally:
+            _release_destination(destination)
 
     def _update_pdffile(self, files: Mapping, mupdf_metadata: Mapping) -> None:
         if not self._path:

--- a/comicbox/box/dump.py
+++ b/comicbox/box/dump.py
@@ -6,12 +6,32 @@ from loguru import logger
 
 from comicbox.box.pages import ComicboxPages
 from comicbox.formats import MetadataFormats
+from comicbox.formats.comicbox.schema import EXT_KEY
 from comicbox.formats.sources import MetadataSources
 
 ARCHIVE_FORMATS = frozenset(
     MetadataSources.ARCHIVE_FILE.value.formats
     + MetadataSources.ARCHIVE_COMMENT.value.formats
 )
+
+
+def _without_filename_only_keys(schema, denormalized_metadata: Mapping) -> Mapping:
+    """
+    Drop keys that describe the file's name rather than its contents.
+
+    ``ext`` is parsed from the filename and means nothing inside the
+    archive — but a metadata file written into a *converted* archive is
+    built before the suffix changes, so it would preserve the old one
+    ("ext: cbt" inside a .cbz). Read back, that stale value outranks the
+    real filename and can rename the archive to a format it isn't.
+    """
+    root_tag = getattr(schema, "ROOT_TAG", None)
+    sub_md = denormalized_metadata.get(root_tag) if root_tag else None
+    if not isinstance(sub_md, Mapping) or EXT_KEY not in sub_md:
+        return denormalized_metadata
+    stripped = dict(denormalized_metadata)
+    stripped[root_tag] = {key: value for key, value in sub_md.items() if key != EXT_KEY}
+    return stripped
 
 
 class ComicboxDump(ComicboxPages):
@@ -80,7 +100,9 @@ class ComicboxDump(ComicboxPages):
             if isinstance(mupdf_md, Mapping):
                 pdf_md.update(mupdf_md.get(schema.ROOT_TAG, {}))
         elif fmt in MetadataSources.ARCHIVE_FILE.value.formats:
-            files[fmt.value.filename] = schema.dumps(denormalized_metadata)
+            files[fmt.value.filename] = schema.dumps(
+                _without_filename_only_keys(schema, denormalized_metadata)
+            )
         elif fmt in MetadataSources.ARCHIVE_COMMENT.value.formats:
             cmnt = schema.dumps(denormalized_metadata)
             cmnt = cmnt.encode(errors="replace")

--- a/comicbox/box/dump_files.py
+++ b/comicbox/box/dump_files.py
@@ -48,13 +48,35 @@ class ComicboxDumpToFiles(ComicboxDump):
         for fmt in formats:
             self.to_file(fmt=fmt)
 
+    def predict_filename(self) -> str:
+        """
+        Return the scheme filename this archive would be renamed to.
+
+        The rendered name ends in ``ext``, which is a *metadata* field
+        rather than the file's suffix. Left to the merge it can be missing
+        (a config that skips or deletes it, whereupon comicfn2dict falls
+        back to its "cbz" default) or stale (a value some tagger embedded
+        in the archive), either of which names a PDF as a zip. The archive
+        on disk is the authority, so its own suffix always wins.
+
+        Returns "" when no usable name could be built, including a name
+        that is nothing but an extension — renaming to that would make a
+        hidden file.
+        """
+        schema, filename_md = self._to_dict(MetadataFormats.FILENAME)
+        fn = schema.dumps(filename_md)
+        if not fn or fn.startswith("."):
+            return ""
+        if self._path:
+            fn = str(Path(fn).with_suffix(self._path.suffix))
+        return fn
+
     def rename_file(self) -> None:
         """Rename the archive."""
         if not self._path:
             reason = "Cannot rename archive without a path."
             raise ArchiveWriteError(reason)
-        schema, filename_md = self._to_dict(MetadataFormats.FILENAME)
-        fn = schema.dumps(filename_md)
+        fn = self.predict_filename()
         old_path = self._path
         if not fn:
             logger.warning(f"Unable to construct a filename for {old_path}")

--- a/tests/unit/test_rename_and_convert_safety.py
+++ b/tests/unit/test_rename_and_convert_safety.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for filename prediction and conversion write safety.
+
+The scheme filename ends in ``ext``, a metadata field rather than the
+file's suffix, so a name can claim a format the archive isn't. Conversions
+add a second hazard: archives differing only by suffix all convert to one
+``.cbz``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox.box import Comicbox
+from comicbox.box.archive.write import (
+    _RECOMPRESS_SUFFIX,
+    _claim_destination,
+    _release_destination,
+)
+from comicbox.config import get_config
+from comicbox.exceptions import ArchiveWriteError
+from comicbox.write import BulkWriteItem, bulk_write
+from tests.const import CIX_CBT_SOURCE_PATH, CIX_CBZ_SOURCE_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_YAML = frozenset({"COMICBOX_YAML"})
+
+
+def test_predict_filename_keeps_a_non_cbz_suffix(tmp_path: Path) -> None:
+    """A CBT is never predicted as a name claiming to be a zip."""
+    cbt = tmp_path / "Predict v1999 #001 (1999).cbt"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+
+    with Comicbox(cbt) as car:
+        predicted = car.predict_filename()
+
+    assert predicted.endswith(".cbt")
+
+
+def test_predict_filename_survives_a_deleted_ext_key(tmp_path: Path) -> None:
+    """
+    A config that skips ``ext`` still predicts the real suffix.
+
+    ``ext`` is only ever parsed from the filename, so a caller that trims
+    the fields it doesn't consume drops it — and comicfn2dict then falls
+    back to its "cbz" default, naming every other format a zip.
+    """
+    cbt = tmp_path / "Deleted v1999 #004 (1999).cbt"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+    config = get_config({"comicbox": {"general": {"delete_keys": ("ext",)}}})
+
+    with Comicbox(cbt, config=config) as car:
+        predicted = car.predict_filename()
+
+    assert predicted.endswith(".cbt")
+
+
+def test_predict_filename_ignores_a_stale_embedded_ext(tmp_path: Path) -> None:
+    """An ``ext`` some tagger wrote into the archive cannot rename it."""
+    cbz = tmp_path / "Stale v1999 #005 (1999).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+    with zipfile.ZipFile(cbz, "a") as zf:
+        zf.writestr("comicbox.yaml", "comicbox:\n  ext: cbr\n  series:\n    name: S\n")
+
+    with Comicbox(cbz) as car:
+        predicted = car.predict_filename()
+
+    assert predicted.endswith(".cbz")
+
+
+def test_predict_filename_keeps_a_cbz_suffix(tmp_path: Path) -> None:
+    """The common case is unchanged."""
+    cbz = tmp_path / "Predict v1999 #002 (1999).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+
+    with Comicbox(cbz) as car:
+        predicted = car.predict_filename()
+
+    assert predicted.endswith(".cbz")
+
+
+def test_rename_file_lands_on_the_predicted_name(tmp_path: Path) -> None:
+    """The rename and the prediction can't disagree."""
+    cbt = tmp_path / "Rename v1999 #003 (1999).cbt"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+
+    with Comicbox(cbt) as car:
+        predicted = car.predict_filename()
+        car.rename_file()
+        landed = car.get_path()
+
+    assert landed is not None
+    assert landed.name == predicted
+    assert landed.suffix == ".cbt"
+    assert landed.exists()
+
+
+def test_a_claimed_destination_is_refused(tmp_path: Path) -> None:
+    """
+    Two writers cannot hold one conversion destination.
+
+    The completed-file check can't see a conversion still in flight, so
+    without the claim two same-stem archives both pass it, and the second
+    replaces the first's finished file while ``delete_orig`` unlinks both
+    originals.
+    """
+    dest = tmp_path / "Held v1 #001 (2001).cbz"
+    _claim_destination(dest)
+    try:
+        with pytest.raises(ArchiveWriteError):
+            _claim_destination(dest)
+    finally:
+        _release_destination(dest)
+    # Free again once that write is done.
+    _claim_destination(dest)
+    _release_destination(dest)
+
+
+def test_conversion_temp_files_do_not_collide(tmp_path: Path) -> None:
+    """Same-stem sources must not share one temp path."""
+    cbt = tmp_path / "Temp v1 #001 (2001).cbt"
+    cb7 = tmp_path / "Temp v1 #001 (2001).cb7"
+
+    assert cbt.with_name(cbt.name + _RECOMPRESS_SUFFIX) != cb7.with_name(
+        cb7.name + _RECOMPRESS_SUFFIX
+    )
+
+
+def test_same_stem_conversions_keep_both_originals(tmp_path: Path) -> None:
+    """
+    Two archives converging on one .cbz must not destroy each other.
+
+    Both convert to the same destination name. Whichever loses has to
+    fail cleanly — before, its original was unlinked while its contents
+    only ever reached a file the winner overwrote.
+    """
+    cbt = tmp_path / "Clash v1 #001 (2001).cbt"
+    cb7 = tmp_path / "Clash v1 #001 (2001).cb7"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+    shutil.copy(CIX_CBT_SOURCE_PATH, cb7)
+
+    results = list(
+        bulk_write(
+            [
+                BulkWriteItem(path=cbt, patch={"title": "a"}, formats=_YAML),
+                BulkWriteItem(path=cb7, patch={"title": "b"}, formats=_YAML),
+            ]
+        )
+    )
+
+    written = [r for r in results if r.written]
+    failed = [r for r in results if not r.written]
+    assert len(written) == 1
+    assert len(failed) == 1
+    # Refused either as an in-flight claim or as a finished file, depending
+    # on whether the two writes actually overlapped.
+    error = str(failed[0].error)
+    assert "already being written" in error or "already exists" in error
+    # Neither archive is destroyed: the loser never reached the destination.
+    assert cbt.exists()
+    assert cb7.exists()
+    assert (tmp_path / "Clash v1 #001 (2001).cbz").exists()
+
+
+def test_conversion_does_not_embed_a_stale_ext(tmp_path: Path) -> None:
+    """The metadata written into a converted archive can't claim the old format."""
+    cbt = tmp_path / "Embed v1 #001 (2001).cbt"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+
+    result = next(
+        iter(bulk_write([BulkWriteItem(path=cbt, patch={"title": "y"}, formats=_YAML)]))
+    )
+
+    assert result.written
+    cbz = result.final_path
+    assert cbz is not None
+    assert cbz.suffix == ".cbz"
+    with zipfile.ZipFile(cbz) as zf:
+        names = [n for n in zf.namelist() if n.endswith("comicbox.yaml")]
+        assert names
+        embedded = zf.read(names[0]).decode()
+    assert "ext:" not in embedded
+
+
+def test_a_conversion_respects_a_held_destination(tmp_path: Path) -> None:
+    """
+    The write path consults the claim, not just the finished-file check.
+
+    Holding the destination stands in for a conversion still in flight,
+    which leaves nothing on disk for ``_get_new_archive_path`` to see.
+    """
+    cbt = tmp_path / "Wired v1 #001 (2001).cbt"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+    dest = tmp_path / "Wired v1 #001 (2001).cbz"
+
+    _claim_destination(dest)
+    try:
+        result = next(
+            iter(
+                bulk_write(
+                    [BulkWriteItem(path=cbt, patch={"title": "z"}, formats=_YAML)]
+                )
+            )
+        )
+    finally:
+        _release_destination(dest)
+
+    assert not result.written
+    assert "already being written" in str(result.error)
+    assert cbt.exists()
+    assert not dest.exists()


### PR DESCRIPTION
Three related fixes around renaming and CBR/CBT/CB7→CBZ conversion, found while auditing a downstream caller (codex) that renames and converts in bulk.

## `predict_filename()`, and the right extension

The rendered scheme name ends in `ext` — a **metadata** field, not the file's suffix. Left to the merge it can be:

- **missing**, when a caller's config trims fields it doesn't consume (codex deletes every schema field it doesn't read). comicfn2dict then falls back to its `"cbz"` default, so *every* PDF and unconverted CBR/CBT is renamed to a name claiming to be a zip.
- **stale**, when some tagger wrote one into the archive, where it outranks the filename.

The archive on disk is the authority, so its suffix now always wins.

`predict_filename()` returns that name without renaming, so a caller can show it in a confirmation dialog, check the destination for collisions, or rename to it later. `rename_file()` is defined in terms of it, so the two can't disagree. It also declines a name that is nothing but an extension, which would have created a hidden file.

## The stale `ext` came from us

`ext` means nothing inside an archive, but the embedded metadata files are built *before* the suffix changes, so a CBT converted to CBZ carried `ext: cbt` inside it. That is the exact value that later outranks the real filename — comicbox was manufacturing the input to its own bug.

## Same-stem conversions destroyed each other

`Foo.cbr` and `Foo.cbt` — a common way for a library to carry one issue twice — both convert to `Foo.cbz`, and `bulk_write` runs them on a thread pool. Two failures compounded:

- They shared one temp path, so a writer could unlink another's in-progress file and then replace a **half-written** archive onto the destination.
- The only destination guard was a check for an already-*finished* file, which cannot see a conversion still in flight. The second writer replaced the first's finished archive while `delete_orig` unlinked both originals — one archive's contents gone for good.

The temp path now carries the whole source name, and a conversion claims its destination for the duration of the write. The loser gets an ordinary per-file error and both originals stay intact.

## Notes for review

- **The claim is in-process only** (a module-level set), which is the scope of the bug: `bulk_write`'s own thread pool. Cross-process conversions to one destination are still last-writer-wins, as before.
- **`predict_filename()` returns the *current* suffix**, not the post-write one. For a conversion that is the correct pre-write rename target; `final_path` already reports where a write actually landed.
- **The test for the same-stem clash accepts either rejection message.** Under load the two writes genuinely overlap and the claim rejects the loser; run alone they serialize and the finished-file check does. Both are correct outcomes — and the full-suite run is what proved the claim does real work.
- Every new test was checked to fail with its fix reverted. 1309 tests pass; `make lint` and `make ty` are clean, with no new warnings.
- Version not bumped — left for the release.