### PR TITLE
fix(archive): store metadata after the pages, and claim every write

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,12 @@
       mtime, as it already did in a CBR.
     - Reading a page no longer depends on the working directory. A directory
       there named like a page made that page read as empty.
+    - Writing metadata to a comic no longer rewrites its pages. Metadata is
+      stored after the pages instead of before them, so re-tagging appends to
+      the end of the archive rather than sliding every page down over itself.
+      Tagging is faster, and an interrupted write can no longer damage a page.
+    - Writing a comic claims it for the duration. One archive named twice in a
+      batch was repacked by two threads at once, which destroyed it.
     - A name slug or tracking suffix after the id in a url is no longer the id.
     - A link to a database's front page no longer becomes an id for it.
     - Urls are recognized whatever the host's case, and with a port or login.

--- a/comicbox/box/archive/write.py
+++ b/comicbox/box/archive/write.py
@@ -185,22 +185,23 @@ class ComicboxArchiveWrite(ComicboxArchiveRead):
         # writers unlink each other's in-progress file and then replace a
         # half-written one onto the destination.
         tmp_path = self._path.with_name(self._path.name + _RECOMPRESS_SUFFIX)
-        destination = self._path.with_suffix(_CBZ_SUFFIX)
-        _claim_destination(destination)
-        try:
-            new_path = self._get_new_archive_path()
-            tmp_path.unlink(missing_ok=True)
-            logger.info(f"Creating {new_path}...")
-            with ZipFile(tmp_path, "x") as zf:
-                self._archive_write_metadata_files(zf, files)
-                self._copy_archive_files_to_new_archive(zf)
-                zf.comment = comment
+        new_path = self._get_new_archive_path()
+        tmp_path.unlink(missing_ok=True)
+        logger.info(f"Creating {new_path}...")
+        with ZipFile(tmp_path, "x") as zf:
+            # Pages first, metadata last. A later in-place re-tag removes the
+            # trailing metadata and appends the new copy, so repack has nothing
+            # after it to shift: no page byte is ever rewritten, and a write
+            # interrupted partway can only damage bytes past the last page.
+            # Metadata written first sat at offset 0 and made every subsequent
+            # write slide the whole archive down over its own pages.
+            self._copy_archive_files_to_new_archive(zf)
+            self._archive_write_metadata_files(zf, files)
+            zf.comment = comment
 
-            # Cleanup
-            self.close()
-            self._cleanup_tmp_archive(tmp_path, new_path)
-        finally:
-            _release_destination(destination)
+        # Cleanup
+        self.close()
+        self._cleanup_tmp_archive(tmp_path, new_path)
 
     def _update_pdffile(self, files: Mapping, mupdf_metadata: Mapping) -> None:
         if not self._path:
@@ -226,10 +227,31 @@ class ComicboxArchiveWrite(ComicboxArchiveRead):
 
         Pure file I/O: cache invalidation after the rewrite is the dump
         layer's job (ComicboxDump._reset_caches_after_write).
+
+        Every write claims its destination, not just the conversions. An
+        in-place rewrite is as destructive as a conversion when two writers
+        overlap on it -- ``bulk_write`` does not deduplicate paths, so one
+        archive named twice in a batch used to be repacked by both threads
+        at once -- and the finished-file check cannot see a write that is
+        still in flight.
         """
-        if self._archive_cls == ZipFile:
-            self._patch_zipfile(files, comment)
-        elif self._archive_is_pdf and not self._config.convert.cbz:
-            self._update_pdffile(files, mupdf_metadata)
-        else:
-            self._create_zipfile(files, comment)
+        if not self._path:
+            reason = "Cannot write archive metadata without a path."
+            raise ArchiveWriteError(reason)
+        is_zip = self._archive_cls == ZipFile
+        is_pdf_in_place = self._archive_is_pdf and not self._config.convert.cbz
+        destination = (
+            self._path
+            if is_zip or is_pdf_in_place
+            else self._path.with_suffix(_CBZ_SUFFIX)
+        )
+        _claim_destination(destination)
+        try:
+            if is_zip:
+                self._patch_zipfile(files, comment)
+            elif is_pdf_in_place:
+                self._update_pdffile(files, mupdf_metadata)
+            else:
+                self._create_zipfile(files, comment)
+        finally:
+            _release_destination(destination)

--- a/tests/unit/test_write_order_and_claims.py
+++ b/tests/unit/test_write_order_and_claims.py
@@ -1,0 +1,172 @@
+"""
+Where metadata sits in a CBZ, and who is allowed to write it.
+
+An in-place re-tag removes the archive's metadata members and repacks.
+``repack()`` only shifts entries that follow a removed one, so metadata
+written at the front makes every later write slide the whole archive
+down over its own pages — the pages are then in the write path, and an
+interrupted or concurrent write lands on them.
+"""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from typing import TYPE_CHECKING
+
+from comicbox.box.archive.write import _claim_destination, _release_destination
+from comicbox.exceptions import ArchiveWriteError
+from comicbox.write import BulkWriteItem, bulk_write, write_metadata
+from tests.const import CIX_CBT_SOURCE_PATH, CIX_CBZ_SOURCE_PATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_CIX = ["COMIC_INFO"]
+_CIX_SET = frozenset({"COMIC_INFO"})
+_PAGE_SUFFIX = ".jpg"
+
+
+def _page_offsets(path: Path) -> dict[str, int]:
+    with zipfile.ZipFile(path) as zf:
+        return {
+            info.filename: info.header_offset
+            for info in zf.infolist()
+            if info.filename.endswith(_PAGE_SUFFIX)
+        }
+
+
+def _last_page_offset(path: Path) -> int:
+    return max(_page_offsets(path).values())
+
+
+def _metadata_offsets(path: Path) -> dict[str, int]:
+    with zipfile.ZipFile(path) as zf:
+        return {
+            info.filename: info.header_offset
+            for info in zf.infolist()
+            if not info.filename.endswith(_PAGE_SUFFIX)
+        }
+
+
+def _convert(tmp_path: Path, name: str) -> Path:
+    """Convert the test CBT so the archive under test is one comicbox wrote."""
+    cbt = tmp_path / f"{name}.cbt"
+    shutil.copy(CIX_CBT_SOURCE_PATH, cbt)
+    result = next(
+        iter(
+            bulk_write(
+                [BulkWriteItem(path=cbt, patch={"title": "a"}, formats=_CIX_SET)]
+            )
+        )
+    )
+    assert result.written
+    assert result.final_path is not None
+    return result.final_path
+
+
+def test_a_converted_archive_puts_its_metadata_after_every_page(
+    tmp_path: Path,
+) -> None:
+    """Metadata trails the pages, so a later repack has nothing to shift."""
+    cbz = _convert(tmp_path, "Order v1 #001 (2001)")
+
+    metadata = _metadata_offsets(cbz)
+    assert metadata
+    assert min(metadata.values()) > _last_page_offset(cbz)
+
+
+def test_an_in_place_rewrite_never_moves_page_data(tmp_path: Path) -> None:
+    """
+    Re-tagging leaves every page at the byte offset it already occupied.
+
+    With metadata at the front this failed: removing it made repack slide
+    all five pages down, rewriting the whole archive over itself. Any
+    interruption then landed on page bytes rather than on the metadata.
+    """
+    cbz = _convert(tmp_path, "Stable v1 #001 (2001)")
+    before = _page_offsets(cbz)
+    with zipfile.ZipFile(cbz) as zf:
+        page_bytes = {name: zf.read(name) for name in before}
+
+    for run in range(2):
+        assert write_metadata(cbz, patch={"title": f"run{run}"}, formats=_CIX).written
+        assert _page_offsets(cbz) == before
+
+    with zipfile.ZipFile(cbz) as zf:
+        assert {name: zf.read(name) for name in before} == page_bytes
+
+
+def test_metadata_stays_last_across_repeated_writes(tmp_path: Path) -> None:
+    """The layout maintains itself: new metadata is appended, not prepended."""
+    cbz = _convert(tmp_path, "Repeat v1 #001 (2001)")
+
+    for run in range(2):
+        assert write_metadata(
+            cbz, patch={"title": f"run{run}"}, formats=["COMIC_INFO", "COMICBOX_YAML"]
+        ).written
+        metadata = _metadata_offsets(cbz)
+        assert metadata
+        assert min(metadata.values()) > _last_page_offset(cbz)
+
+
+def test_an_in_place_write_respects_a_held_destination(tmp_path: Path) -> None:
+    """
+    An in-place write claims its archive, as a conversion claims its output.
+
+    Only conversions used to claim, so two writers on one CBZ repacked it
+    at once and destroyed it. Holding the path stands in for the other
+    writer, which leaves nothing on disk for any file check to see.
+    """
+    cbz = tmp_path / "Held v1 #001 (2001).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+    before = cbz.read_bytes()
+
+    _claim_destination(cbz)
+    try:
+        result = write_metadata(cbz, patch={"title": "z"}, formats=_CIX)
+    finally:
+        _release_destination(cbz)
+
+    assert not result.written
+    assert isinstance(result.error, ArchiveWriteError)
+    assert "already being written" in str(result.error)
+    # Refused before touching anything.
+    assert cbz.read_bytes() == before
+
+    # And the claim is released, so the same write goes through afterwards.
+    assert write_metadata(cbz, patch={"title": "z"}, formats=_CIX).written
+
+
+def test_one_archive_named_twice_in_a_batch_survives(tmp_path: Path) -> None:
+    """
+    Two writers on one path: one wins, one is refused, the comic is intact.
+
+    ``bulk_write`` does not deduplicate paths, so this ran two concurrent
+    in-place repacks over the same bytes. It destroyed every page in
+    roughly one run out of three.
+    """
+    cbz = tmp_path / "Twice v1 #001 (2001).cbz"
+    shutil.copy(CIX_CBZ_SOURCE_PATH, cbz)
+    with zipfile.ZipFile(cbz) as zf:
+        pages = {n: zf.read(n) for n in zf.namelist() if n.endswith(_PAGE_SUFFIX)}
+    assert pages
+
+    results = list(
+        bulk_write(
+            [
+                BulkWriteItem(path=cbz, patch={"title": f"t{i}"}, formats=_CIX_SET)
+                for i in range(2)
+            ],
+            workers=2,
+        )
+    )
+
+    assert sum(r.written for r in results) == 1
+    refused = next(r for r in results if not r.written)
+    assert "already being written" in str(refused.error)
+
+    with zipfile.ZipFile(cbz) as zf:
+        assert {
+            n: zf.read(n) for n in zf.namelist() if n.endswith(_PAGE_SUFFIX)
+        } == pages


### PR DESCRIPTION
Follow-up to [#174](https://github.com/ajslater/comicbox/pull/174), from the write-path audit. Two changes, one cause.

## Metadata placement

An in-place re-tag removes the archive's metadata members and repacks. `repack()` only shifts entries that **follow** a removed one — so where the metadata sits decides how much of the archive a write touches.

`_create_zipfile` wrote metadata *before* copying the pages, putting it at offset 0 of every archive comicbox produced. Removing it made every later write slide the whole archive down over its own pages.

Swapping the two calls puts metadata last. Measured on a 68 MB / 180-page archive through `write_metadata`:

| Metadata position | Re-tag | Page bytes rewritten |
| --- | --- | --- |
| Front (before) | 23.2 ms | **68.4 MB** |
| End (after) | 11.4 ms | **0 MB** |

Instrumenting every write and recording the lowest byte offset touched shows why that matters:

```
metadata at FRONT   last page ends at 240339   lowest byte written 0
metadata at END     last page ends at 240240   lowest byte written 240240
```

Page data is no longer in the write path at all. A write interrupted partway can only damage the metadata and the central directory — both of which comicbox regenerates.

That was not theoretical: killing a repack mid-shift (`os._exit`, no finalizers, as SIGKILL and power loss behave) left an archive that was the right size, opened without error, listed all its members, and had 4 of 5 pages unreadable.

**No migration needed.** Removing trailing metadata and appending the new copy leaves it trailing, so page offsets stay byte-identical across re-tags. An archive arriving with leading metadata pays the shift once, on its first write, and is in the new layout from then on.

## Claiming every write

Only conversions claimed their destination. `bulk_write` does not deduplicate paths, so one archive named twice in a batch was repacked by two threads at once — roughly **one run in three lost every page**, and the caller was told `Unsupported archive type`.

The claim moves up to `write_archive_metadata`, covering the in-place zip and PDF branches too. The destination is resolved once for all three branches rather than letting `_create_zipfile` claim a path it would then contend with itself for. The loser now gets the same clean `ArchiveWriteError` a conversion does. Re-running that race six times: one write wins, one is refused, all pages intact, every time.

## Tests

`tests/unit/test_write_order_and_claims.py` — 5 tests. Four fail without these changes (verified by reverse-applying the source patch); the fifth guards the self-maintaining layout, which holds on both sides by construction.

- metadata lands after every page in a converted archive
- an in-place rewrite leaves page offsets and bytes untouched
- metadata stays last across repeated writes
- an in-place write respects a held destination, and the archive is byte-identical after the refusal
- one archive named twice in a batch: one write wins, one refused, pages intact

`make fix`, `make lint`, `make ty` clean; 1475 passed, 1 skipped.

## Not addressed

Cross-process contention — the claim is still a process-local set, so two comicbox processes on one library have no guard. With metadata trailing, the worst outcome there is a clobbered central directory with pages physically recoverable, rather than lost pages. Full reasoning, including why an `O_EXCL` sidecar is the wrong tool for it, is in the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)