### PR TITLE
Fix five inert safety layers under formats/base

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,16 @@
     - A link to a database's front page no longer becomes an id for it.
     - Urls are recognized whatever the host's case, and with a port or login.
     - Notes urns are written only in a form the notes reader reads back.
+    - An XML tag that carries an attribute is read instead of being dropped.
+      Every XML field looked for the tag's text only after its value parser had
+      already failed on the whole tag, so a `<Series lang="en">` took the file's
+      entire metadata down with it.
+    - Two reprints that sort alike are combined instead of becoming one empty
+      entry. Any list that deduplicates was affected.
+    - Metadata that comicbox skips is named in a warning with the value it came
+      from. Malformed tags were dropped as silently as absent ones.
+    - Schema-wide validation hooks run. The first one added to any schema would
+      have failed on a bad call.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/formats/base/fields/collection_fields.py
+++ b/comicbox/formats/base/fields/collection_fields.py
@@ -1,7 +1,7 @@
 """Marshmallow collection fields."""
 
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 from glom import glom
@@ -10,10 +10,7 @@ from marshmallow.utils import is_collection
 from typing_extensions import override
 
 from comicbox.empty import filter_list_empty, is_empty
-from comicbox.formats.base.fields.fields import (
-    StringField,
-    TrapExceptionsMeta,
-)
+from comicbox.formats.base.fields.fields import StringField
 from comicbox.formats.base.fields.number_fields import IntegerField
 
 
@@ -23,7 +20,7 @@ def case_insensitive_dict(d: dict) -> dict:
     return {v[0]: v[1] for v in cid.values()}
 
 
-class ListField(fields.List, metaclass=TrapExceptionsMeta):
+class ListField(fields.List):
     """List that guarauntees no empty values."""
 
     def __init__(
@@ -60,7 +57,7 @@ class ListField(fields.List, metaclass=TrapExceptionsMeta):
         """Override in XmlListField."""
         return value
 
-    def _sort_value(self, value: dict[str, Any], sort_dict: dict[Any, Any]) -> None:
+    def _sort_value(self, value: Any, sort_dict: dict[Any, Any]) -> None:
         if is_empty(value):
             return
         key = []
@@ -74,15 +71,21 @@ class ListField(fields.List, metaclass=TrapExceptionsMeta):
             key = (self.get_tag_value(value),)
         key = tuple(key)
 
-        # combine elements by key
-        if old_value := sort_dict.get(key):
-            new_value = old_value.update(value)
+        # Combine elements that dedupe to the same key. dict.update() returns
+        # None, so assigning its result dropped the merged element and left a
+        # null in the serialized list. Merge into a new dict instead of
+        # mutating in place so the caller's data is never modified.
+        old_value = sort_dict.get(key)
+        if isinstance(old_value, Mapping) and isinstance(value, Mapping):
+            new_value = {**old_value, **value}
         else:
+            # Non mappings (and first sightings) can't merge: the later
+            # element wins, which is what update() would have done anyway.
             new_value = value
 
         sort_dict[key] = new_value
 
-    def _sorted(self, values: list[dict[str, Any]]) -> list:
+    def _sorted(self, values: list[Any]) -> list:
         """Create a dict of ordered keys to deduplicate and sort on."""
         if not self._sort:
             return values
@@ -109,7 +112,7 @@ class ListField(fields.List, metaclass=TrapExceptionsMeta):
         return self._sorted(values)
 
 
-class DictField(fields.Dict, metaclass=TrapExceptionsMeta):
+class DictField(fields.Dict):
     """Dict field for nested schemas with case insensitive keys and sorting."""
 
     def __init__(
@@ -160,7 +163,7 @@ class DictField(fields.Dict, metaclass=TrapExceptionsMeta):
         return result_dict
 
 
-class StringListField(fields.List, metaclass=TrapExceptionsMeta):
+class StringListField(fields.List):
     """A list of non empty strings."""
 
     FIELD: type[fields.Field] = StringField

--- a/comicbox/formats/base/fields/enum_fields.py
+++ b/comicbox/formats/base/fields/enum_fields.py
@@ -13,7 +13,7 @@ from comicbox.enums.comicinfo import ComicInfoPageTypeEnum
 from comicbox.enums.maps.age_rating import AGE_RATING_ENUM_MAP
 from comicbox.enums.maps.formats import GENERIC_FORMAT_MAP
 from comicbox.enums.maps.reading_direction import READING_DIRECTION_ENUM_MAP
-from comicbox.formats.base.fields.fields import StringField, TrapExceptionsMeta
+from comicbox.formats.base.fields.fields import StringField
 
 
 class FuzzyEnumMixin:
@@ -74,7 +74,7 @@ class FuzzyEnumMixin:
         return None
 
 
-class EnumField(FuzzyEnumMixin, fields.Enum, metaclass=TrapExceptionsMeta):
+class EnumField(FuzzyEnumMixin, fields.Enum):
     """Fuzzy lookup Enum field that allows caseless enum lookups with variations."""
 
     ENUM = Enum

--- a/comicbox/formats/base/fields/fields.py
+++ b/comicbox/formats/base/fields/fields.py
@@ -1,12 +1,10 @@
 """Custom Marshmallow fields."""
 
 import re
-from abc import ABCMeta
 from decimal import Decimal
 from enum import Enum
 from typing import Any
 
-from loguru import logger
 from marshmallow import fields
 from marshmallow.exceptions import ValidationError
 from typing_extensions import override
@@ -16,45 +14,7 @@ _LEADING_ZERO_RE = re.compile(r"^(0+)(\w)")
 _HALF_RE = re.compile(r"(½|1/2)")
 
 
-class TrapExceptionsMeta(ABCMeta):
-    """Wrap the deserialize method to never throw."""
-
-    _WRAP_METHODS = ("deserialize",)
-
-    @classmethod
-    def wrap_method(cls, method):
-        """Wrap method to never throw."""
-
-        def wrapper(self, value, attr, *args, **kwargs):
-            """Trap exceptions, log and return None."""
-            try:
-                return method(self, value, attr, *args, **kwargs)
-            except Exception as exc:
-                # Log the exception
-                cls_name = self.__class__.__name__
-                logger.warning(
-                    f"Could not deserialize {attr}:{value} as {cls_name} - {exc}"
-                )
-                return None
-
-        return wrapper
-
-    def __new__(
-        cls, name: str, bases: tuple, attrs: dict[str, Any]
-    ) -> "TrapExceptionsMeta":
-        """Wrap the deserialize method."""
-        new_attrs = {}
-        for attr_name, attr_value in attrs.items():
-            if attr_name in cls._WRAP_METHODS and callable(attr_value):
-                # Override the deserialize method with exception handling and logging
-                new_attr_value = cls.wrap_method(attr_value)
-            else:
-                new_attr_value = attr_value
-            new_attrs[attr_name] = new_attr_value
-        return super().__new__(cls, name, bases, new_attrs)
-
-
-class StringField(fields.String, metaclass=TrapExceptionsMeta):
+class StringField(fields.String):
     """Durable Stripping String Field."""
 
     def __init__(self, *args: Any, clean_tabs: bool = False, **kwargs: Any) -> None:

--- a/comicbox/formats/base/fields/number_fields.py
+++ b/comicbox/formats/base/fields/number_fields.py
@@ -11,7 +11,6 @@ from typing_extensions import override
 from comicbox.empty import is_empty
 from comicbox.formats.base.fields.fields import (
     StringField,
-    TrapExceptionsMeta,
     half_replace,
 )
 
@@ -19,10 +18,12 @@ NumberType = int | float | Decimal
 PAGE_COUNT_KEY = "page_count"
 
 
-class RangedNumberMixin(metaclass=TrapExceptionsMeta):
+class RangedNumberMixin:
     """Number range methods."""
 
     ZERO_FILL: int = 0
+    _min: NumberType | None = None
+    _max: NumberType | None = None
 
     def _set_range(
         self, minimum: NumberType | None, maximum: NumberType | None
@@ -144,5 +145,5 @@ class DecimalField(fields.Decimal, RangedNumberMixin):
         return self._serialize_post(result)
 
 
-class BooleanField(fields.Boolean, metaclass=TrapExceptionsMeta):
+class BooleanField(fields.Boolean):
     """A liberally parsed boolean field."""

--- a/comicbox/formats/base/fields/pycountry.py
+++ b/comicbox/formats/base/fields/pycountry.py
@@ -8,12 +8,12 @@ from loguru import logger
 from pycountry.db import Data, Database
 from typing_extensions import override
 
-from comicbox.formats.base.fields.fields import StringField, TrapExceptionsMeta
+from comicbox.formats.base.fields.fields import StringField
 
 _ALPHA_CODES = ("alpha_2", "alpha_3", "alpha_4", "name")
 
 
-class PyCountryField(StringField, ABC, metaclass=TrapExceptionsMeta):
+class PyCountryField(StringField, ABC):
     """A pycountry value."""
 
     DB: Database = pycountry.countries

--- a/comicbox/formats/base/fields/time_fields.py
+++ b/comicbox/formats/base/fields/time_fields.py
@@ -9,10 +9,10 @@ from marshmallow import fields
 from ruamel.yaml.timestamp import TimeStamp
 from typing_extensions import override
 
-from comicbox.formats.base.fields.fields import StringField, TrapExceptionsMeta
+from comicbox.formats.base.fields.fields import StringField
 
 
-class DateField(fields.Date, metaclass=TrapExceptionsMeta):
+class DateField(fields.Date):
     """A date only field."""
 
     def __init__(
@@ -62,7 +62,7 @@ class DateField(fields.Date, metaclass=TrapExceptionsMeta):
         return value
 
 
-class DateTimeField(fields.DateTime, metaclass=TrapExceptionsMeta):
+class DateTimeField(fields.DateTime):
     """A Datetime field."""
 
     def __init__(

--- a/comicbox/formats/base/fields/xml_fields.py
+++ b/comicbox/formats/base/fields/xml_fields.py
@@ -3,6 +3,7 @@
 from collections.abc import Mapping
 from typing import Any
 
+from marshmallow.exceptions import ValidationError
 from marshmallow.fields import Field, Nested
 from marshmallow_union import Union
 from typing_extensions import override
@@ -46,57 +47,63 @@ class CDataFieldMixin:
     """Get value or cdata."""
 
     def _deserialize(self, value, *args, **kwargs):
+        if isinstance(value, Mapping) and CDATA_KEY not in value:
+            # An attributed tag is {"@attr": …, "#text": …}. A mapping with no
+            # text at all is a structure standing where a scalar belongs, so
+            # fail visibly instead of unwrapping it to nothing.
+            reason = f"No {CDATA_KEY} in {tuple(value.keys())}"
+            raise ValidationError(reason)
         value = get_cdata(value)
         return super()._deserialize(value, *args, **kwargs)  # pyright: ignore[reportAttributeAccessIssue], # ty: ignore[unresolved-attribute]
 
 
 # FIELDS
-class XmlStringField(StringField, CDataFieldMixin):
+class XmlStringField(CDataFieldMixin, StringField):
     """Get value or cdata."""
 
 
-class XmlIssueField(IssueField, CDataFieldMixin):
+class XmlIssueField(CDataFieldMixin, IssueField):
     """Get value or cdata."""
 
 
 # DATETIME
-class XmlDateField(DateField, CDataFieldMixin):
+class XmlDateField(CDataFieldMixin, DateField):
     """Get value or cdata."""
 
 
-class XmlDateTimeField(DateTimeField, CDataFieldMixin):
+class XmlDateTimeField(CDataFieldMixin, DateTimeField):
     """Get value or cdata."""
 
 
-class XmlPdfDateTimeField(PdfDateTimeField, CDataFieldMixin):
+class XmlPdfDateTimeField(CDataFieldMixin, PdfDateTimeField):
     """Get value or cdata."""
 
 
 # ENUM
-class XmlEnumField(EnumField, CDataFieldMixin):
+class XmlEnumField(CDataFieldMixin, EnumField):
     """Get value or cdata."""
 
 
-class XmlReadingDirectionField(ReadingDirectionField, CDataFieldMixin):
+class XmlReadingDirectionField(CDataFieldMixin, ReadingDirectionField):
     """Get value or cdata."""
 
 
-class XmlOriginalFormatField(OriginalFormatField, CDataFieldMixin):
+class XmlOriginalFormatField(CDataFieldMixin, OriginalFormatField):
     """Get value or cdata."""
 
 
-class XmlComicInfoMangaField(ComicInfoMangaField, CDataFieldMixin):
+class XmlComicInfoMangaField(CDataFieldMixin, ComicInfoMangaField):
     """Get value or cdata."""
 
 
-class XmlYesNoField(YesNoField, CDataFieldMixin):
+class XmlYesNoField(CDataFieldMixin, YesNoField):
     """Get value or cdata."""
 
 
 # NUMBERS
 
 
-class XmlBooleanField(BooleanField, CDataFieldMixin):
+class XmlBooleanField(CDataFieldMixin, BooleanField):
     """Get value or cdata."""
 
     @override
@@ -110,18 +117,18 @@ class XmlBooleanField(BooleanField, CDataFieldMixin):
         return result if result is None else str(result).lower()
 
 
-class XmlIntegerField(IntegerField, CDataFieldMixin):
+class XmlIntegerField(CDataFieldMixin, IntegerField):
     """Get value or cdata."""
 
 
-class XmlDecimalField(DecimalField, CDataFieldMixin):
+class XmlDecimalField(CDataFieldMixin, DecimalField):
     """Get value or cdata."""
 
 
 # PYCOUNTRY
 
 
-class XmlLanguageField(LanguageField, CDataFieldMixin):
+class XmlLanguageField(CDataFieldMixin, LanguageField):
     """Get value or cdata."""
 
 

--- a/comicbox/formats/base/schemas/error_store.py
+++ b/comicbox/formats/base/schemas/error_store.py
@@ -19,18 +19,69 @@ from typing_extensions import override
 # value.
 _current_path: ContextVar[str | None] = ContextVar("comicbox_schema_path", default=None)
 
+_UNKNOWN_KEY = "UNKNOWN"
+# Offending values go in the warning so the field name is actionable, but a
+# whole embedded page list would drown the log.
+_MAX_VALUE_REPR = 128
+
+
+def _repr_value(value: Any) -> str:
+    """Represent an offending value, truncated."""
+    value_repr = repr(value)
+    if len(value_repr) > _MAX_VALUE_REPR:
+        value_repr = value_repr[:_MAX_VALUE_REPR] + "…"
+    return value_repr
+
 
 class ClearingErrorStore(ErrorStore):
     """Take over error processing."""
 
     def _clean_error_list(
         self,
-        key: str,
-        error_list: list[str],
+        key: Any,
+        error_list: Any,
         cleaned_errors: dict[Any, Any],
     ) -> None:
-        if cleaned_error_list := frozenset(error_list) - self._ignore_errors:
+        """Filter ignored messages out of one field's errors."""
+        if isinstance(error_list, Mapping):
+            # Nested schema and collection errors arrive keyed by sub field
+            # name or by index. Recurse so the leaf messages stay readable
+            # instead of collapsing to a set of their container's keys.
+            nested: dict[Any, Any] = {}
+            for sub_key, sub_error_list in error_list.items():
+                self._clean_error_list(sub_key, sub_error_list, nested)
+            if nested:
+                cleaned_errors[key] = nested
+            return
+        messages = error_list if isinstance(error_list, list | tuple) else [error_list]
+        # str() keeps the set hashable and sortable whatever marshmallow put
+        # in the list; ignored messages are plain strings and still match.
+        if cleaned_error_list := frozenset(str(m) for m in messages) - (
+            self._ignore_errors
+        ):
             cleaned_errors[key] = sorted(cleaned_error_list)
+
+    def _log_cleaned_errors(self, cleaned_errors: dict[Any, Any]) -> None:
+        """
+        Warn about the fields being dropped.
+
+        Clearing the error store is what lets one bad tag not condemn a whole
+        file, but dropping it silently makes malformed metadata indis-
+        tinguishable from absent metadata. Name every field, and what was in
+        it, so a silent drop is at least a visible one.
+        """
+        if not cleaned_errors:
+            return
+        data = self._data if isinstance(self._data, Mapping) else {}
+        reports = []
+        for key in sorted(cleaned_errors, key=str):
+            messages = cleaned_errors[key]
+            if key in data:
+                reports.append(f"{key}={_repr_value(data[key])} {messages}")
+            else:
+                reports.append(f"{key} {messages}")
+        path = f"{self._path}: " if self._path else ""
+        logger.warning(f"{path}Dropped invalid metadata: {', '.join(reports)}")
 
     def _clear_errors(self) -> None:
         if not self.errors:
@@ -40,14 +91,15 @@ class ClearingErrorStore(ErrorStore):
             for key, error_list in self.errors.items():
                 self._clean_error_list(key, error_list, cleaned_errors)
         else:
-            self._clean_error_list("UNKNOWN", self.errors, cleaned_errors)
+            self._clean_error_list(_UNKNOWN_KEY, self.errors, cleaned_errors)
+        self._log_cleaned_errors(cleaned_errors)
         self.clear_errors = merge_errors(self.clear_errors, cleaned_errors)
         self.errors = {}
 
     def __init__(
         self,
         error_store: ErrorStore,
-        data: Mapping[str, Any],
+        data: Any,
         path: str | None = None,
         ignore_errors: frozenset | None = None,
     ) -> None:
@@ -145,7 +197,7 @@ class ClearingErrorStoreSchema(Schema):
             error_store = ClearingErrorStore(
                 error_store, data, self._path, ignore_errors=self._ignore_errors
             )
-        super()._invoke_schema_validators(error_store=error_store, **kwargs)
+        super()._invoke_schema_validators(error_store=error_store, data=data, **kwargs)
 
     def _filter_list(self, error_list: list) -> list:
         return sorted(frozenset(error_list) - self._ignore_errors)

--- a/tests/unit/test_error_store_visibility.py
+++ b/tests/unit/test_error_store_visibility.py
@@ -1,0 +1,125 @@
+"""
+Suppressed schema errors are logged instead of vanishing.
+
+`ClearingErrorStore` exists so one malformed tag can't condemn a whole file,
+but it accumulated the cleaned errors into `clear_errors` and nothing ever
+read that attribute. Bad metadata was therefore indistinguishable from absent
+metadata. It now names every field it drops, and what was in it.
+
+`_invoke_schema_validators` is covered here too: it swallowed the `data`
+keyword instead of forwarding it, so the first `@validates_schema` hook added
+to any comicbox schema would have raised TypeError.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from loguru import logger
+from marshmallow import ValidationError, validates_schema
+
+from comicbox.formats.base.fields.fields import StringField
+from comicbox.formats.base.fields.number_fields import IntegerField
+from comicbox.formats.base.schemas.base import BaseSubSchema
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _TagSchema(BaseSubSchema):
+    """A one-tag schema for exercising the store directly."""
+
+    tag = StringField()
+    count = IntegerField()
+
+
+class _ValidatedSchema(BaseSubSchema):
+    """A schema with the kind of hook the missing kwarg would have broken."""
+
+    tag = StringField()
+
+    @validates_schema
+    def check_tag(self, data: dict, **_kwargs: object) -> None:
+        """Reject one sentinel value."""
+        if data.get("tag") == "bad":
+            reason = "tag is bad"
+            raise ValidationError(reason, "tag")
+
+
+@pytest.fixture
+def warnings() -> Iterator[list[str]]:
+    """Capture WARNING records and restore the path prefix afterward."""
+    messages: list[str] = []
+    handler_id = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        yield messages
+    finally:
+        logger.remove(handler_id)
+        _TagSchema().set_path(None)
+
+
+def test_a_dropped_field_is_named(warnings: list[str]) -> None:
+    """The warning says which field went away and why."""
+    assert _TagSchema().load({"tag": {"nested": "dict"}}) == {}
+    assert len(warnings) == 1
+    message = warnings[0]
+    assert "tag" in message
+    assert "is not a string" in message
+
+
+def test_a_dropped_field_reports_its_value(warnings: list[str]) -> None:
+    """The offending value is in the warning, so the tag is findable."""
+    _TagSchema().load({"tag": {"nested": "dict"}})
+    assert "nested" in warnings[0]
+
+
+def test_the_warning_is_prefixed_with_the_path(warnings: list[str]) -> None:
+    """A batch run has to be able to tell which file complained."""
+    _TagSchema(path="captain-science-001.cbz").load({"tag": ["a", "list"]})
+    assert warnings[0].startswith("captain-science-001.cbz: ")
+
+
+def test_good_data_logs_nothing(warnings: list[str]) -> None:
+    """No false positives on metadata that parses."""
+    assert _TagSchema().load({"tag": "Marvel", "count": "12"}) == {
+        "tag": "Marvel",
+        "count": 12,
+    }
+    assert warnings == []
+
+
+def test_ignored_errors_stay_quiet(warnings: list[str]) -> None:
+    """
+    An explicit null is a normal absence, not a defect.
+
+    "Field may not be null." is in the ignore set, and ignored messages must
+    not become log noise now that the rest are visible.
+    """
+    assert _TagSchema().load({"tag": None}) == {}
+    assert warnings == []
+
+
+def test_unparseable_numbers_are_reported(warnings: list[str]) -> None:
+    """Junk in a number tag is a real drop and says so."""
+    assert _TagSchema().load({"count": "not a number"}) == {}
+    assert len(warnings) == 1
+    assert "count" in warnings[0]
+
+
+def test_schema_validators_run(warnings: list[str]) -> None:
+    """
+    A `@validates_schema` hook loads without raising TypeError.
+
+    `_invoke_schema_validators` used to drop `data` on the floor, so
+    marshmallow's own signature check failed before any hook body ran.
+    """
+    assert _ValidatedSchema().load({"tag": "fine"}) == {"tag": "fine"}
+    assert warnings == []
+
+
+def test_schema_validator_failures_are_logged(warnings: list[str]) -> None:
+    """A hook that rejects data gets its message surfaced, not swallowed."""
+    _ValidatedSchema().load({"tag": "bad"})
+    assert len(warnings) == 1
+    assert "tag is bad" in warnings[0]

--- a/tests/unit/test_list_field_dedupe.py
+++ b/tests/unit/test_list_field_dedupe.py
@@ -1,0 +1,115 @@
+"""
+ListField merges the elements that dedupe to the same sort key.
+
+`_sort_value` combined duplicates with `old_value.update(value)` and stored
+the *return* of `update()`, which is always `None`. Two elements sharing a
+sort key therefore collapsed into a single null: both were lost and a bare
+`null` was written into the serialized list.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from marshmallow import Schema
+from marshmallow.fields import Nested
+
+from comicbox.box import Comicbox
+from comicbox.formats import MetadataFormats
+from comicbox.formats.base.fields.collection_fields import ListField
+from comicbox.formats.comicbox.schema.publishing import ReprintSchema
+
+# The comicbox schema's own reprint sort keys. `name` is deliberately absent:
+# two differently worded citations of the same issue dedupe together.
+_REPRINT_SORT_KEYS = (
+    "language",
+    "series.sort_name",
+    "series.name",
+    "volume.number",
+    "volume.number_to",
+    "issue",
+)
+
+_METRON_XML = """<MetronInfo>
+  <Series><Name>Captain Science</Name></Series>
+  <Reprints>
+    <Reprint>Strange Academy (2020) #1</Reprint>
+    <Reprint>Strange Academy #1 (2020)</Reprint>
+  </Reprints>
+</MetronInfo>"""
+
+
+class _ReprintsSchema(Schema):
+    """A stand-in for the comicbox schema's reprints field."""
+
+    reprints = ListField(Nested(ReprintSchema), sort_keys=_REPRINT_SORT_KEYS)
+
+
+def _dump(reprints: list[dict]) -> list:
+    dumped = _ReprintsSchema().dump({"reprints": reprints})
+    assert isinstance(dumped, Mapping)
+    return dumped["reprints"]
+
+
+def test_two_reprints_sharing_a_sort_key_merge() -> None:
+    """The pair becomes one element, never a null."""
+    dumped = _dump(
+        [
+            {"series": {"name": "Strange Academy"}, "issue": "1", "name": "A"},
+            {"series": {"name": "Strange Academy"}, "issue": "1", "name": "B"},
+        ]
+    )
+    assert dumped == [
+        {"series": {"name": "Strange Academy"}, "issue": "1", "name": "B"}
+    ]
+
+
+def test_merging_keeps_fields_only_the_earlier_element_had() -> None:
+    """Combining is a merge, so nothing unique to either side is dropped."""
+    dumped = _dump(
+        [
+            {
+                "series": {"name": "Strange Academy"},
+                "issue": "1",
+                "identifiers": {"metron": {"key": "123"}},
+            },
+            {"series": {"name": "Strange Academy"}, "issue": "1", "name": "B"},
+        ]
+    )
+    assert dumped == [
+        {
+            "series": {"name": "Strange Academy"},
+            "issue": "1",
+            "identifiers": {"metron": {"key": "123"}},
+            "name": "B",
+        }
+    ]
+
+
+def test_distinct_sort_keys_are_not_merged() -> None:
+    """Deduplication still only fires on an actual key collision."""
+    dumped = _dump(
+        [
+            {"series": {"name": "Strange Academy"}, "issue": "2", "name": "B"},
+            {"series": {"name": "Strange Academy"}, "issue": "1", "name": "A"},
+        ]
+    )
+    assert [reprint["issue"] for reprint in dumped] == ["1", "2"]
+
+
+def test_dumping_does_not_mutate_the_input() -> None:
+    """Merging builds a new dict rather than updating the caller's."""
+    first = {"series": {"name": "Strange Academy"}, "issue": "1", "name": "A"}
+    _dump([first, {"series": {"name": "Strange Academy"}, "issue": "1", "name": "B"}])
+    assert first["name"] == "A"
+
+
+def test_colliding_reprints_do_not_write_a_null() -> None:
+    """End to end: the comicbox dump used to emit a lone empty list item."""
+    with Comicbox() as car:
+        car.add_metadata(_METRON_XML, MetadataFormats.METRON_INFO)
+        reprints = car.to_dict()["comicbox"]["reprints"]
+        yaml = car.to_string(MetadataFormats.COMICBOX_YAML)
+    assert None not in reprints
+    assert all(reprint.get("name") for reprint in reprints)
+    assert "- \n" not in yaml

--- a/tests/unit/test_xml_cdata_fields.py
+++ b/tests/unit/test_xml_cdata_fields.py
@@ -1,0 +1,193 @@
+"""
+XML scalar fields read a tag's text even when the tag carries attributes.
+
+xmltodict renders `<Series lang="en">Captain Science</Series>` as
+`{"@lang": "en", "#text": "Captain Science"}`. `CDataFieldMixin` exists to
+unwrap that `#text`, but every `Xml*` field listed the mixin *after* its value
+field, so the MRO reached the value field's `_deserialize` first and the mixin
+never ran. Attribute-bearing tags raised, and the clearing error store dropped
+them without a trace.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from marshmallow.exceptions import ValidationError
+
+from comicbox.box import Comicbox
+from comicbox.enums.comicbox import ReadingDirectionEnum
+from comicbox.formats import MetadataFormats
+from comicbox.formats.base.fields import xml_fields
+from comicbox.formats.base.fields.enum_fields import ComicInfoMangaEnum
+from comicbox.formats.base.fields.xml_fields import (
+    CDataFieldMixin,
+    XmlBooleanField,
+    XmlComicInfoMangaField,
+    XmlDateField,
+    XmlDateTimeField,
+    XmlDecimalField,
+    XmlEnumField,
+    XmlIntegerField,
+    XmlIssueField,
+    XmlLanguageField,
+    XmlOriginalFormatField,
+    XmlPdfDateTimeField,
+    XmlReadingDirectionField,
+    XmlStringField,
+    XmlYesNoField,
+)
+
+if TYPE_CHECKING:
+    from marshmallow.fields import Field
+
+
+class _ColorEnum(Enum):
+    """A concrete enum, because XmlEnumField's own ENUM is the empty base."""
+
+    RED = "Red"
+
+
+class _XmlColorField(XmlEnumField):
+    """Instantiable stand-in for XmlEnumField."""
+
+    ENUM = _ColorEnum  # pyright: ignore[reportIncompatibleUnannotatedOverride]
+
+
+# One instantiable field and one representative tag text per scalar XML field.
+_CASES: dict[type, tuple[Field, str, Any]] = {
+    XmlStringField: (XmlStringField(), "Marvel", "Marvel"),
+    XmlIssueField: (XmlIssueField(), "#001", "1"),
+    XmlDateField: (XmlDateField(), "2020-01-02", date(2020, 1, 2)),
+    XmlDateTimeField: (
+        XmlDateTimeField(),
+        "2020-01-02T03:04:05",
+        datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+    ),
+    XmlPdfDateTimeField: (
+        XmlPdfDateTimeField(),
+        "2020-01-02T03:04:05",
+        datetime(2020, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+    ),
+    XmlEnumField: (_XmlColorField(), "red", _ColorEnum.RED),
+    XmlReadingDirectionField: (
+        XmlReadingDirectionField(),
+        "ltr",
+        ReadingDirectionEnum.LTR,
+    ),
+    XmlOriginalFormatField: (
+        XmlOriginalFormatField(),
+        "trade paperback",
+        "Trade Paperback",
+    ),
+    XmlComicInfoMangaField: (
+        XmlComicInfoMangaField(),
+        "YesAndRightToLeft",
+        ComicInfoMangaEnum.YES_RTL,
+    ),
+    XmlYesNoField: (XmlYesNoField(), "Yes", True),
+    XmlBooleanField: (XmlBooleanField(), "true", True),
+    XmlIntegerField: (XmlIntegerField(), "12", 12),
+    XmlDecimalField: (XmlDecimalField(), "1.5", Decimal("1.5")),
+    XmlLanguageField: (XmlLanguageField(), "en", "en"),
+}
+
+_XML_SCALAR_FIELDS = frozenset(
+    obj
+    for obj in vars(xml_fields).values()
+    if isinstance(obj, type)
+    and issubclass(obj, CDataFieldMixin)
+    and obj is not CDataFieldMixin
+)
+
+_PARAMS = tuple(
+    pytest.param(field, raw, expected, id=cls.__name__)
+    for cls, (field, raw, expected) in _CASES.items()
+)
+
+_FIELD_PARAMS = tuple(
+    pytest.param(field, id=cls.__name__) for cls, (field, _raw, _ok) in _CASES.items()
+)
+
+_CLASS_PARAMS = tuple(
+    pytest.param(cls, id=cls.__name__)
+    for cls in sorted(_XML_SCALAR_FIELDS, key=lambda field_class: field_class.__name__)
+)
+
+
+def test_every_scalar_xml_field_has_a_case() -> None:
+    """A new Xml* scalar field must arrive with a round-trip case."""
+    assert frozenset(_CASES) == _XML_SCALAR_FIELDS
+
+
+@pytest.mark.parametrize("field_class", _CLASS_PARAMS)
+def test_cdata_mixin_wins_the_mro(field_class: type[CDataFieldMixin]) -> None:
+    """
+    The mixin's `_deserialize` is the one the field actually resolves to.
+
+    This is the whole contract: the value fields do not call `super()`, so a
+    mixin reached second in the MRO is dead code.
+    """
+    assert field_class._deserialize is CDataFieldMixin._deserialize
+
+
+@pytest.mark.parametrize(("field", "raw", "expected"), _PARAMS)
+def test_bare_tag_text_parses(field: Field, raw: str, expected: Any) -> None:
+    """Establish the value each field reads from a plain tag."""
+    assert field.deserialize(raw, "tag", {}) == expected
+
+
+@pytest.mark.parametrize(("field", "raw", "expected"), _PARAMS)
+def test_attributed_tag_parses_the_same(field: Field, raw: str, expected: Any) -> None:
+    """An attribute on the tag must not change the value comicbox reads."""
+    cdata = {"@id": "9", xml_fields.CDATA_KEY: raw}
+    assert field.deserialize(cdata, "tag", {}) == expected
+
+
+@pytest.mark.parametrize("field", _FIELD_PARAMS)
+def test_a_mapping_with_no_text_is_refused(field: Field) -> None:
+    """
+    A structure standing where a scalar belongs must not read as empty.
+
+    Unwrapping a missing `#text` to None would quietly turn a nested tag into
+    no value at all. Raising keeps the drop visible in the error store.
+    """
+    with pytest.raises(ValidationError):
+        field.deserialize({"Inner": "Captain Science"}, "tag", {})
+
+
+def test_a_nested_tag_is_dropped_loudly() -> None:
+    """End to end: the bad tag goes, the rest of the file stays."""
+    xml = (
+        '<?xml version="1.0"?><ComicInfo>'
+        "<Series><Inner>Captain Science</Inner></Series>"
+        "<Number>1</Number>"
+        "</ComicInfo>"
+    )
+    with Comicbox(metadata=xml, fmt=MetadataFormats.COMIC_INFO) as car:
+        md = car.to_dict()["comicbox"]
+    assert "series" not in md
+    assert md["issue"]["name"] == "1"
+
+
+def test_attributed_comic_info_tags_survive_a_read() -> None:
+    """
+    End to end: stray attributes used to take the whole file's metadata down.
+
+    Both tags failed to deserialize, the error store cleared them, and the
+    load returned no comicbox metadata at all.
+    """
+    xml = (
+        '<?xml version="1.0"?><ComicInfo>'
+        '<Series lang="en">Captain Science</Series>'
+        '<Number issue="1">1</Number>'
+        "</ComicInfo>"
+    )
+    with Comicbox(metadata=xml, fmt=MetadataFormats.COMIC_INFO) as car:
+        md = car.to_dict()["comicbox"]
+    assert md["series"]["name"] == "Captain Science"
+    assert md["issue"]["name"] == "1"


### PR DESCRIPTION
Five things under `comicbox/formats/base` looked like they were protecting a load path but never ran, or ran and discarded their result. Each is fixed with a regression test that fails on `develop`.

## 1. `CDataFieldMixin` was unreachable in all 14 `Xml*` fields

Every `Xml*` scalar field listed the mixin **after** its value field, so the MRO reached the value field's `_deserialize` first — and none of them call `super()`. The mixin was dead code, and an XML tag carrying an attribute never got its `#text` unwrapped.

The blast radius was larger than "one tag is skipped". In ComicInfo it took the whole file down:

```xml
<ComicInfo><Series lang="en">Captain Science</Series><Number issue="1">1</Number></ComicInfo>
```

Before: `to_dict()` had no `comicbox` key at all. After: both tags read.

The mixin now also refuses a mapping with **no** `#text` — a structure standing where a scalar belongs. Unwrapping that to `None` would have been new liberal parsing that the MRO fix enabled; it stays a visible failure instead. Polyfields (`xml_polyfield`) still resolve through their nested branch with no added noise.

## 2. `TrapExceptionsMeta` matched no method — deleted

`_WRAP_METHODS = ("deserialize",)`, and every field defines `_deserialize`. It wrapped nothing on any of the seven classes that used it.

Deleted rather than repaired. Making it wrap `_deserialize` would convert every field error into a silent `None`, which is the opposite of the schema v3 stance. Errors already flow to the clearing error store, and #3 makes that store report them. Removing the metaclass is a runtime no-op — it also let basedpyright see `RangedNumberMixin` for the first time, which is why `_min`/`_max` are now declared in the class body.

## 3. `ClearingErrorStore` accumulated errors nobody read

`clear_errors` was merged into on every pass and never consulted, so malformed metadata was indistinguishable from absent metadata. It now warns with the field name and the offending value:

```
captain-science-001.cbz: Dropped invalid metadata: tag={'nested': 'dict'} ["<class 'dict'> is not a string"]
```

Nested error structures are recursed rather than collapsing to a set of their container's keys, and the ignore set (`Field may not be null.`, the union probe's `Invalid input type.`) still suppresses what it always did. **Zero new warnings across the full suite** — this fires only on metadata that was already being dropped.

## 4. `ListField._sort_value` injected a null

```python
new_value = old_value.update(value)   # always None
```

Two reprints sharing a sort key collapsed into a single `None`. End to end, two `<Reprint>` tags naming the same issue produced:

```yaml
comicbox:
  reprints:
    - 
```

Both entries lost, plus a null in the output. They now merge into a new dict, which also stops the old in-place `update()` from mutating the caller's data.

## 5. `_invoke_schema_validators` dropped the `data` kwarg

It bound `data` and never forwarded it, so the first `@validates_schema` hook added to any comicbox schema would have raised `TypeError: Schema._invoke_schema_validators() missing 1 required keyword-only argument: 'data'` before the hook body ran.

## Verification

- `make fix`, `make lint`, `make ty`, `make complexity` — all clean, no new findings
- 1547 passed, 1 skipped (was 1475 on `develop`; 72 new tests in three files)
- Each fix was confirmed against the pre-fix code before the test was written

🤖 Generated with [Claude Code](https://claude.com/claude-code)