### PR TITLE
fix(identifiers): url paths, urn grammar, and hostname matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,10 @@
     - An unrecognized ComicVine type code reads as an issue, not an arc.
     - An `id_type` comicbox doesn't know no longer leaks into a url.
     - kitsu.app urls are recognized.
+    - A name slug or tracking suffix after the id in a url is no longer the id.
+    - A link to a database's front page no longer becomes an id for it.
+    - Urls are recognized whatever the host's case, and with a port or login.
+    - Notes urns are written only in a form the notes reader reads back.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/box/computed/notes.py
+++ b/comicbox/box/computed/notes.py
@@ -29,6 +29,7 @@ from comicbox.identifiers.identifiers import (
     create_identifier,
 )
 from comicbox.identifiers.urns import (
+    URN_SCAN_EXP,
     parse_urn_identifier,
 )
 from comicbox.merge import AdditiveMerger, Merger
@@ -53,9 +54,10 @@ _NOTES_RE_EXP = (
     + r"?"
 )
 _NOTES_RE = re.compile(_NOTES_RE_EXP, flags=re.IGNORECASE)
-# Notes are prose. A urn ends where its key ends, not at the next space, so
-# the comma or period after it in a sentence isn't read as part of the key.
-_URN_RE_EXP = r"(?P<urn>urn:[A-Za-z0-9][A-Za-z0-9-]{0,30}:[\w%.:-]*[\w%])"
+# One grammar for urns, owned by the urns module that reads and writes them.
+# A hand-maintained copy here drifted: it accepted a one character namespace
+# and a trailing hyphen that the urn parser then rejected.
+_URN_RE_EXP = rf"(?P<urn>{URN_SCAN_EXP})"
 _URN_RE = re.compile(_URN_RE_EXP, flags=re.IGNORECASE)
 _NOTES_IDENTIFIER_EXTRA_EXP = r"\[" + IDENTIFIER_RE_EXP + r"\]"
 _NOTES_IDENTIFIER_EXTRA_RE = re.compile(

--- a/comicbox/identifiers/identifiers.py
+++ b/comicbox/identifiers/identifiers.py
@@ -104,11 +104,14 @@ class IdentifierParts:
         return self.id_type.map.inverse.get(id_type_code, default)
 
     def parse_url_path(self, url: str) -> tuple[str, str]:
-        """Parse URL path with regex."""
+        """Parse URL path with regex, or return no match."""
         obj = urlparse(url)
         match = self.url_path_regex_compiled.search(obj.path[1:])
         if not match:
-            return "", obj.path
+            # A known database's own site is full of pages that are not an
+            # id: /about, /search, the front page. Handing the raw path back
+            # as the key minted ids like "/about/" that nothing can look up.
+            return "", ""
         try:
             id_type_slug = match.group("id_type")
         except IndexError:
@@ -144,7 +147,9 @@ IDENTIFIER_PARTS_MAP: MappingProxyType[IdSources, IdentifierParts] = MappingProx
         IdSources.ASIN: IdentifierParts(
             domain="www.amazon.com",
             id_type=IdentifierTypes(issue="issue"),
-            url_path_regex=r"dp/(?P<id_key>\S+)",
+            # An asin is one path segment. \S+ swallowed the /ref=... amazon
+            # appends to nearly every url into the id.
+            url_path_regex=r"dp/(?P<id_key>[^/]+)",
             url_path_template="dp/{id_key}",
         ),
         IdSources.COMICVINE: IdentifierParts(
@@ -184,13 +189,15 @@ IDENTIFIER_PARTS_MAP: MappingProxyType[IdSources, IdentifierParts] = MappingProx
         IdSources.ISBN: IdentifierParts(
             domain="isbndb.com",
             id_type=IdentifierTypes(issue="book", series="series"),
-            url_path_regex=r"(?P<id_type>book)/(?P<id_key>[\d-]+)",
+            # Both declared slugs, or a series url unparse_url built parsed
+            # back as nothing.
+            url_path_regex=r"(?P<id_type>book|series)/(?P<id_key>[\d-]+)",
             url_path_template="{id_type}/{id_key}",
         ),
         IdSources.KITSU: IdentifierParts(
             domain="kitsu.app",
             id_type=IdentifierTypes(series="manga"),
-            url_path_regex=r"(?P<id_type>manga)/(?P<id_key>\S+)",
+            url_path_regex=r"(?P<id_type>manga)/(?P<id_key>[^/]+)",
             url_path_template="{id_type}/{id_key}",
         ),
         IdSources.LCG: IdentifierParts(
@@ -198,19 +205,23 @@ IDENTIFIER_PARTS_MAP: MappingProxyType[IdSources, IdentifierParts] = MappingProx
             id_type=IdentifierTypes(
                 issue="comic", series="comics/series", publisher="comics"
             ),
-            url_path_regex=rf"(?P<id_type>\S+)/(?P<id_key>\S+){_SLUG_REXP}",
+            # The series slug is two segments, so the type is spelled out
+            # longest first rather than matched generically. A greedy \S+ for
+            # either group ate the whole path and read the trailing name slug
+            # as the id.
+            url_path_regex=rf"(?P<id_type>comics/series|comics|comic)/(?P<id_key>[^/]+){_SLUG_REXP}",
             url_path_template="{id_type}/{id_key}/s",
         ),
         IdSources.MANGADEX: IdentifierParts(
             domain="mangadex.org",
             id_type=IdentifierTypes(series="title"),
-            url_path_regex=rf"(?P<id_type>title)/(?P<id_key>\S+){_SLUG_REXP}",
+            url_path_regex=rf"(?P<id_type>title)/(?P<id_key>[^/]+){_SLUG_REXP}",
             url_path_template="{id_type}/{id_key}/s",
         ),
         IdSources.MANGAUPDATES: IdentifierParts(
             domain="mangaupdates.com",
             id_type=IdentifierTypes(series="series"),
-            url_path_regex=rf"(?P<id_type>series)/(?P<id_key>\S+){_SLUG_REXP}",
+            url_path_regex=rf"(?P<id_type>series)/(?P<id_key>[^/]+){_SLUG_REXP}",
             url_path_template="{id_type}/{id_key}/s",
         ),
         IdSources.MARVEL: IdentifierParts(
@@ -360,11 +371,15 @@ def create_identifier(
 def get_id_source_from_url(url: str) -> str:
     """Parse the id source for a url."""
     obj = urlparse(url)
-    parts = obj.netloc.split(".")
+    # The hostname, not the netloc: it is lowercased and carries neither the
+    # port nor the userinfo, so metron.cloud:443 and Metron.Cloud both name
+    # metron instead of falling through as unknown domains.
+    hostname = obj.hostname or ""
+    parts = hostname.split(".")
 
     parts.reverse()
     node = SOURCE_ALIAS_TREE
-    id_source_str = obj.netloc
+    id_source_str = hostname
     for part in parts:
         node = node.get(part)
         if isinstance(node, IdSources):

--- a/comicbox/identifiers/urns.py
+++ b/comicbox/identifiers/urns.py
@@ -26,12 +26,21 @@ from comicbox.identifiers.other import parse_identifier_other_str
 
 _ID_TYPES = frozenset(ID_TYPE_NAMES)
 # RFC 8141 §2: 2-32 chars, alphanumeric at both ends, hyphens inside.
-_NID_EXP = r"[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]"
-_NID_RE = re.compile(_NID_EXP)
+NID_EXP = r"[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]"
+_NID_RE = re.compile(NID_EXP)
+# The namespace specific string as comicbox writes it and finds it again in
+# prose. A urn has to end where its key ends, not at the next space, so the
+# comma or period after it in a sentence is not read as part of the key.
+NSS_EXP = r"[\w%.:-]*[\w%]"
+_NSS_RE = re.compile(NSS_EXP)
+# One urn, for finding urns embedded in a sentence. The only grammar
+# comicbox writes, so it is also the one to_urn_string composes against.
+URN_SCAN_EXP = rf"urn:{NID_EXP}:{NSS_EXP}"
+# The reader is deliberately looser than the writer: whatever another tagger
+# put in the key comes back whole rather than being silently truncated.
 # The scheme is case insensitive per RFC 8141 §2.
-_URN_RE = re.compile(rf"urn:(?P<nid>{_NID_EXP}):(?P<nss>\S+)", re.IGNORECASE)
+_URN_RE = re.compile(rf"urn:(?P<nid>{NID_EXP}):(?P<nss>\S+)", re.IGNORECASE)
 _URN_SCHEME = "urn:"
-_WHITESPACE_RE = re.compile(r"\s")
 
 
 def _is_urn(tag: str) -> bool:
@@ -83,13 +92,13 @@ def to_urn_string(id_source_str: str, id_type: str, id_key_str: str) -> str:
     Compose an urn string.
 
     Returns the empty string for parts that cannot make a legal urn, so a
-    hand written identifier source or key never aborts a read.
+    hand written identifier source or key never aborts a read. A key is
+    checked against the same grammar the notes scanner looks for, because a
+    urn comicbox writes but cannot find again is worse than no urn: the
+    scanner would stop at the first illegal character and record the
+    truncated head as the id.
     """
-    if (
-        not _NID_RE.fullmatch(id_source_str)
-        or not id_key_str
-        or _WHITESPACE_RE.search(id_key_str)
-    ):
+    if not _NID_RE.fullmatch(id_source_str) or not _NSS_RE.fullmatch(id_key_str):
         return ""
     id_type = id_type.lower()
     if id_type in ("", DEFAULT_ID_TYPE):

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import fields
+from types import MappingProxyType
 
 from comicbox.box import Comicbox
 from comicbox.enums.comicbox import IdSources
@@ -22,10 +24,13 @@ from comicbox.identifiers.identifiers import (
 )
 from comicbox.identifiers.other import parse_identifier_other_str
 from comicbox.identifiers.urns import (
+    URN_SCAN_EXP,
     parse_string_identifier,
     parse_urn_identifier,
     to_urn_string,
 )
+
+_URN_SCAN_RE = re.compile(URN_SCAN_EXP, flags=re.IGNORECASE)
 
 # A Metron-tagged issue carrying both the numeric id and the slug web url —
 # the shape that exposed the url-clobbers-key bug.
@@ -281,9 +286,32 @@ def test_metron_url_path_strips_trailing_slash() -> None:
     )
 
 
-def test_get_id_source_from_url_unknown_domain_returns_netloc() -> None:
-    """An unrecognized domain falls back to returning the netloc itself."""
+def test_get_id_source_from_url_unknown_domain_returns_hostname() -> None:
+    """An unrecognized domain falls back to returning the hostname itself."""
     assert get_id_source_from_url("https://example.com/foo") == "example.com"
+    # The hostname is lowercased, so the fallback is too.
+    assert get_id_source_from_url("https://Example.COM/foo") == "example.com"
+
+
+def test_get_id_source_from_url_ignores_port_case_and_userinfo() -> None:
+    """
+    The host names the database; the rest of the authority does not.
+
+    Matching on the netloc made metron.cloud:8000 and Metron.Cloud unknown
+    domains, so their urls yielded no id at all.
+    """
+    for url in (
+        "https://metron.cloud/issue/123495/",
+        "https://metron.cloud:443/issue/123495/",
+        "https://Metron.Cloud/issue/123495/",
+        "https://user:pw@metron.cloud/issue/123495/",
+    ):
+        assert get_id_source_from_url(url) == IdSources.METRON.value, url
+
+
+def test_get_id_source_from_url_hostless_url_names_nothing() -> None:
+    """A url with no authority at all yields no source rather than raising."""
+    assert get_id_source_from_url("not a url") == ""
 
 
 ######################
@@ -553,3 +581,287 @@ def test_metron_id_survives_comic_info_round_trip() -> None:
 def test_metron_id_survives_metron_info_round_trip() -> None:
     """A Metron issue id written to MetronInfo reads back as the numeric key."""
     assert _round_trip_metron_key(MetadataFormats.METRON_INFO) == "123495"
+
+
+##################################################
+# url paths: no match, whole segments, round trip
+##################################################
+
+
+def test_parse_url_path_non_id_page_on_a_known_domain_is_no_match() -> None:
+    """
+    A known database's non-id pages are not ids.
+
+    Handing the raw path back as the key minted ids like "/about/" and "/"
+    for the front page, and a comic carrying a plain link to the site got a
+    junk id for that database that no lookup could ever resolve.
+    """
+    cases = (
+        (IdSources.METRON, "https://metron.cloud/about/"),
+        (IdSources.METRON, "https://metron.cloud/"),
+        (IdSources.COMICVINE, "https://comicvine.gamespot.com/news/"),
+        (IdSources.LCG, "https://leagueofcomicgeeks.com/about"),
+        (IdSources.GCD, "https://comics.org/donate/"),
+        (IdSources.ASIN, "https://www.amazon.com/gp/help/customer/display.html"),
+    )
+    for id_source, url in cases:
+        assert IDENTIFIER_PARTS_MAP[id_source].parse_url_path(url) == ("", ""), url
+        # And the public entrypoint invents no identifier from it.
+        assert identifier_from_url(url) == ("", {}), url
+
+
+def test_parse_url_path_stops_the_id_at_the_path_segment() -> None:
+    """
+    An id is one path segment, never the rest of the url.
+
+    A greedy match read the trailing name slug most of these databases append
+    as the id, and amazon's /ref=... tracking suffix as part of the asin.
+    """
+    cases = (
+        (
+            IdSources.LCG,
+            "https://leagueofcomicgeeks.com/comic/1234/batman-1",
+            ("issue", "1234"),
+        ),
+        (
+            IdSources.LCG,
+            "https://leagueofcomicgeeks.com/comics/series/178012/batman",
+            ("series", "178012"),
+        ),
+        (
+            IdSources.LCG,
+            "https://leagueofcomicgeeks.com/comics/9/dc-comics",
+            ("publisher", "9"),
+        ),
+        (
+            IdSources.MANGADEX,
+            "https://mangadex.org/title/a1b2c3/one-piece",
+            ("series", "a1b2c3"),
+        ),
+        (
+            IdSources.MANGAUPDATES,
+            "https://mangaupdates.com/series/wn3q3v5/berserk",
+            ("series", "wn3q3v5"),
+        ),
+        (
+            IdSources.KITSU,
+            "https://kitsu.app/manga/bleach/chapters",
+            ("series", "bleach"),
+        ),
+        (
+            IdSources.ASIN,
+            "https://www.amazon.com/Some-Title/dp/B08XYZ1234/ref=sr_1_1",
+            ("issue", "B08XYZ1234"),
+        ),
+    )
+    for id_source, url, expected in cases:
+        assert IDENTIFIER_PARTS_MAP[id_source].parse_url_path(url) == expected, url
+
+
+# One sample key per database, shaped the way that database's url path regex
+# accepts: bare numbers, hyphenated barcodes, slugs and uuids.
+_ROUND_TRIP_ID_KEYS: MappingProxyType[IdSources, str] = MappingProxyType(
+    {
+        IdSources.ANILIST: "30002",
+        IdSources.ASIN: "B08XYZ1234",
+        IdSources.COMICVINE: "145269",
+        IdSources.COMIXOLOGY: "216693",
+        IdSources.GCD: "1234567",
+        IdSources.ISBN: "978-0-306-40615-7",
+        IdSources.KITSU: "bleach",
+        IdSources.LCG: "178012",
+        IdSources.MANGADEX: "f9c33607-9180-4ba6-b85c-e4b5faee7192",
+        IdSources.MANGAUPDATES: "wn3q3v5",
+        IdSources.MARVEL: "12345",
+        IdSources.METRON: "batman-2016-0",
+        IdSources.MYANIMELIST: "13",
+        IdSources.PANELSYNDICATE: "theprivateeye",
+        IdSources.UPC: "76194130593400111",
+    }
+)
+
+
+def test_round_trip_table_covers_every_source_that_has_url_parts() -> None:
+    """Drift guard: the sample keys name every database in the parts map."""
+    assert frozenset(_ROUND_TRIP_ID_KEYS) == frozenset(IDENTIFIER_PARTS_MAP)
+
+
+def test_every_url_parses_back_to_the_parts_it_was_built_from() -> None:
+    """
+    parse_url_path inverts unparse_url for every source and every type.
+
+    unparse_url builds a url for any type the source declares a slug for, so
+    parse_url_path has to read every one of them back. Where it could not,
+    a url comicbox wrote itself came back as a different type, or as no id.
+    """
+    for id_source, id_parts in IDENTIFIER_PARTS_MAP.items():
+        id_key = _ROUND_TRIP_ID_KEYS[id_source]
+        for id_type in id_parts.id_type.map:
+            url = id_parts.unparse_url(id_type, id_key)
+            assert url, f"{id_source.value} {id_type} builds no url"
+            assert id_parts.parse_url_path(url) == (id_type, id_key), url
+            assert get_id_source_from_url(url) == id_source.value, url
+
+
+def test_every_url_yields_the_identifier_it_was_built_from() -> None:
+    """The whole public path, url to identifier, round trips for every type."""
+    for id_source, id_parts in IDENTIFIER_PARTS_MAP.items():
+        id_key = _ROUND_TRIP_ID_KEYS[id_source]
+        for id_type in id_parts.id_type.map:
+            url = get_identifier_url(id_source.value, id_type, id_key)
+            expected = {"key": id_key}
+            if id_type != "issue":
+                expected["id_type"] = id_type
+            assert identifier_from_url(url) == (id_source.value, expected), url
+
+
+#####################################
+# legacy identifier strings still read
+#####################################
+
+
+def test_legacy_urns_still_parse() -> None:
+    """
+    Every urn shape already in the wild reads back.
+
+    Comicbox wrote a type segment into every urn before v3, and the notes of
+    files tagged by hand and by other programs carry stranger things still.
+    """
+    cases = (
+        # The typed form comicbox wrote before v3, including for the default
+        # type it no longer states.
+        ("urn:comicvine:issue:145269", IdSources.COMICVINE, "issue", "145269"),
+        ("urn:metron:series:178012", IdSources.METRON, "series", "178012"),
+        (
+            "urn:leagueofcomicgeeks:issue:178012",
+            IdSources.LCG,
+            "issue",
+            "178012",
+        ),
+        # A comicvine long code inside a urn, typed and untyped. The urn layer
+        # hands it over whole; create_identifier splits it.
+        (
+            "urn:comicvine:issue:4050-160294",
+            IdSources.COMICVINE,
+            "issue",
+            "4050-160294",
+        ),
+        ("urn:comicvine:4000-45722", IdSources.COMICVINE, "issue", "4000-45722"),
+        # RFC 8141 makes the scheme case insensitive, and comicbox the type.
+        ("URN:comicvine:145269", IdSources.COMICVINE, "issue", "145269"),
+        ("URN:METRON:SERIES:178012", IdSources.METRON, "series", "178012"),
+        # Colons inside the key keep every segment.
+        ("urn:metron:series:a:b", IdSources.METRON, "series", "a:b"),
+        (
+            "urn:comicvine:notatype:145269",
+            IdSources.COMICVINE,
+            "issue",
+            "notatype:145269",
+        ),
+        # A segment that spells a source, not a type, is key data here. The
+        # redundant same-source prefix is stripped later, by normalize_key.
+        ("urn:metron:metron:123", IdSources.METRON, "issue", "metron:123"),
+        # A whole key that happens to spell a type is still the key.
+        ("urn:metron:series", IdSources.METRON, "issue", "series"),
+        # An alternate source prefix names its database.
+        ("urn:cvdb:145269", IdSources.COMICVINE, "issue", "145269"),
+    )
+    for urn, id_source, id_type, id_key in cases:
+        assert parse_urn_identifier(urn) == (id_source, id_type, id_key), urn
+
+
+def test_legacy_urns_normalize_to_the_key_they_name() -> None:
+    """The identifier a legacy urn finally becomes carries the bare key."""
+    cases = (
+        ("comicvine", "urn:comicvine:issue:145269", {"key": "145269"}),
+        (
+            "comicvine",
+            "urn:comicvine:issue:4050-160294",
+            {"key": "160294", "id_type": "series"},
+        ),
+        ("metron", "urn:metron:metron:123", {"key": "123"}),
+        ("metron", "urn:metron:series:178012", {"key": "178012", "id_type": "series"}),
+    )
+    for id_source_str, urn, expected in cases:
+        _, id_type, id_key = parse_urn_identifier(urn)
+        assert create_identifier(id_source_str, id_key, id_type=id_type) == expected, (
+            urn
+        )
+
+
+_LEGACY_GTIN_COMIC_INFO = """<?xml version="1.0" encoding="utf-8"?>
+<ComicInfo>
+  <Title>Legacy</Title>
+  <GTIN>urn:comicvine:issue:145269, urn:metron:series:178012,urn:isbn:issue:978-0-306-40615-7</GTIN>
+</ComicInfo>
+"""
+
+
+def test_legacy_comma_joined_gtin_urns_still_read() -> None:
+    """
+    ComicInfo GTIN holds a barcode now, but old files list comicbox urns there.
+
+    Comicbox used to dump every identifier into that tag as a comma joined
+    list of urns. Plenty of files carry them, so each one still reads, spaces
+    around the commas and all.
+    """
+    with Comicbox() as car:
+        car.add_metadata(_LEGACY_GTIN_COMIC_INFO, MetadataFormats.COMIC_INFO)
+        identifiers = dict(car.to_dict().get("comicbox", {}).get("identifiers", {}))
+    assert identifiers["comicvine"] == {"key": "145269"}
+    assert identifiers["metron"] == {"key": "178012", "id_type": "series"}
+    assert identifiers["isbn"] == {"key": "978-0-306-40615-7"}
+
+
+#################################
+# one urn grammar, reader & writer
+#################################
+
+
+def test_every_urn_written_is_found_whole_in_prose() -> None:
+    """
+    Comicbox only writes urns its own notes scanner reads back.
+
+    The scanner stops at the first character outside the urn grammar, so a
+    urn the writer composed with one in it was recorded as its truncated
+    head. The writer now composes against the grammar the scanner looks for.
+    """
+    keys = (
+        "145269",
+        "batman-2016-0",
+        "978-0-306-40615-7",
+        "100%",
+        "a:b",
+        "f9c33607-9180-4ba6-b85c-e4b5faee7192",
+    )
+    for key in keys:
+        urn = to_urn_string("metron", "issue", key)
+        assert urn, key
+        match = _URN_SCAN_RE.search(f"Tagged by hand. See {urn}, and more.")
+        assert match is not None, urn
+        assert match.group() == urn, urn
+
+
+def test_urn_illegal_keys_are_refused_rather_than_truncated() -> None:
+    """
+    A key the urn grammar has no room for yields no urn at all.
+
+    Writing one anyway put a urn in notes that read back as the part before
+    the illegal character: urn:metron:a/b became the id "a".
+    """
+    for key in ("a/b", "a{b}", "a+b", "a~b", "a b", ""):
+        assert to_urn_string("metron", "issue", key) == "", key
+
+
+def test_urn_scan_and_urn_parse_agree_on_the_namespace() -> None:
+    """
+    The scanner and the parser share one namespace grammar.
+
+    The hand-maintained copy in the notes module accepted a one character
+    namespace and a trailing hyphen, so it handed the parser urns the parser
+    then refused, and the notes said nothing about why.
+    """
+    for text in ("urn:x:123", "urn:ab-:123"):
+        assert _URN_SCAN_RE.search(text) is None, text
+        assert parse_urn_identifier(text) == (None, "", ""), text
+    assert _URN_SCAN_RE.search("urn:ab:123") is not None

--- a/tests/unit/test_urls_and_identifiers.py
+++ b/tests/unit/test_urls_and_identifiers.py
@@ -204,3 +204,53 @@ comicbox:
   notes: "Tagged with Comictagger using info from Metron [Issue ID 145269]"
 """)
     assert sub_md["identifiers"]["metron"]["key"] == "99999"
+
+
+def test_a_known_sites_non_id_page_invents_no_identifier() -> None:
+    """
+    A link to a database's front page or about page is not an id for it.
+
+    The url path used to be handed back as the key whenever the id regex
+    missed, so a comic linking to metron.cloud got the metron id "/about/",
+    which then outranked nothing and looked up as nothing.
+    """
+    non_id_url = "https://metron.cloud/about/"
+    sub_md = _load_yaml(f"""
+comicbox:
+  urls:
+    - {non_id_url}
+""")
+    assert sub_md["urls"] == [non_id_url]
+    assert not sub_md.get("identifiers")
+
+
+def test_a_known_sites_non_id_page_does_not_displace_a_real_id() -> None:
+    """The real id stays, and no url is invented over the one the file has."""
+    sub_md = _load_yaml("""
+comicbox:
+  identifiers:
+    metron:
+      key: "123495"
+  urls:
+    - https://metron.cloud/about/
+""")
+    assert sub_md["identifiers"]["metron"] == {"key": "123495"}
+    assert "https://metron.cloud/issue/123495" in sub_md["urls"]
+
+
+def test_a_url_slug_after_the_id_is_not_the_id() -> None:
+    """
+    Most databases append a name slug the id regex must stop before.
+
+    A greedy match read the slug as the id, so a League of Comic Geeks link
+    recorded the book's title where its number belonged.
+    """
+    sub_md = _load_yaml("""
+comicbox:
+  urls:
+    - https://leagueofcomicgeeks.com/comics/series/178012/batman
+""")
+    assert sub_md["identifiers"]["leagueofcomicgeeks"] == {
+        "key": "178012",
+        "id_type": "series",
+    }


### PR DESCRIPTION
Four defects in the identifier layer, all introduced or exposed by #172. Each
was reproduced against `develop` before being fixed.

## 1. A non-id path became an id key

`IdentifierParts.parse_url_path` handed the raw url path back as the id key
whenever no pattern matched, so every ordinary page on a database comicbox
knows minted an id for that database.

```text
identifier_from_url("https://metron.cloud/about/")  -> ("metron", {"key": "/about/"})
identifier_from_url("https://metron.cloud/")        -> ("metron", {"key": "/"})
identifier_from_url("https://comicvine.gamespot.com/news/")
                                                    -> ("comicvine", {"key": "/news/"})
```

It reports no match now. `identifier_from_url` already discards a keyless
result, so such a url stays a url and yields nothing else. It was the only
caller that depended on the old fallback.

## 2. Greedy id captures reached past the path separator

Five sources captured the id with `\S+`, which does not stop at `/`. League of
Comic Geeks, MangaDex, MangaUpdates and Kitsu all append a name slug after the
id, and amazon appends `/ref=...` tracking:

```text
leagueofcomicgeeks.com/comic/1234/batman-1        -> ("issue",  "some-slug")
leagueofcomicgeeks.com/comics/series/178012/batman -> ("issue",  "batman")
mangadex.org/title/abc-123/one-piece              -> ("series", "abc-123/some-title")
www.amazon.com/dp/B00X123/ref=foo                 -> ("issue",  "B00X123/ref=foo")
```

They capture one segment now, the way METRON already did. League of Comic Geeks
needed its type spelled out as well, because one of its slugs is two segments
(`comics/series`) and a greedy type ate the whole path.

`isbndb` turned up while writing the round-trip test: it declares a `series`
slug that `unparse_url` will build a url from, but its path regex only read
`book`, so a url comicbox wrote itself parsed back as nothing. The regex reads
both declared slugs now.

## 3. One urn grammar

Two copies of it had drifted apart. The notes scanner accepted a one-character
namespace and a trailing hyphen that the urn parser then refused, and
`to_urn_string` composed urns containing characters the scanner stops at:

```text
to_urn_string("metron", "issue", "a/b") -> "urn:metron:a/b"
notes scan of that urn                  -> "urn:metron:a"   # id becomes "a"
```

The grammar lives once in `urns.py` now and `notes.py` derives its regex from
it. **`to_urn_string` rejects rather than percent-encodes** a key it cannot
express: it already returns `""` for a whitespace-bearing key and an unknown
type, encoding would change the key's text, and the identifier itself is stored
structurally regardless — the notes urn is a convenience copy. The invariant is
that every urn comicbox writes, comicbox reads back identically.

Reading stays deliberately looser than writing, so a urn another tagger wrote
still comes back whole instead of being silently truncated.

## 4. `hostname`, not `netloc`

`get_id_source_from_url` matched on the netloc, so the port, the case of the
host and any userinfo made a known database an unknown domain:

```text
https://metron.cloud:443/issue/123/   -> "metron.cloud:443"
https://Metron.Cloud/issue/123/       -> "Metron.Cloud"
https://user@metron.cloud/issue/123/  -> "user@metron.cloud"
```

## Tests

- A known domain with a non-id path yields no match, at both the parse layer
  and through `Comicbox`.
- Whole-segment captures for each of the five sources.
- **Table driven `parse(unparse(x)) == x`** over every entry in
  `IDENTIFIER_PARTS_MAP` × every id type it declares — 39 pairs across the 15
  sources that have url parts (GTIN is the 16th `IdSources` member and declares
  none). A companion test asserts the sample-key table names every source, so a
  new database cannot skip the round trip. This is what surfaced the isbndb
  asymmetry.
- Legacy inputs: pre-#172 typed urns, comicvine long codes inside urns, the
  comma-joined GTIN urn lists old comicbox wrote into ComicInfo, colons inside
  keys, the uppercase `URN:` scheme, and segments that collide with a type or a
  source alias.
- Writer/reader agreement: every urn `to_urn_string` produces is found whole in
  prose, and keys it cannot express yield no urn at all.

`make lint` (ruff, basedpyright, vulture, complexity, codespell) and the full
suite — 1460 passed, 1 skipped — verified in an isolated worktree at this
commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)