### PR TITLE
fix(metron): revive the primary-id-source fallback that dropped every tag id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,15 @@
       from. Malformed tags were dropped as silently as absent ones.
     - Schema-wide validation hooks run. The first one added to any schema would
       have failed on a bad call.
+    - MetronInfo `id` attributes are read from files that name no primary id
+      source. A file with no `<ID primary="true">` and no url comicbox
+      recognizes dropped every tag-level id — on Publisher, Imprint, Series,
+      Arc, Universe, Creator, Role, Story and Reprint. The fallback source that
+      should have caught this never ran, and the ids were filed under a null
+      source and discarded on load. They now read as Metron ids, the database
+      that writes the format.
+    - A MetronInfo `AlternativeName`'s `id` attribute is read. The schema
+      dropped it before the transform that handles it ever saw it.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/formats/base/transforms/spec.py
+++ b/comicbox/formats/base/transforms/spec.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
 
-from glom import A, Coalesce, Path, S, T, Val, assign
+from glom import SKIP, A, Coalesce, Path, S, T, Val, assign
 
 from comicbox.constants import ROOT_KEYPATH
 from comicbox.empty import is_empty
@@ -48,7 +48,10 @@ def _get_multi_values_spec(
         path_parts.append(tail_path)
         path = Path(*path_parts)
     # Don't know which of multiple values are critical so don't throw.
-    return keypath, Coalesce(path, skip=is_empty, default=None)
+    # SKIP, not None: a missing source must leave the key *out* of the values
+    # dict. Emitting an explicit None made every `values.get(key, default)` in
+    # the spec functions return None instead of the default they asked for.
+    return keypath, Coalesce(path, skip=is_empty, default=SKIP)
 
 
 def _get_spec_source_values(

--- a/comicbox/formats/metron_info/schema/publishing.py
+++ b/comicbox/formats/metron_info/schema/publishing.py
@@ -6,7 +6,10 @@ from typing import Any
 from typing_extensions import override
 
 from comicbox.formats.base.fields.fields import StringField
-from comicbox.formats.base.fields.metroninfo import MetronFormatField
+from comicbox.formats.base.fields.metroninfo import (
+    MetronFormatField,
+    MetronIDAttrField,
+)
 from comicbox.formats.base.fields.number_fields import IntegerField
 from comicbox.formats.base.fields.pycountry import LanguageField
 from comicbox.formats.base.fields.xml_fields import (
@@ -47,6 +50,10 @@ class MetronNameSchema(XmlSubSchema):
         include = MappingProxyType(
             {
                 "#text": StringField(),
+                # nameType declares `id` alongside `lang` in the XSD, and the
+                # reprints transform already reads and writes it. Omitting it
+                # here stripped the attribute before the transform ever saw it.
+                "@id": MetronIDAttrField(),
                 "@lang": LanguageField(),
             }
         )

--- a/comicbox/formats/metron_info/transform/const.py
+++ b/comicbox/formats/metron_info/transform/const.py
@@ -3,3 +3,8 @@
 from comicbox.enums.comicbox import IdSources
 
 DEFAULT_ID_SOURCE = IdSources.METRON
+# MetronInfo's bare `id` attributes and its unsourced ids belong to Metron, the
+# database that writes the format. The identifier dicts are keyed by the id
+# source *string*, so the fallback has to be the value, not the enum member --
+# an enum key here reads back as "IdSources.METRON" and drops out on load.
+DEFAULT_ID_SOURCE_STR = DEFAULT_ID_SOURCE.value

--- a/comicbox/formats/metron_info/transform/credits.py
+++ b/comicbox/formats/metron_info/transform/credits.py
@@ -21,7 +21,7 @@ from comicbox.formats.comicbox.schema import (
     ROLES_KEY,
 )
 from comicbox.formats.metron_info.schema import CREATOR_TAG
-from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE
+from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
 from comicbox.formats.metron_info.transform.identified_name import (
     identified_name_from_cb,
     identified_name_to_cb,
@@ -167,7 +167,7 @@ def _credits_to_cb(
     metron_credits = values.get(CREDITS_KEYPATH)
     if not metron_credits:
         return {}
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     return {
         person_credit[0]: person_credit[1]
         for metron_credit in metron_credits
@@ -239,7 +239,7 @@ def _credits_from_cb(
     comicbox_credits = values.get(CREDITS_KEY)
     if comicbox_credits is None:
         comicbox_credits = {}
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     return [
         metron_credit
         for person_name, comicbox_credit in comicbox_credits.items()

--- a/comicbox/formats/metron_info/transform/identifier_attribute.py
+++ b/comicbox/formats/metron_info/transform/identifier_attribute.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from loguru import logger
 
 from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY
-from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE
+from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
 from comicbox.identifiers import ID_KEY_KEY
 from comicbox.identifiers.identifiers import create_identifier
 
@@ -28,7 +28,7 @@ def metron_id_attribute_to_cb(
             str(id_key),
             # The attribute names no type of its own; the tag it hangs on does.
             positional_id_type=id_type,
-            default_id_source_str=DEFAULT_ID_SOURCE.value,
+            default_id_source_str=DEFAULT_ID_SOURCE_STR,
         )
         comicbox_obj[IDENTIFIERS_KEY] = {id_source_str: comicbox_identifier}
     except Exception as exc:

--- a/comicbox/formats/metron_info/transform/identifiers.py
+++ b/comicbox/formats/metron_info/transform/identifiers.py
@@ -19,7 +19,7 @@ from comicbox.formats.comicbox.schema import (
     PRIMARY_ID_SOURCE_KEY,
     URLS_KEY,
 )
-from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE
+from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
 from comicbox.identifiers import DEFAULT_ID_TYPE, ID_KEY_KEY, ID_TYPE_KEY
 from comicbox.identifiers.identifiers import (
     create_identifier,
@@ -117,7 +117,7 @@ def _identifier_to_cb(native_identifier: Any) -> tuple[str, dict]:
     identifier = create_identifier(
         id_source_str,
         id_key,
-        default_id_source_str=DEFAULT_ID_SOURCE.value,
+        default_id_source_str=DEFAULT_ID_SOURCE_STR,
     )
     return id_source_str, identifier
 
@@ -138,7 +138,7 @@ def _identifiers_to_cb_gtin(values: dict[str, Any]) -> dict:
         for tag, id_source_str in GTIN_SUBTAG_ID_SOURCE_MAP.items():
             if id_key := metron_gtin.get(tag):
                 identifier = create_identifier(
-                    id_source_str, id_key, default_id_source_str=DEFAULT_ID_SOURCE.value
+                    id_source_str, id_key, default_id_source_str=DEFAULT_ID_SOURCE_STR
                 )
                 if identifier:
                     gtin_identifiers[id_source_str] = identifier
@@ -195,9 +195,7 @@ def identifiers_from_cb(values: dict[str, Any]) -> list:
     comicbox_identifiers = values.get(IDENTIFIERS_KEY)
     if not comicbox_identifiers:
         return []
-    primary_id_source_str = values.get(
-        PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE.value
-    )
+    primary_id_source_str = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     metron_identifiers = []
     id_sources = []
     for id_source_str, comicbox_identifier in comicbox_identifiers.items():
@@ -267,9 +265,7 @@ def _urls_from_cb(values: dict[str, Any]) -> list:
     if not urls:
         return []
 
-    primary_id_source_str = values.get(
-        PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE.value
-    )
+    primary_id_source_str = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     url_list = list(urls)
     url_sources = [
         id_source_by_url.get(url) or get_url_id_source(url) for url in url_list

--- a/comicbox/formats/metron_info/transform/publishing_tags.py
+++ b/comicbox/formats/metron_info/transform/publishing_tags.py
@@ -34,13 +34,13 @@ from comicbox.formats.metron_info.schema import (
     SERIES_TAG,
     VOLUME_TAG,
 )
+from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
 from comicbox.formats.metron_info.transform.identifier_attribute import (
     ID_ATTRIBUTE,
     metron_id_attribute_from_cb,
     metron_id_attribute_to_cb,
 )
 from comicbox.formats.metron_info.transform.identifiers import SCOPE_PRIMARY_SOURCE
-from comicbox.identifiers import DEFAULT_ID_SOURCE
 
 LANGUAGE_TAGPATH = f"{SERIES_TAG}.{LANG_ATTR}"
 FORMAT_TAGPATH = f"{SERIES_TAG}.Format"
@@ -74,7 +74,7 @@ def _publisher_to_cb(
     metron_publisher = values.get(PUBLISHER_TAG)
     if not metron_publisher:
         return None
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     comicbox_publisher = {}
     if name := metron_publisher.get(NAME_TAG):
         comicbox_publisher[NAME_KEY] = name
@@ -97,7 +97,7 @@ def _imprint_from_cb(values: dict[str, Any], primary_id_source: str) -> dict | N
 
 def _publisher_from_cb(values: dict[str, Any]) -> dict:
     metron_publisher = {}
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     if comicbox_publisher := values.get(PUBLISHER_KEY):
         if publisher_name := comicbox_publisher.get(NAME_KEY):
             metron_publisher[NAME_TAG] = publisher_name
@@ -124,7 +124,7 @@ def _imprint_to_cb(values: dict[str, Any]) -> dict | None:
     metron_imprint = values.get(IMPRINT_TAGPATH)
     if not metron_imprint:
         return None
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     comicbox_imprint = {}
     if imprint_name := get_cdata(metron_imprint):
         comicbox_imprint[NAME_KEY] = imprint_name
@@ -147,7 +147,7 @@ def _series_id_to_cb(values: dict[str, Any]) -> None:
     metron_series = values.get(SERIES_TAG)
     if not metron_series:
         return None
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     comicbox_series = {}
     metron_id_attribute_to_cb(
         "series", metron_series, comicbox_series, primary_id_source
@@ -159,7 +159,7 @@ def _series_id_from_cb(values: dict[str, Any]) -> None:
     comicbox_series = values.get(SERIES_KEY)
     if not comicbox_series:
         return None
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     metron_series = {}
     metron_id_attribute_from_cb(metron_series, comicbox_series, primary_id_source)
     return metron_series.get(ID_ATTRIBUTE)

--- a/comicbox/formats/metron_info/transform/reprints.py
+++ b/comicbox/formats/metron_info/transform/reprints.py
@@ -29,7 +29,7 @@ from comicbox.formats.comicbox.schema import (
     REPRINTS_KEY,
 )
 from comicbox.formats.metron_info.schema import ALTERNATIVE_NAMES_TAGPATH, LANG_ATTR
-from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE
+from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
 from comicbox.formats.metron_info.transform.identifier_attribute import (
     metron_id_attribute_from_cb,
     metron_id_attribute_to_cb,
@@ -53,7 +53,7 @@ def _reprint_to_cb(
 
 
 def _reprints_to_cb(values: dict[str, Any]) -> list:
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     metron_reprints = values.get(REPRINTS_TAGPATH) or ()
     return [
         comicbox_reprint
@@ -80,7 +80,7 @@ def _reprints_from_cb(values: dict[str, Any]) -> list:
     comicbox_reprints = values.get(REPRINTS_KEY)
     if not comicbox_reprints:
         return []
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     return [
         metron_reprint
         for comicbox_reprint in comicbox_reprints
@@ -118,7 +118,7 @@ def _alternative_name_to_cb(
 
 
 def _alternative_names_to_cb(values: dict[str, Any]) -> list:
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     metron_alternative_names = values.get(ALTERNATIVE_NAMES_TAGPATH) or ()
     return [
         comicbox_alternative_name
@@ -135,7 +135,7 @@ def _alternative_names_from_cb(values: dict[str, Any]) -> list:
     comicbox_alternative_names = values.get(ALTERNATIVE_NAMES_KEYPATH)
     if not comicbox_alternative_names:
         return []
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     metron_alternative_names = []
     for comicbox_alternative_name in comicbox_alternative_names:
         name = comicbox_alternative_name.get(NAME_KEY)

--- a/comicbox/formats/metron_info/transform/resources.py
+++ b/comicbox/formats/metron_info/transform/resources.py
@@ -29,6 +29,7 @@ from comicbox.formats.metron_info.schema import (
     DESIGNATION_TAG,
     NUMBER_TAG,
 )
+from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
 from comicbox.formats.metron_info.transform.identified_name import (
     identified_name_from_cb,
     identified_name_to_cb,
@@ -36,7 +37,6 @@ from comicbox.formats.metron_info.transform.identified_name import (
     identified_name_with_tag_to_cb,
 )
 from comicbox.formats.metron_info.transform.identifiers import SCOPE_PRIMARY_SOURCE
-from comicbox.identifiers import DEFAULT_ID_SOURCE
 
 ARC_KEYPATH = "Arcs.Arc"
 UNIVERSES_KEYPATH = "Universes.Universe"
@@ -92,7 +92,7 @@ def _resources_to_cb(metron_resources: Any, id_type: str, id_source: Any) -> dic
 
 def _resources_from_cb(cb_key: str, values: dict[str, Any]) -> list:
     comicbox_resources = values.get(cb_key)
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     return comicbox_dict_to_metron_list(
         comicbox_resources, primary_id_source, identified_name_from_cb
     )
@@ -103,7 +103,7 @@ def _create_resource_transform_to(metron_key_path: str, cb_key: str) -> MetaSpec
 
     def to_cb(values: dict[str, Any]) -> dict[str, dict[Any, Any]]:
         metron_resources = values.get(metron_key_path)
-        id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+        id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
         return _resources_to_cb(metron_resources, id_type, id_source)
 
     return MetaSpec(
@@ -159,7 +159,7 @@ def _arc_to_cb(
 
 def _arcs_to_cb(values: dict[str, Any]) -> dict:
     metron_arcs = values.get(ARC_KEYPATH, [])
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     return metron_list_to_comicbox_dict(
         metron_arcs, "arc", primary_id_source, _arc_to_cb
     )
@@ -174,7 +174,7 @@ def _arc_from_cb(name: str, comicbox_arc: Any, primary_id_source: str) -> dict:
 
 def _arcs_from_cb(values: dict[str, Any]) -> list:
     comicbox_arcs = values.get(ARCS_KEY)
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     return comicbox_dict_to_metron_list(comicbox_arcs, primary_id_source, _arc_from_cb)
 
 
@@ -229,7 +229,7 @@ def _universe_to_cb(
 
 def _universes_to_cb(values: dict[str, Any]) -> dict:
     metron_universes = values.get(UNIVERSES_KEYPATH)
-    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE_STR)
     return metron_list_to_comicbox_dict(
         metron_universes, "universe", primary_id_source, _universe_to_cb
     )
@@ -248,7 +248,7 @@ def _universe_from_cb(
 
 def _universes_from_cb(values: dict[str, Any]) -> list:
     comicbox_universes = values.get(UNIVERSES_KEY)
-    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE)
+    primary_id_source = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     return comicbox_dict_to_metron_list(
         comicbox_universes, primary_id_source, _universe_from_cb
     )

--- a/tests/files/metadata/metroninfo-no-primary-id.xml
+++ b/tests/files/metadata/metroninfo-no-primary-id.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+	A MetronInfo file that carries `id` attributes on its tags but names no
+	primary id source: no <ID primary="true">, and the only <URL> belongs to
+	no database comicbox recognizes.
+
+	Every tag-level `id` here has to survive the read and land under the
+	`metron` source. Regression fixture for the multi-source `values` dict
+	emitting an explicit None, which made the primary-source fallback dead
+	and dropped all of these ids on the floor.
+-->
+<MetronInfo>
+	<IDS>
+		<ID source="Comic Vine">145269</ID>
+	</IDS>
+	<Publisher id="11">
+		<Imprint id="222">Youthful Imprint</Imprint>
+		<Name>Youthful Adventure Stories</Name>
+	</Publisher>
+	<Series id="2222" lang="en">
+		<AlternativeNames>
+			<AlternativeName id="3333" lang="es">Capitán Ciencia</AlternativeName>
+		</AlternativeNames>
+		<Name>Captain Science</Name>
+	</Series>
+	<Stories>
+		<Story id="5555">Captain Lost</Story>
+	</Stories>
+	<Arcs>
+		<Arc id="7777">
+			<Name>Captain Arc</Name>
+		</Arc>
+	</Arcs>
+	<Universes>
+		<Universe id="8888">
+			<Name>Mirror</Name>
+		</Universe>
+	</Universes>
+	<Credits>
+		<Credit>
+			<Creator id="9999">Joe Orlando</Creator>
+			<Roles>
+				<Role id="1111">Writer</Role>
+			</Roles>
+		</Credit>
+	</Credits>
+	<Reprints>
+		<Reprint id="4444">Captain Science Alternate #001</Reprint>
+	</Reprints>
+	<URLs>
+		<URL>https://example.com/not-a-known-database/1</URL>
+	</URLs>
+</MetronInfo>

--- a/tests/unit/test_metron_id_attribute_fallback.py
+++ b/tests/unit/test_metron_id_attribute_fallback.py
@@ -1,0 +1,153 @@
+"""
+MetronInfo tag `id` attributes when the file names no primary id source.
+
+A MetronInfo file may hang an `id` attribute on Publisher, Series, Arc,
+Universe, Creator, Role, Story, Reprint and AlternativeName. Which database
+those ids belong to is only stated indirectly, by whichever <ID> or <URL> the
+file marks primary. When nothing is marked -- or the primary <URL> points at a
+site comicbox doesn't recognize -- the transforms fall back to a default
+source.
+
+That fallback was dead. The multi-source `values` dict the spec layer feeds
+these functions emitted an explicit ``None`` for every missing source, so
+``values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)`` returned ``None``
+rather than the default: ``.get`` only substitutes when the key is *absent*.
+Every id was then filed under a ``None`` key and dropped by schema load.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+from glom import glom
+
+from comicbox.enums.comicbox import IdSources
+from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY
+from comicbox.formats.metron_info.transform import MetronInfoTransform
+from comicbox.identifiers import ID_KEY_KEY
+from tests.const import TEST_METADATA_DIR
+
+NO_PRIMARY_FN = "metroninfo-no-primary-id.xml"
+METRON = IdSources.METRON.value
+
+
+def _load_fixture(transform: MetronInfoTransform) -> dict[str, Any]:
+    """Parse the fixture with the MetronInfo schema."""
+    xml = (TEST_METADATA_DIR / NO_PRIMARY_FN).read_text()
+    loaded: dict[str, Any] = transform.SCHEMA_CLASS().loads(xml)  # pyright: ignore[reportAssignmentType]
+    return dict(loaded)
+
+
+def _to_comicbox() -> dict[str, Any]:
+    transform = MetronInfoTransform()
+    loaded = _load_fixture(transform)
+    return dict(dict(transform.to_comicbox(loaded))["comicbox"])
+
+
+def _raw_glom() -> dict[str, Any]:
+    """Return the transform output before schema load, where None keys appeared."""
+    transform = MetronInfoTransform()
+    loaded = _load_fixture(transform)
+    return glom(loaded, dict(transform.SPECS_TO))["comicbox"]
+
+
+def test_fixture_names_no_primary_id_source() -> None:
+    """The fixture has to keep provoking the fallback, or it proves nothing."""
+    assert _to_comicbox().get("primary_id_source") is None
+
+
+def _id_source_keys(node: Any) -> Iterator[Any]:
+    """Yield every id source key under every `identifiers` dict in the tree."""
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            if key == IDENTIFIERS_KEY and isinstance(value, Mapping):
+                yield from value
+            yield from _id_source_keys(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _id_source_keys(item)
+
+
+def test_no_identifier_is_keyed_by_none() -> None:
+    """A None id source key is the bug's signature. It must appear nowhere."""
+    id_source_keys = list(_id_source_keys(_raw_glom()))
+    # Guard against the walker silently finding nothing to check.
+    assert id_source_keys
+    assert None not in id_source_keys
+
+
+@pytest.mark.parametrize(
+    ("keypath", "id_key"),
+    [
+        ("publisher", "11"),
+        ("imprint", "222"),
+        ("series", "2222"),
+        ("arcs.Captain Arc", "7777"),
+        ("universes.Mirror", "8888"),
+        ("credits.Joe Orlando", "9999"),
+        ("credits.Joe Orlando.roles.Writer", "1111"),
+        ("stories.Captain Lost", "5555"),
+    ],
+)
+def test_tag_id_attribute_survives_and_is_attributed_to_metron(
+    keypath: str, id_key: str
+) -> None:
+    """Each tag `id` lands under the metron source, not None and not comicvine."""
+    obj = glom(_to_comicbox(), keypath)
+    identifiers = obj[IDENTIFIERS_KEY]
+    assert set(identifiers) == {METRON}
+    assert identifiers[METRON][ID_KEY_KEY] == id_key
+
+
+def test_reprint_id_attribute_survives() -> None:
+    reprints = _to_comicbox()["reprints"]
+    assert len(reprints) == 1
+    identifiers = reprints[0][IDENTIFIERS_KEY]
+    assert identifiers == {METRON: {ID_KEY_KEY: "4444"}}
+
+
+def test_alternative_name_id_attribute_survives() -> None:
+    alternative_names = _to_comicbox()["series"]["alternative_names"]
+    assert len(alternative_names) == 1
+    identifiers = alternative_names[0][IDENTIFIERS_KEY]
+    assert identifiers == {METRON: {ID_KEY_KEY: "3333"}}
+
+
+def test_sourced_id_tag_keeps_its_own_source() -> None:
+    """The fallback must not overwrite an <ID> that names its own database."""
+    identifiers = _to_comicbox()[IDENTIFIERS_KEY]
+    assert identifiers[IdSources.COMICVINE.value][ID_KEY_KEY] == "145269"
+
+
+def test_default_id_source_is_metron_not_comicvine() -> None:
+    """
+    MetronInfo's bare ids belong to Metron, the database that writes the format.
+
+    Two different DEFAULT_ID_SOURCE constants used to be imported across these
+    modules: the Metron one, and comicbox.identifiers' COMICVINE one. A fixed
+    fallback reading the wrong constant would file Metron's ids under ComicVine
+    and mint ComicVine urls that 404.
+    """
+    from comicbox.formats.metron_info.transform.const import (
+        DEFAULT_ID_SOURCE,
+        DEFAULT_ID_SOURCE_STR,
+    )
+
+    assert DEFAULT_ID_SOURCE is IdSources.METRON
+    # The identifier dicts are keyed by the source *string*. An enum member
+    # here reads back as "IdSources.METRON" and drops out on load.
+    assert DEFAULT_ID_SOURCE_STR == METRON
+    assert isinstance(DEFAULT_ID_SOURCE_STR, str)
+
+
+def test_roundtrip_writes_the_id_attributes_back() -> None:
+    """Read then write: the ids have to reappear as `id` attributes."""
+    transform = MetronInfoTransform()
+    comicbox_data = MappingProxyType({"comicbox": _to_comicbox()})
+    metron = dict(transform.from_comicbox(comicbox_data))["MetronInfo"]
+    assert metron["Publisher"]["@id"] == "11"
+    assert metron["Publisher"]["Imprint"]["@id"] == "222"
+    assert metron["Series"]["@id"] == "2222"

--- a/tests/unit/test_transform_spec_missing_keys.py
+++ b/tests/unit/test_transform_spec_missing_keys.py
@@ -1,0 +1,64 @@
+"""
+Missing sources must be absent from the multi-source `values` dict.
+
+`MetaSpec` key maps whose source is a tuple hand the spec function a dict of
+every named source. A source the file didn't supply used to arrive as an
+explicit ``None``, which silently disabled every ``values.get(key, default)``
+written against that dict -- ``dict.get`` substitutes its default only when the
+key is *absent*, never when it is present and None.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from glom import glom
+
+from comicbox.formats.base.transforms.spec import MetaSpec, create_specs_to_comicbox
+
+SENTINEL = "THE-DEFAULT"
+
+
+def _run(source: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+    """Run a two-source MetaSpec and hand back the values dict it produced."""
+    captured: dict[str, Any] = {}
+
+    def spec(values: dict[str, Any]) -> dict:
+        captured.update(values)
+        return {}
+
+    specs = create_specs_to_comicbox(
+        MetaSpec(key_map={"dest": keys}, spec=spec),
+        comicbox_root_keypath="",
+    )
+    glom(source, dict(specs))
+    return captured
+
+
+def test_missing_source_key_is_absent_not_none() -> None:
+    values = _run({"present": "yes"}, ("present", "missing"))
+    assert values["present"] == "yes"
+    assert "missing" not in values
+
+
+def test_get_with_default_returns_the_default() -> None:
+    """The property the ~17 metron primary-id-source call sites rely on."""
+    values = _run({"present": "yes"}, ("present", "missing"))
+    assert values.get("missing", SENTINEL) == SENTINEL
+
+
+def test_empty_source_value_is_also_absent() -> None:
+    """`skip=is_empty` treats an empty value as unsupplied."""
+    values = _run({"present": "yes", "blank": ""}, ("present", "blank"))
+    assert values.get("blank", SENTINEL) == SENTINEL
+
+
+def test_zero_is_a_real_value_and_survives() -> None:
+    """`is_empty` respects zero, so 0 must not be mistaken for missing."""
+    values = _run({"zero": 0}, ("zero", "missing"))
+    assert values.get("zero", SENTINEL) == 0
+
+
+def test_all_sources_missing_yields_an_empty_dict() -> None:
+    values = _run({"unrelated": 1}, ("nope", "also-nope"))
+    assert values == {}


### PR DESCRIPTION
## The claim, checked

A MetronInfo file states which database its tag-level `id` attributes belong to only indirectly — via whichever `<ID>` or `<URL>` it marks primary. When nothing is marked, ~17 sites across `metron_info/transform/{publishing_tags,resources,reprints,credits}.py` fall back to a default:

```python
primary_id_source = values.get(SCOPE_PRIMARY_SOURCE, DEFAULT_ID_SOURCE)
```

**Not one of those defaults could ever be reached.** Confirmed, and the damage is worse than "misattribution" — the ids are lost outright.

`_get_multi_values_spec` in `formats/base/transforms/spec.py` resolved a missing source to `Coalesce(..., default=None)`. That puts the key **in** the dict holding `None`, and `dict.get` substitutes its default only when the key is *absent*.

Reduced to the mechanism:

```python
>>> glom({"a": 1}, {"scope": Coalesce(S.globals.comicbox["primary_id_source"],
...                                   skip=is_empty, default=None)})
{'scope': None}          # key present
>>> _.get("scope", "FALLBACK")
None                     # default never fires
```

End to end, on a file with `@id` attributes, no `<ID primary="true">`, and an unrecognized url — the fixture this combination never had, now `tests/files/metadata/metroninfo-no-primary-id.xml`:

| | before | after |
|---|---|---|
| `publisher` | `{'identifiers': {None: {'key': '11'}}}` | `{'identifiers': {'metron': {'key': '11'}}}` |
| `imprint` | `{None: {'key': '222'}}` | `{'metron': {'key': '222'}}` |
| `series` | `{None: {'key': '2222'}}` | `{'metron': {'key': '2222'}}` |
| `arcs`, `universes`, `credits`, `roles`, `stories`, `reprints` | all `{None: ...}` | all `{'metron': ...}` |

Marshmallow then drops the `None`-keyed entry on load, so **all of them vanish** — read *and* write. `metron_id_attribute_from_cb` guards on `if primary_id_source_str and ...`, so a null source writes no `@id` either.

## Three defects, stacked

1. **Root cause — `spec.py:51`.** `default=None` → `default=SKIP`, so a missing source leaves the key out and `.get(k, default)` works as written. This fixes the fallbacks *wherever they are*, not just in metron. Blast radius checked: every spec function in the tree reads `values` only via `.get()` — no subscripts, no `in` tests, no iteration — so nothing else changes behavior.

2. **Wrong type.** `DEFAULT_ID_SOURCE` is an `IdSources` enum member, but the identifier dicts are keyed by the source *string*. Even a reachable fallback would have produced `{IdSources.METRON: ...}`, which reads back as `"IdSources.METRON"` and drops out on load. Added `DEFAULT_ID_SOURCE_STR`.

3. **Two constants, reconciled.** `resources.py` and `publishing_tags.py` imported `comicbox.identifiers`' **COMICVINE**; `credits.py`, `reprints.py` and `identifier_attribute.py` used metron's **METRON**. A fixed fallback reading the wrong one would have filed Metron's ids under ComicVine and minted ComicVine urls that 404. All five now read METRON — the database that writes the format.

`spec.py:97`'s `Coalesce(spec, default=None)` was also named in the report. It is **not** a cause: it defaults the *destination* value, and never feeds a `values` dict. Left alone — changing it is a far wider behavioral change with no bug attached.

## Adjacent gap found while testing

MetronInfo's `nameType` declares `id` in the bundled XSD, and `reprints.py` already calls `metron_id_attribute_to_cb`/`_from_cb` for alternative names — but `MetronNameSchema.Meta.include` listed only `#text` and `@lang`, so the attribute was stripped before the transform ever saw it. That transform code was dead. One-line schema fix; called out separately since it is its own defect.

## Verification

`make fix`, `make lint`, `make ty` all clean. Full suite **1567 passed, 1 skipped** (1547 baseline + 20 new). No unrelated `make fix` noise in the diff.

New tests: `test_metron_id_attribute_fallback.py` (15) asserts no identifier is ever keyed by `None`, each id lands under `metron`, a sourced `<ID>` keeps its own source, and the ids round-trip back out as `@id`. `test_transform_spec_missing_keys.py` (5) pins the spec-layer SKIP contract, including that `is_empty` still respects `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)