### PR TITLE
fix(archive): four archive i/o defects and their regressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,13 @@
     - An unrecognized ComicVine type code reads as an issue, not an arc.
     - An `id_type` comicbox doesn't know no longer leaks into a url.
     - kitsu.app urls are recognized.
+    - `--recurse` finds `.cb7` archives, which it silently skipped.
+    - Renaming refuses a name another file already holds instead of replacing
+      that file. Two comics whose metadata predicts one name kept both.
+    - A ComicBookInfo comment in a CBZ dates the metadata by the file's own
+      mtime, as it already did in a CBR.
+    - Reading a page no longer depends on the working directory. A directory
+      there named like a page made that page read as empty.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/box/archive/init.py
+++ b/comicbox/box/archive/init.py
@@ -41,6 +41,7 @@ class ComicboxArchiveInit(ComicboxInit):
             # be many KB on archives with hundreds of pages.
             self._namelist = None
             self._infolist = None
+            self._dirnames = None
 
     def _get_archive(self) -> ArchiveType:
         """Set archive instance open for reading."""

--- a/comicbox/box/archive/mtime.py
+++ b/comicbox/box/archive/mtime.py
@@ -14,10 +14,13 @@ class ComicboxArchiveMtime(ComicboxArchiveWrite):
     """Calculate page filenames."""
 
     def _is_comment_json(self, archive: ArchiveType) -> bool:
+        # Slice, don't index: zipfile hands back a bytes comment and rarfile
+        # a str one, and indexing bytes yields an int (123) that matches
+        # neither bracket, so every CBZ comment tested as not-json.
         return (
             self._config.is_read_comments
             and bool(comment := getattr(archive, "comment", ""))
-            and (comment[0] in _BRACKETS)
+            and (comment[:1] in _BRACKETS)
         )
 
     def get_path_mtime_dttm(self) -> datetime | None:

--- a/comicbox/box/archive/read.py
+++ b/comicbox/box/archive/read.py
@@ -8,6 +8,7 @@ from sys import maxsize
 from typing import TYPE_CHECKING, cast
 
 from comicbox.box.archive.archive import Archive
+from comicbox.box.archive.archiveinfo import ArchiveInfo
 from comicbox.box.archive.init import ComicboxArchiveInit
 from comicbox.enums.comicbox import FileTypeEnum
 from comicbox.exceptions import ArchiveError, UnsupportedArchiveTypeError
@@ -63,6 +64,17 @@ class ComicboxArchiveRead(ComicboxArchiveInit):
             self._infolist = infolist
         return self._infolist
 
+    def dirnames(self) -> frozenset[str]:
+        """Get the names of the archive's directory entries."""
+        self._ensure_read_archive()
+        if self._dirnames is None:
+            self._dirnames: frozenset[str] | None = frozenset(
+                self._get_info_fn(info)
+                for info in self.infolist()
+                if ArchiveInfo.is_dir(info)
+            )
+        return self._dirnames
+
     @classmethod
     def check_unrar_executable(cls) -> bool:
         """Check for the unrar executable."""
@@ -116,9 +128,13 @@ class ComicboxArchiveRead(ComicboxArchiveInit):
         """Read an archive file to memory."""
         # Consider chunking files by 4096 bytes and streaming them.
         data = b""
-        if Path(filename).is_dir():
-            return data
         self._ensure_read_archive()
+        # Ask the archive, not the filesystem. Path(filename).is_dir()
+        # resolved an archive-internal name against the process cwd, so a
+        # directory that happened to share a page's name made the read
+        # return b"" -- and a real directory entry was never caught at all.
+        if filename in self.dirnames():
+            return data
         archive = self._get_archive()
         factory = self._get_7zfactory()
         pdf_format = self._get_pdf_format(pdf_format)

--- a/comicbox/box/dump_files.py
+++ b/comicbox/box/dump_files.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from loguru import logger
 
+from comicbox.box.archive.write import _claim_destination, _release_destination
 from comicbox.box.dump import ComicboxDump
 from comicbox.exceptions import ArchiveWriteError, ExportError
 from comicbox.formats import MetadataFormats
@@ -71,6 +72,39 @@ class ComicboxDumpToFiles(ComicboxDump):
             fn = str(Path(fn).with_suffix(self._path.suffix))
         return fn
 
+    @staticmethod
+    def _is_same_file(old_path: Path, new_path: Path) -> bool:
+        """Return whether both names already refer to one file on disk."""
+        # Not just `==`: on a case-insensitive filesystem a rename that only
+        # changes case lands on the same inode, and refusing it would make
+        # `--rename` fail on every macOS library.
+        try:
+            return new_path.samefile(old_path)
+        except OSError:
+            return False
+
+    def _rename_to(self, old_path: Path, new_path: Path) -> None:
+        """
+        Rename onto a destination no one else holds.
+
+        Path.rename() replaces an existing destination silently on posix,
+        so two archives whose metadata predicts one name -- the same issue
+        carried twice, or a scheme that renders too few fields -- left only
+        the last one written. Claim the destination for the same reason
+        conversions do (comicbox.box.archive.write): the finished-file
+        check alone can't see a rename still in flight on another thread.
+        """
+        if self._is_same_file(old_path, new_path):
+            return
+        _claim_destination(new_path)
+        try:
+            if new_path.exists():
+                reason = f"{new_path} already exists."
+                raise ArchiveWriteError(reason)
+            old_path.rename(new_path)
+        finally:
+            _release_destination(new_path)
+
     def rename_file(self) -> None:
         """Rename the archive."""
         if not self._path:
@@ -85,6 +119,6 @@ class ComicboxDumpToFiles(ComicboxDump):
         if self._config.general.dry_run:
             logger.info(f"Would rename:\n{old_path} ==> {new_path}")
             return
-        self._path.rename(new_path)
+        self._rename_to(old_path, new_path)
         self._path: Path | None = new_path
         logger.info(f"Renamed:\n{old_path} ==> {new_path}")

--- a/comicbox/box/init.py
+++ b/comicbox/box/init.py
@@ -130,6 +130,7 @@ class ComicboxInit:
         self._archive: ArchiveType | None = None
         self._namelist: tuple[str, ...] | None = None
         self._infolist: tuple[InfoType, ...] | None = None
+        self._dirnames: frozenset[str] | None = None
         self._7zfactory: BytesIOFactory | None = None
 
         self._transform_cache: dict = {}

--- a/comicbox/run.py
+++ b/comicbox/run.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from comicbox.box import Comicbox
 from comicbox.config import get_config
+from comicbox.enums.comicbox import FileTypeEnum
 from comicbox.formats.base.online import outcome_stats
 from comicbox.formats.base.online.auto_engage import resolve_auto_engaged_budget
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
@@ -26,7 +27,11 @@ if TYPE_CHECKING:
 class Runner:
     """Main runner."""
 
-    _RECURSE_SUFFIXES = frozenset({".cbz", ".cbr", ".cbt", ".pdf"})
+    # Derived from the file-type enum so a newly supported archive can't be
+    # left out of a recursive walk. Hardcoding the set is what dropped .cb7.
+    _RECURSE_SUFFIXES = frozenset(
+        {"." + file_type.value.lower() for file_type in FileTypeEnum}
+    )
 
     def __init__(self, config: Namespace | Mapping | ComicboxSettings | None) -> None:
         """Initialize actions and config."""

--- a/tests/files/list_recurse_output.txt
+++ b/tests/files/list_recurse_output.txt
@@ -83,6 +83,19 @@ tests/files/Captain Science #001-metron.cbz
 │      │ metroninfo.xml │
 └──────┴────────────────┘
 ════════════════════════════════════════════════════════════════════════════════
+tests/files/Captain Science #001.cb7
+┏━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Page ┃ Archive Path                                ┃
+┡━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│   0  │ Captain Science 001/CaptainScience#1_01.jpg │
+│   1  │ Captain Science 001/CaptainScience#1_02.jpg │
+│   2  │ Captain Science 001/CaptainScience#1_03.jpg │
+│   3  │ Captain Science 001/CaptainScience#1_04.jpg │
+│   4  │ Captain Science 001/CaptainScience#1_05.jpg │
+│      │ Captain Science 001/comicinfo.xml           │
+│      │ Captain Science 001/metroninfo.xml          │
+└──────┴─────────────────────────────────────────────┘
+════════════════════════════════════════════════════════════════════════════════
 tests/files/Captain Science #001.cbz
 ┏━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Page ┃ Archive Path                                ┃

--- a/tests/test_mtime.py
+++ b/tests/test_mtime.py
@@ -1,6 +1,9 @@
 """Test getting pages."""
 
+import json
+import zipfile
 from datetime import datetime, timezone
+from pathlib import Path
 from types import MappingProxyType
 
 import pytest
@@ -24,8 +27,11 @@ FIXTURES = MappingProxyType(
         "Captain Science #001.cbz": datetime(
             2026, 5, 17, 21, 43, 38, tzinfo=timezone.utc
         ),
-        "Captain Science #001 (1950) The Beginning - multi.cbz": datetime(
-            2026, 5, 17, 21, 43, 38, tzinfo=timezone.utc
+        # Carries a ComicBookInfo json comment, like the cbr above, so the
+        # file's own mtime dates it. It read as the members' date_time
+        # while the json check couldn't see a bytes (zip) comment.
+        "Captain Science #001 (1950) The Beginning - multi.cbz": _get_stat_mtime(
+            "Captain Science #001 (1950) The Beginning - multi.cbz"
         ),
         "empty.cbz": None,
     }
@@ -40,3 +46,30 @@ def test_get_mtime(fn: str) -> None:
         mtime = car.get_metadata_mtime()
     test_mtime = FIXTURES[fn]
     assert test_mtime == mtime
+
+
+def test_json_comment_in_a_zip_uses_the_path_mtime(tmp_path: Path) -> None:
+    """
+    A ComicBookInfo comment is detected on a CBZ, not just a CBR.
+
+    zipfile hands the comment back as bytes and rarfile as a str, and the
+    detection indexed it — `b'{'[0]` is 123, matching neither bracket — so
+    every zip comment tested as not-json and fell through to the
+    archive-file scan, which finds nothing in a comment-only archive.
+    """
+    cbz = tmp_path / "Comment v1999 #001 (1999).cbz"
+    with zipfile.ZipFile(cbz, "w") as zf:
+        zf.writestr("CaptainScience#1_01.jpg", b"\xff\xd8\xff\xe0not-really-a-jpeg")
+        zf.comment = json.dumps(
+            {"appID": "test/1", "ComicBookInfo/1.0": {"series": "Captain Science"}}
+        ).encode()
+
+    with Comicbox(cbz) as car:
+        assert car._is_comment_json(car._get_archive())
+        mtime = car.get_metadata_mtime()
+        path_mtime = car.get_path_mtime_dttm()
+
+    # The comment is the metadata, so the file's own mtime dates it. Before,
+    # this scanned for metadata files the archive doesn't have and got None.
+    assert mtime is not None
+    assert mtime == path_mtime

--- a/tests/unit/test_archive_read.py
+++ b/tests/unit/test_archive_read.py
@@ -7,7 +7,9 @@ import sys
 
 from comicbox.box import Comicbox
 from comicbox.box.archive import archive as archive_module
-from tests.const import CB7_SOURCE_PATH, CIX_CBZ_SOURCE_PATH
+from tests.const import CB7_SOURCE_PATH, CIX_CBZ_SOURCE_PATH, TEST_FILES_DIR
+
+RESOURCE_FORK_ARCHIVE = TEST_FILES_DIR / "macos_resource_fork.cbz"
 
 
 def test_namelist_derives_from_cached_infolist(monkeypatch) -> None:
@@ -125,3 +127,38 @@ def test_infolist_and_namelist_share_sort_order() -> None:
         infolist = cb.infolist()
         names_from_infolist = tuple(cb._get_info_fn(i) for i in infolist)
     assert names_from_namelist == names_from_infolist
+
+
+def test_readfile_ignores_a_same_named_directory_in_the_cwd(tmp_path, monkeypatch):
+    """
+    A member name is the archive's, not the filesystem's.
+
+    The dir guard called Path(filename).is_dir(), which resolves a relative
+    archive name against the process cwd — so a directory that happened to
+    share a page's name made the read return b"" and the page vanished.
+    """
+    import zipfile
+
+    cbz = tmp_path / "trap.cbz"
+    page = "CaptainScience#1_01.jpg"
+    payload = b"\xff\xd8\xff\xe0page-data"
+    with zipfile.ZipFile(cbz, "w") as zf:
+        zf.writestr(page, payload)
+
+    # cwd now holds a *directory* named exactly like the archive's page.
+    cwd = tmp_path / "cwd"
+    (cwd / page).mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+
+    with Comicbox(cbz) as cb:
+        assert cb._archive_readfile(page) == payload
+
+
+def test_readfile_still_skips_a_real_archive_directory_entry():
+    """The guard's actual job: a directory member of the archive reads empty."""
+    with Comicbox(RESOURCE_FORK_ARCHIVE) as cb:
+        dirnames = cb.dirnames()
+        assert "__MACOSX/" in dirnames
+        assert cb._archive_readfile("__MACOSX/") == b""
+        # Only the directory entry is skipped; real members still read.
+        assert cb._archive_readfile("CaptainScience#1_01.jpg")

--- a/tests/unit/test_rename_and_convert_safety.py
+++ b/tests/unit/test_rename_and_convert_safety.py
@@ -215,3 +215,72 @@ def test_a_conversion_respects_a_held_destination(tmp_path: Path) -> None:
     assert "already being written" in str(result.error)
     assert cbt.exists()
     assert not dest.exists()
+
+
+def test_rename_refuses_an_existing_destination(tmp_path: Path) -> None:
+    """
+    A rename cannot silently eat the file already at the predicted name.
+
+    Path.rename() replaces the destination on posix, so two archives whose
+    metadata predicts one name — the same issue carried twice, or a scheme
+    that renders too few distinguishing fields — left only the last one
+    written, with no error and no log line saying anything was lost.
+    """
+    cbz = tmp_path / "Rename v1999 #006 (1999).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+    with Comicbox(cbz) as car:
+        occupied = tmp_path / car.predict_filename()
+    occupied.write_bytes(b"already-here")
+
+    with pytest.raises(ArchiveWriteError, match="already exists"), Comicbox(cbz) as car:
+        car.rename_file()
+
+    # Both files survive: the destination is untouched and the source stays
+    # where it was, so a later run can still find it.
+    assert occupied.read_bytes() == b"already-here"
+    assert cbz.exists()
+
+
+def test_rename_respects_a_held_destination(tmp_path: Path) -> None:
+    """
+    A rename consults the in-flight claim, like a conversion does.
+
+    Holding the destination stands in for another thread's rename that
+    hasn't landed yet, which leaves nothing on disk for the exists() check
+    to see.
+    """
+    cbz = tmp_path / "Rename v1999 #007 (1999).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+    with Comicbox(cbz) as car:
+        dest = tmp_path / car.predict_filename()
+
+    _claim_destination(dest)
+    try:
+        with (
+            pytest.raises(ArchiveWriteError, match="already being written"),
+            Comicbox(cbz) as car,
+        ):
+            car.rename_file()
+    finally:
+        _release_destination(dest)
+
+    assert cbz.exists()
+    assert not dest.exists()
+
+
+def test_rename_to_the_same_name_is_not_a_collision(tmp_path: Path) -> None:
+    """An archive already at its predicted name must not refuse itself."""
+    cbz = tmp_path / "Idempotent v1999 #008 (1999).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+    with Comicbox(cbz) as car:
+        car.rename_file()
+        landed = car.get_path()
+    assert landed is not None
+
+    # Renaming the already-renamed archive is a no-op, not "already exists".
+    with Comicbox(landed) as car:
+        car.rename_file()
+        again = car.get_path()
+
+    assert again == landed
+    assert landed.exists()

--- a/tests/unit/test_run_recurse.py
+++ b/tests/unit/test_run_recurse.py
@@ -1,0 +1,63 @@
+"""Unit tests for the Runner's recursive directory walk."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from comicbox.enums.comicbox import FileTypeEnum
+from comicbox.run import Runner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _runner(path: Path) -> Runner:
+    return Runner({"comicbox": {"general": {"recurse": True}, "paths": (str(path),)}})
+
+
+def test_recurse_finds_every_supported_file_type(tmp_path: Path) -> None:
+    """
+    --recurse walks all five archive types, .cb7 included.
+
+    The suffix set was written out by hand and .cb7 was left off it, so a
+    recursive run silently skipped every 7z comic in a library — no error,
+    no log line, just files that were never processed.
+    """
+    for file_type in FileTypeEnum:
+        (tmp_path / f"comic.{file_type.value.lower()}").write_bytes(b"")
+
+    found = {path.suffix for path in _runner(tmp_path)._iter_recurse(tmp_path)}
+
+    assert found == {f".{file_type.value.lower()}" for file_type in FileTypeEnum}
+    assert ".cb7" in found
+
+
+def test_recurse_ignores_unsupported_suffixes(tmp_path: Path) -> None:
+    """Deriving the set from the enum must not widen the walk to everything."""
+    (tmp_path / "comic.cbz").write_bytes(b"")
+    for name in ("cover.jpg", "notes.txt", "comicinfo.xml", "noext"):
+        (tmp_path / name).write_bytes(b"")
+
+    found = [path.name for path in _runner(tmp_path)._iter_recurse(tmp_path)]
+
+    assert found == ["comic.cbz"]
+
+
+def test_recurse_matches_a_suffix_case_insensitively(tmp_path: Path) -> None:
+    """Libraries carry uppercase suffixes; the walk lowercases before matching."""
+    (tmp_path / "SHOUTING.CB7").write_bytes(b"")
+
+    found = [path.name for path in _runner(tmp_path)._iter_recurse(tmp_path)]
+
+    assert found == ["SHOUTING.CB7"]
+
+
+def test_recurse_descends_into_subdirectories(tmp_path: Path) -> None:
+    """The walk is recursive and yields in sorted order."""
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "second.cb7").write_bytes(b"")
+    (tmp_path / "a.cbz").write_bytes(b"")
+
+    found = [path.name for path in _runner(tmp_path)._iter_recurse(tmp_path)]
+
+    assert found == ["a.cbz", "second.cb7"]


### PR DESCRIPTION
Four independent bugs in the archive I/O paths. Each was reproduced first, then fixed, then covered by a test that fails without its fix (verified by reverse-applying the source patch and re-running: all five key tests fail, then pass again).

None of the four was covered by `tests/test_mtime.py`, `tests/unit/test_rename_and_convert_safety.py`, or `tests/unit/test_write_api.py` — confirmed before starting.

## 1. `mtime.py` — the ComicBookInfo comment check was always False for zips

`comment[0] in ("{", b"{")` indexes the comment. zipfile hands it back as **bytes** and rarfile as a **str**, so `b'{'[0]` is `123` and matches neither bracket. Every zip comment tested as not-json and fell through to the archive-file scan.

The repo's own fixtures show it: `Captain Science #001-cix-cbi.cbr` (str comment) took the path mtime, while `...The Beginning - multi.cbz` — carrying the same kind of CBI json comment — took its members' `date_time`. Same metadata, different answer, purely from the container type. That fixture had the buggy value baked in and is corrected here.

Slicing (`comment[:1]`) keeps one expression correct for both types.

## 2. `read.py` — `is_dir()` ran against the process working directory

`_archive_readfile` guarded with `Path(filename).is_dir()`, which resolves an archive-internal name against the **cwd**. A directory there named like a page made that page read as `b""`; a genuine directory entry inside the archive was never caught at all.

Now asks the archive, via a `dirnames()` set cached and released beside `namelist`/`infolist`.

## 3. `dump_files.py` — rename silently overwrote its destination

`Path.rename` replaces an existing destination on posix. Two archives whose metadata predicts one name — the same issue carried twice, or a scheme that renders too few distinguishing fields — left only the last one written, with no error and nothing logged. Reproduced: a 13-byte file was replaced by a 22KB archive and the original vanished.

Mirrors the conversion path's handling (`_claim_destination` / `_release_destination` + an occupied-destination check), so an in-flight rename on another thread is refused too. A rename that only changes case on a case-insensitive filesystem stays a no-op rather than becoming a self-collision.

## 4. `run.py` — `.cb7` missing from the recurse suffixes

A recursive run silently skipped every 7z comic. Now derived from `FileTypeEnum` so it can't drift again.

The checked-in golden output proves the bug: `tests/files/list_recurse_output.txt` never listed `tests/files/Captain Science #001.cb7`. Regenerating adds exactly that one block (+13 lines, no other change).

## Tests

| Bug | Test |
| --- | --- |
| 1 | `tests/test_mtime.py::test_json_comment_in_a_zip_uses_the_path_mtime` |
| 2 | `tests/unit/test_archive_read.py::test_readfile_ignores_a_same_named_directory_in_the_cwd` (+ a companion asserting the guard still skips a real `__MACOSX/` entry) |
| 3 | `tests/unit/test_rename_and_convert_safety.py::test_rename_refuses_an_existing_destination`, `..._respects_a_held_destination`, `..._to_the_same_name_is_not_a_collision` |
| 4 | `tests/unit/test_run_recurse.py` (4 tests) |

`make fix`, `make lint`, `make ty` all clean; 1454 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)