### PR TITLE
fix(online): honest lookup outcomes, bounded prompts, abort propagation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,21 @@
       from. Malformed tags were dropped as silently as absent ones.
     - Schema-wide validation hooks run. The first one added to any schema would
       have failed on a bad call.
+    - Online tagging reports a match only when metadata was actually applied. A
+      `--id` fetch or a stored-id refresh that failed still reported the comic
+      as written, so a batch run counted it as tagged and the file was rewritten
+      with its own existing metadata.
+    - The online summary and the `AutoWritten` event are emitted after the issue
+      fetch lands, not before it. A failed fetch used to be counted as an
+      auto-write.
+    - A prompt whose answer keeps changing the session's match policy without
+      ever choosing now gives up instead of asking forever, and a chosen
+      candidate number outside the offered list is refused. A negative one
+      silently tagged the comic with the last candidate.
+    - Aborting at a prompt ends the run. `--recurse` walked on to the next comic
+      and `--jobs` worked through the rest of the batch; a cancelled retry
+      inside a Comic Vine volume or a Metron year-retry was swallowed like an
+      ordinary API failure.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/box/online_lookup.py
+++ b/comicbox/box/online_lookup.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import sys
 import threading
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -120,6 +120,39 @@ def _online_source_enums() -> frozenset[MetadataSources]:
 
 
 _ONLINE_SOURCE_ENUMS: frozenset[MetadataSources] = _online_source_enums()
+
+# Hard cap on selector round-trips for a single prompt. Only the two
+# session-level actions (`set_unattended` / `set_policy`) re-prompt, and a
+# user needs at most one of each before landing on a terminal answer, so
+# anything past this is a selector that never terminates -- a buggy or
+# hostile programmatic callback, not a person. Not a match-quality
+# threshold: nothing under tasks/ calibrates it.
+_MAX_PROMPT_ROUNDS = 8
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceOutcome:
+    """
+    What one source's lookup attempt did, as two independent facts.
+
+    ``applied`` -- online metadata actually landed in the source pool.
+    This is the only signal allowed to report success: it feeds
+    ``run_online_lookup()``'s return value, ``FileFinished.outcome`` and
+    ``OnlineSession``'s ``OnlineResult.matched``.
+
+    ``claimed`` -- the source consumed a pinned identity for this comic
+    (a ``--id`` pin, or an id a previous tagging run stored on the file).
+    A claim suppresses the fuzzy fallback on *other* sources under
+    first-wins whether or not the fetch landed: when the user or the file
+    names an exact issue, a transient API failure must not silently hand
+    the comic to a sibling source's guess.
+
+    The two were one boolean until this split, so a failed pinned fetch
+    reported ``written`` with nothing written.
+    """
+
+    applied: bool = False
+    claimed: bool = False
 
 
 class _NoTtyHintGuard:
@@ -457,16 +490,45 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         self._profile_cache = profile
         return profile
 
-    def _accept_candidate(self, source: OnlineSource, candidate: Candidate) -> bool:
+    def _accept(
+        self,
+        source: OnlineSource,
+        issue_id: int,
+        record: Callable[[str], None],
+        *,
+        emit_auto_written: bool,
+        candidate: Candidate | None = None,
+    ) -> bool:
         """
-        Fetch the full record for an accepted candidate and inject it.
+        Turn an issue id into applied metadata; the one accept chokepoint.
 
-        Returns True when the fetch succeeded and metadata was added —
-        acceptance alone isn't a "win" if the follow-up fetch fails.
+        Every accepting path funnels through here so "we counted a win"
+        and "metadata was added" cannot drift apart: the outcome counter,
+        the ``AutoWritten`` event and the series-cache population all run
+        *after* the fetch and only when it succeeded. Ordering used to be
+        per-caller, and three of them recorded the win first, so a failed
+        follow-up fetch still incremented the summary and emitted the
+        event. `_fetch_explicit_id` logs its own failure, so a False
+        return is silent here.
         """
-        added = self._fetch_explicit_id(source, candidate.issue_id)
-        self._maybe_populate_series_cache(source, candidate)
-        return added
+        if not self._fetch_explicit_id(source, issue_id):
+            return False
+        record(source.name)
+        if candidate is not None:
+            self._maybe_populate_series_cache(source, candidate)
+        if emit_auto_written:
+            self._emit_auto_written(source, issue_id)
+        return True
+
+    def _accept_candidate(self, source: OnlineSource, candidate: Candidate) -> bool:
+        """Accept a ranked candidate as an auto-write. True when applied."""
+        return self._accept(
+            source,
+            candidate.issue_id,
+            outcome_stats.record_auto_write,
+            emit_auto_written=True,
+            candidate=candidate,
+        )
 
     def _maybe_populate_series_cache(
         self, source: OnlineSource, candidate: Candidate
@@ -638,7 +700,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         current = candidates
         path = getattr(self, "_path", None)
         prompt_id = f"{source.name}:{id(candidates)}"
-        while True:
+        for _ in range(_MAX_PROMPT_ROUNDS):
             self._emit(
                 PromptQueued(
                     path=path,
@@ -671,6 +733,15 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             return self._dispatch_terminal_prompt_action(
                 source, current, action, payload
             )
+        # Only `set_unattended` / `set_policy` reach here; every other
+        # action returned above. A selector that keeps asking for session
+        # changes without ever deciding would have spun forever.
+        logger.warning(
+            f"online {source.name}: selector requested a session change "
+            f"{_MAX_PROMPT_ROUNDS} times without choosing; skipping"
+        )
+        outcome_stats.record_prompt_declined(source.name)
+        return False
 
     def _invoke_selector(
         self, source: OnlineSource, candidates: tuple[Candidate, ...]
@@ -753,16 +824,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 f"id={resolution.chosen.issue_id} "
                 f"(score={resolution.chosen.score:.2f}){suffix}"
             )
-            outcome_stats.record_auto_write(source.name)
-            accepted = self._accept_candidate(source, resolution.chosen)
-            self._emit(
-                AutoWritten(
-                    path=path,
-                    source=source.name,
-                    candidate_summary=str(resolution.chosen.issue_id),
-                )
-            )
-            return accepted
+            return self._accept_candidate(source, resolution.chosen)
         if resolution.kind is ResolutionKind.NO_MATCH:
             logger.info(
                 f"online {source.name}: no match cleared min_confidence{suffix}"
@@ -792,10 +854,26 @@ class ComicboxOnlineLookup(ComicboxNormalize):
     ) -> bool:
         """Apply a terminal prompt action. True when metadata was accepted."""
         if action == "choose" and isinstance(payload, int):
+            if not 0 <= payload < len(candidates):
+                # A selector index is untrusted input, same as in
+                # OnlineSession._store_prompt_resolution. Unguarded, a
+                # negative index is a legal Python from-the-end lookup, so
+                # the comic gets tagged with a candidate nobody chose.
+                logger.warning(
+                    f"online {source.name}: prompt chose index {payload} but "
+                    f"only {len(candidates)} candidate(s) were offered; skipping"
+                )
+                outcome_stats.record_prompt_declined(source.name)
+                return False
             chosen = candidates[payload]
             logger.info(f"online {source.name}: prompt-chose id={chosen.issue_id}")
-            outcome_stats.record_prompt_accepted(source.name)
-            return self._accept_candidate(source, chosen)
+            return self._accept(
+                source,
+                chosen.issue_id,
+                outcome_stats.record_prompt_accepted,
+                emit_auto_written=False,
+                candidate=chosen,
+            )
         if action == "manual" and isinstance(payload, str):
             try:
                 src_name, _, raw_id = payload.partition(":")
@@ -811,8 +889,12 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 )
                 outcome_stats.record_prompt_declined(source.name)
                 return False
-            outcome_stats.record_prompt_accepted(source.name)
-            return self._fetch_explicit_id(source, issue_id)
+            return self._accept(
+                source,
+                issue_id,
+                outcome_stats.record_prompt_accepted,
+                emit_auto_written=False,
+            )
         if action == "abort":
             reason = "online: aborted by user from prompt"
             raise OnlineLookupAbortedError(reason)
@@ -892,14 +974,14 @@ class ComicboxOnlineLookup(ComicboxNormalize):
 
     def _emit_auto_written(self, source: OnlineSource, issue_id: int) -> None:
         """
-        Emit AutoWritten for an id-fetch fast-path win.
+        Emit AutoWritten for a win, however the issue id was obtained.
 
-        The cold-path search and series-cache wins emit AutoWritten directly,
-        but the explicit ``--id`` fetch and the stored-id refresh used to win
-        silently — leaving event consumers (e.g. Codex's status table) unable
-        to attribute the matched source for previously-tagged comics. Emitting
-        it here means every auto-write carries its source and path, however the
-        issue id was obtained.
+        Called only from `_accept`, and only once the fetch has landed, so
+        every auto-write — cold-path search, series-cache hit, ``--id``
+        pin, stored-id refresh — carries its source and path, and no
+        failed fetch announces one. Event consumers (e.g. Codex's status
+        table) need it on the fast paths too, or they can't attribute the
+        matched source for previously-tagged comics.
         """
         self._emit(
             AutoWritten(
@@ -909,13 +991,16 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             )
         )
 
-    def _lookup_one_source(self, source: OnlineSource) -> bool:
+    def _lookup_one_source(self, source: OnlineSource) -> _SourceOutcome:
         """
-        Drive the lookup for one source; return True iff the source "won".
+        Drive the lookup for one source and report what it did.
 
-        A win is any of: explicit-id fetch, --ignore-existing skip on a
-        pre-tagged file, stored-id refresh, or an accepted search result.
-        The win signal feeds the first-wins early-exit in `run_online_lookup`.
+        Two facts come back, not one (see `_SourceOutcome`): whether
+        metadata was applied, and whether the source consumed a pinned
+        identity for this comic. The two pinned-id fast paths claim the
+        comic either way, so first-wins still keeps a sibling source from
+        fuzzy-matching behind a failed pin, but only a landed fetch
+        reports ``applied``.
         """
         online = self._config.online
         # Explicit --id is the strongest user signal. It overrides
@@ -923,10 +1008,13 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         explicit_ids = online.lookup.ids
         issue_id = explicit_ids.get(source.name)
         if issue_id is not None:
-            outcome_stats.record_explicit_id(source.name)
-            if self._fetch_explicit_id(source, issue_id):
-                self._emit_auto_written(source, issue_id)
-            return True
+            applied = self._accept(
+                source,
+                issue_id,
+                outcome_stats.record_explicit_id,
+                emit_auto_written=True,
+            )
+            return _SourceOutcome(applied=applied, claimed=True)
 
         # Fast refresh: a stored upstream id from a prior tag lets us
         # call source.get(id) instead of walking the full search path.
@@ -938,9 +1026,13 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 logger.info(
                     f"online {source.name}: refreshing via stored id={stored_id}"
                 )
-                if self._fetch_explicit_id(source, stored_id):
-                    self._emit_auto_written(source, stored_id)
-                return True
+                applied = self._accept(
+                    source,
+                    stored_id,
+                    outcome_stats.record_auto_write,
+                    emit_auto_written=True,
+                )
+                return _SourceOutcome(applied=applied, claimed=True)
 
         # Series-first batching fast path (plan §3.10). When the session
         # has cached a resolved volume_id for this comic's series
@@ -949,9 +1041,9 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         # path too (consistent with its "don't trust prior verdict"
         # intent).
         if not online.lookup.rematch and self._try_series_cache_lookup(source):
-            return True
+            return _SourceOutcome(applied=True)
 
-        return self._search_path(source)
+        return _SourceOutcome(applied=self._search_path(source))
 
     def _try_series_cache_lookup(self, source: OnlineSource) -> bool:  # noqa: PLR0911
         """
@@ -996,15 +1088,6 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             f"online {source.name}: series-cache hit; accepted "
             f"id={candidate.issue_id} via volume_id={volume_id}"
         )
-        outcome_stats.record_auto_write(source.name)
-        path = getattr(self, "_path", None)
-        self._emit(
-            AutoWritten(
-                path=path,
-                source=source.name,
-                candidate_summary=str(candidate.issue_id),
-            )
-        )
         return self._accept_candidate(source, candidate)
 
     def _first_normalized(self, src: MetadataSources) -> dict | None:
@@ -1043,25 +1126,69 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         )
 
     def _should_skip_first_wins(
-        self, source: OnlineSource, online: OnlineSettings, *, won_any: bool
+        self, source: OnlineSource, online: OnlineSettings, *, satisfied: bool
     ) -> bool:
-        """First-wins skip; explicit-id sources always run."""
-        if not won_any or not online.lookup.first_wins:
+        """
+        First-wins skip; explicit-id sources always run.
+
+        ``satisfied`` means an earlier source either applied metadata or
+        claimed the comic with a pinned id. The claim half is what keeps a
+        failed ``--id`` fetch from handing the comic to a sibling source's
+        fuzzy search.
+        """
+        if not satisfied or not online.lookup.first_wins:
             return False
         has_explicit = (
             source.name in online.lookup.ids or source.name in online.lookup.series_ids
         )
         return not has_explicit
 
+    def _run_active_sources(
+        self,
+        active_sources: list[OnlineSource],
+        online: OnlineSettings,
+        path: Path | None,
+    ) -> bool:
+        """
+        Query each source in order; return whether any applied metadata.
+
+        ``satisfied`` accumulates both halves of `_SourceOutcome` because
+        first-wins stops on either one, while only ``applied`` is reported
+        back to the caller.
+        """
+        applied_any = False
+        satisfied = False
+        for source in active_sources:
+            if self._should_skip_first_wins(source, online, satisfied=satisfied):
+                logger.info(
+                    f"online {source.name}: skipped (first-wins satisfied; "
+                    f"use --all-sources to query every source)"
+                )
+                continue
+            # After the first-wins skip, so a source that sat out never
+            # claims to be running. Covers every route _lookup_one_source
+            # can take, including the explicit-id, stored-id and
+            # series-cache fast paths that never reach a SearchStarted.
+            self._emit(SourceStarted(path=path, source=source.name))
+            outcome = self._lookup_one_source(source)
+            applied_any = applied_any or outcome.applied
+            satisfied = satisfied or outcome.applied or outcome.claimed
+        return applied_any
+
     def run_online_lookup(self) -> bool:
         """
         Idempotent: populate online MetadataSources once per box instance.
 
-        Returns whether any source won — i.e. whether online metadata was
-        actually applied to this box. A repeat call returns the first
-        run's outcome. ``False`` means the comic's metadata is unchanged
-        (disabled, no sources, no match, skipped, or deferred prompt), so
+        Returns whether online metadata was actually applied to this box.
+        A repeat call returns the first run's outcome. ``False`` means the
+        comic's metadata is unchanged (disabled, no sources, no match,
+        skipped, deferred prompt, or a pinned-id fetch that failed), so
         callers can avoid pointless re-writes of existing tags.
+
+        A source claiming the comic via a pinned id is deliberately *not*
+        folded into this return value; it only gates the first-wins skip
+        below. Reporting "applied" for a claim is what let a failed
+        ``--id`` fetch surface as ``written``.
         """
         if self._online_lookup_already_done():
             return self._online_lookup_won
@@ -1078,24 +1205,10 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 "online: --online all requested but no sources are configured "
                 "(no credentials available for any known source)"
             )
-        won_any = False
-        for source in active_sources:
-            if self._should_skip_first_wins(source, online, won_any=won_any):
-                logger.info(
-                    f"online {source.name}: skipped (first-wins satisfied; "
-                    f"use --all-sources to query every source)"
-                )
-                continue
-            # After the first-wins skip, so a source that sat out never
-            # claims to be running. Covers every route _lookup_one_source
-            # can take, including the explicit-id, stored-id and
-            # series-cache fast paths that never reach a SearchStarted.
-            self._emit(SourceStarted(path=path, source=source.name))
-            if self._lookup_one_source(source):
-                won_any = True
-        self._online_lookup_won = won_any
+        applied_any = self._run_active_sources(active_sources, online, path)
+        self._online_lookup_won = applied_any
         self._cross_source_cv_id_check()
         self._emit(
-            FileFinished(path=path, outcome="written" if won_any else "no_change")
+            FileFinished(path=path, outcome="written" if applied_any else "no_change")
         )
-        return won_any
+        return applied_any

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from loguru import logger
 from typing_extensions import override
 
+from comicbox.exceptions import OnlineLookupAbortedError
 from comicbox.formats import MetadataFormats
 from comicbox.formats.base.online.profile import (
     Candidate,
@@ -211,19 +212,34 @@ class ComicVineOnlineSource(OnlineSource):
             (dump.get("volume") or {}).get("id")
         )
         if volume_id is not None:
-            try:
-                volume = self._get_volume_with_retry(session, int(volume_id))
-            except Exception as exc:
-                logger.warning(
-                    f"online {self.name}: get_volume({volume_id}) failed; "
-                    f"publisher will be missing from this issue: {exc}"
-                )
-            else:
-                if volume.publisher is not None:
-                    dump["publisher"] = volume.publisher.model_dump(mode="json")
-                if volume.aliases and isinstance(dump.get("volume"), dict):
-                    dump["volume"]["aliases"] = volume.aliases
+            self._enrich_from_volume(session, dump, int(volume_id))
         return dump
+
+    def _enrich_from_volume(
+        self, session: Any, dump: dict[str, Any], volume_id: int
+    ) -> None:
+        """
+        Inject the volume's publisher and aliases into an issue dump.
+
+        Best-effort: a source-side failure leaves the issue without a
+        publisher rather than failing the fetch. An abort is not such a
+        failure -- it ends the whole lookup, as in
+        `OnlineSource.lookup_issue`.
+        """
+        try:
+            volume = self._get_volume_with_retry(session, volume_id)
+        except OnlineLookupAbortedError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                f"online {self.name}: get_volume({volume_id}) failed; "
+                f"publisher will be missing from this issue: {exc}"
+            )
+            return
+        if volume.publisher is not None:
+            dump["publisher"] = volume.publisher.model_dump(mode="json")
+        if volume.aliases and isinstance(dump.get("volume"), dict):
+            dump["volume"]["aliases"] = volume.aliases
 
     # Limit how many candidate volumes to expand into issue queries; each
     # volume → one extra `list_issues` API call under CV's 1/sec rate limit.
@@ -373,6 +389,10 @@ class ComicVineOnlineSource(OnlineSource):
             narrow = self._volume_filter_search_with_retry(
                 session, profile.series, profile.year, max_volumes
             )
+        except OnlineLookupAbortedError:
+            # An abort ends the whole lookup; it is not a source-side
+            # failure to degrade past. Mirrors OnlineSource.lookup_issue.
+            raise
         except Exception as exc:
             logger.info(
                 f"online {self.name}: volume filter-search failed "
@@ -669,6 +689,10 @@ class ComicVineOnlineSource(OnlineSource):
                 year=year,
                 alt_series=alt_series,
             )
+        except OnlineLookupAbortedError:
+            # An abort ends the whole lookup; it is not a source-side
+            # failure to degrade past. Mirrors OnlineSource.lookup_issue.
+            raise
         except Exception as exc:
             logger.warning(
                 f"online {self.name}: issue-list for volume {vol.id} "

--- a/comicbox/formats/metron_api/online_source.py
+++ b/comicbox/formats/metron_api/online_source.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from loguru import logger
 from typing_extensions import override
 
+from comicbox.exceptions import OnlineLookupAbortedError
 from comicbox.formats import MetadataFormats
 from comicbox.formats.base.online.profile import (
     Candidate,
@@ -539,6 +540,10 @@ class MetronOnlineSource(OnlineSource):
                         cover_year_override=retry_year,
                         include_volume=include_volume,
                     )
+                except OnlineLookupAbortedError:
+                    # An abort ends the whole lookup; it is not a
+                    # source-side failure to degrade past.
+                    raise
                 except Exception as exc:
                     logger.warning(
                         f"online {self.name}: issue-list retry at "

--- a/comicbox/run.py
+++ b/comicbox/run.py
@@ -12,6 +12,7 @@ from loguru import logger
 from comicbox.box import Comicbox
 from comicbox.config import get_config
 from comicbox.enums.comicbox import FileTypeEnum
+from comicbox.exceptions import OnlineLookupAbortedError
 from comicbox.formats.base.online import outcome_stats
 from comicbox.formats.base.online.auto_engage import resolve_auto_engaged_budget
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
@@ -66,11 +67,20 @@ class Runner:
         return out
 
     def _run_one(self, path: Path) -> None:
-        """Process a single file, swallowing exceptions for batch resilience."""
+        """
+        Process a single file, swallowing exceptions for batch resilience.
+
+        Abort is the one exception that isn't about this file: the user
+        answered "abort" at a prompt (or a caller cancelled a retry
+        sleep), which is a decision about the run. Swallowing it here
+        turned it into "skip one comic and keep prompting for the rest."
+        """
         try:
             with Comicbox(path, config=self._config) as car:
                 car.print_file_header()
                 car.run()
+        except OnlineLookupAbortedError:
+            raise
         except Exception:
             logger.exception(path)
 
@@ -101,6 +111,10 @@ class Runner:
         for full_path in self._iter_recurse(path):
             try:
                 self.run_on_file(full_path)
+            except OnlineLookupAbortedError:
+                # Abort ends the walk; the remaining files are not ours
+                # to keep processing.
+                raise
             except Exception:
                 logger.exception(full_path)
 
@@ -145,12 +159,23 @@ class Runner:
         logger.info(f"Running {len(paths)} files with {jobs} workers")
         with ThreadPoolExecutor(max_workers=jobs) as executor:
             futures = {executor.submit(self._run_one, p): p for p in paths}
-            for future in as_completed(futures):
-                path = futures[future]
-                try:
-                    future.result()
-                except Exception:
-                    logger.exception(path)
+            try:
+                for future in as_completed(futures):
+                    path = futures[future]
+                    try:
+                        future.result()
+                    except OnlineLookupAbortedError:
+                        raise
+                    except Exception:
+                        logger.exception(path)
+            except OnlineLookupAbortedError:
+                # Drop every file still queued so the abort actually ends
+                # the batch. Workers already in flight can't be
+                # interrupted from here -- the pool joins them on the way
+                # out -- but no further file is started.
+                for pending in futures:
+                    pending.cancel()
+                raise
 
     def run(self) -> None:
         """Run actions with config."""

--- a/tests/unit/test_online_abort_propagation.py
+++ b/tests/unit/test_online_abort_propagation.py
@@ -1,0 +1,308 @@
+"""
+``OnlineLookupAbortedError`` must end the run, everywhere.
+
+Abort is not a per-file or per-API-call failure: the user answered
+"abort" at a prompt, or a caller cancelled a retry sleep. Four broad
+``except Exception`` handlers degraded it into "log it and carry on", so
+a ``--recurse`` walk kept prompting for the rest of the library and a
+cancelled source call fell through to the next search attempt.
+
+``OnlineSource.lookup_issue`` (formats/base/online/sources/base.py) has
+always had the right shape -- re-raise the abort above the broad handler
+-- and these are the sites that didn't.
+"""
+
+from __future__ import annotations
+
+import time
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from comicbox.config.settings import (
+    OnlineSettings,
+    OnlineSourceCredentials,
+)
+from comicbox.exceptions import OnlineLookupAbortedError
+from comicbox.formats.base.online.profile import ComicProfile
+from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
+from comicbox.formats.metron_api.online_source import MetronOnlineSource
+from comicbox.run import Runner
+
+_ABORT_REASON = "online: aborted by user from prompt"
+
+# The fakes below never touch the session; the sources' signatures are
+# vendor-typed (mokkari Session), so hand them an untyped placeholder.
+_NO_SESSION: Any = None
+
+
+def _abort() -> OnlineLookupAbortedError:
+    return OnlineLookupAbortedError(_ABORT_REASON)
+
+
+# --- Runner: --recurse ------------------------------------------------------
+
+
+def _make_comics(tmp_path: Path, count: int) -> list[Path]:
+    paths = []
+    for i in range(count):
+        path = tmp_path / f"comic_{i:02d}.cbz"
+        path.write_bytes(b"")
+        paths.append(path)
+    return paths
+
+
+def _runner(tmp_path: Path, **general: Any) -> Runner:
+    return Runner(
+        Namespace(
+            comicbox=Namespace(
+                paths=[str(tmp_path)],
+                general=Namespace(recurse=True, **general),
+            )
+        )
+    )
+
+
+def test_recurse_stops_the_walk_on_abort(tmp_path, monkeypatch) -> None:
+    """An abort on file 2 must not leave files 3..N to be prompted for."""
+    _make_comics(tmp_path, 5)
+    seen: list[str] = []
+
+    def fake_run_on_file(self, path):
+        seen.append(Path(path).name)
+        if len(seen) == 2:
+            raise _abort()
+
+    monkeypatch.setattr(Runner, "run_on_file", fake_run_on_file)
+    runner = _runner(tmp_path)
+
+    with pytest.raises(OnlineLookupAbortedError):
+        runner.recurse(tmp_path)
+
+    assert seen == ["comic_00.cbz", "comic_01.cbz"]
+
+
+def test_recurse_still_swallows_ordinary_file_errors(tmp_path, monkeypatch) -> None:
+    """Batch resilience is intact: a broken comic doesn't end the walk."""
+    _make_comics(tmp_path, 4)
+    seen: list[str] = []
+
+    def fake_run_on_file(self, path):
+        seen.append(Path(path).name)
+        if len(seen) == 2:
+            msg = "corrupt archive"
+            raise ValueError(msg)
+
+    monkeypatch.setattr(Runner, "run_on_file", fake_run_on_file)
+    runner = _runner(tmp_path)
+
+    runner.recurse(tmp_path)
+
+    assert len(seen) == 4
+
+
+# --- Runner: _run_one -------------------------------------------------------
+
+
+def test_run_one_reraises_abort(tmp_path, monkeypatch) -> None:
+    """The per-file guard is where both batch paths pick the abort up."""
+    path = _make_comics(tmp_path, 1)[0]
+    runner = _runner(tmp_path)
+
+    class _AbortingBox:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> bool:
+            return False
+
+        def print_file_header(self) -> None:
+            pass
+
+        def run(self) -> None:
+            raise _abort()
+
+    monkeypatch.setattr("comicbox.run.Comicbox", _AbortingBox)
+
+    with pytest.raises(OnlineLookupAbortedError):
+        runner._run_one(path)
+
+
+def test_run_one_still_swallows_ordinary_errors(tmp_path, monkeypatch) -> None:
+    """A zero-byte cbz still fails softly, as batch resilience requires."""
+    path = _make_comics(tmp_path, 1)[0]
+    runner = _runner(tmp_path)
+
+    runner._run_one(path)  # must not raise
+
+
+# --- Runner: -j N -----------------------------------------------------------
+
+
+def test_parallel_run_aborts_and_drops_queued_files(tmp_path, monkeypatch) -> None:
+    """
+    Abort ends the batch instead of working through the remaining paths.
+
+    Files already in flight can't be interrupted from the collector, but
+    everything still queued is cancelled, so the count of processed files
+    stays near the worker count rather than the whole batch.
+    """
+    paths = _make_comics(tmp_path, 40)
+    started: list[Path] = []
+
+    def fake_run_one(self, path):
+        started.append(path)
+        if path == paths[0]:
+            raise _abort()
+        # Keep the workers busy so the pool can't drain the queue before
+        # the collector sees the abort and cancels what's left.
+        time.sleep(0.05)
+
+    monkeypatch.setattr(Runner, "_run_one", fake_run_one)
+    runner = _runner(tmp_path, jobs=2)
+
+    with pytest.raises(OnlineLookupAbortedError):
+        runner._run_parallel(paths, 2)
+
+    assert len(started) < len(paths)
+
+
+def test_parallel_run_still_swallows_ordinary_errors(tmp_path, monkeypatch) -> None:
+    """One bad comic must not take the rest of the batch down with it."""
+    paths = _make_comics(tmp_path, 6)
+    started: list[Path] = []
+
+    def fake_run_one(self, path):
+        started.append(path)
+        if path == paths[0]:
+            msg = "corrupt archive"
+            raise ValueError(msg)
+
+    monkeypatch.setattr(Runner, "_run_one", fake_run_one)
+    runner = _runner(tmp_path, jobs=2)
+
+    runner._run_parallel(paths, 2)
+
+    assert len(started) == len(paths)
+
+
+# --- ComicVine: the per-volume issue-list loop ------------------------------
+
+
+class _FakeVolume:
+    """Minimal simyan BasicVolume stand-in that clears both pre-filters."""
+
+    id = 77
+    name = "Foo Comics"
+    start_year = 2018
+    aliases = None
+
+
+def _cv_source() -> ComicVineOnlineSource:
+    return ComicVineOnlineSource(OnlineSourceCredentials(key="x"), OnlineSettings())
+
+
+def _cv_profile() -> ComicProfile:
+    return ComicProfile(series="Foo Comics", issue="5", year=2020)
+
+
+def test_comicvine_per_volume_loop_propagates_abort(monkeypatch) -> None:
+    """A cancelled retry sleep inside one volume aborts the whole search."""
+    src = _cv_source()
+
+    def boom(*args, **kwargs):
+        raise _abort()
+
+    monkeypatch.setattr(src, "_list_with_year_retry", boom)
+
+    with pytest.raises(OnlineLookupAbortedError):
+        src._candidates_for_volume(
+            _NO_SESSION,
+            _FakeVolume(),
+            profile=_cv_profile(),
+            issue_number="5",
+            year=2020,
+            name_threshold=0.0,
+        )
+
+
+def test_comicvine_per_volume_loop_still_degrades_on_api_error(monkeypatch) -> None:
+    """An ordinary source-side failure still drops just that volume."""
+    src = _cv_source()
+
+    def boom(*args, **kwargs):
+        msg = "comicvine 500"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(src, "_list_with_year_retry", boom)
+
+    assert (
+        src._candidates_for_volume(
+            _NO_SESSION,
+            _FakeVolume(),
+            profile=_cv_profile(),
+            issue_number="5",
+            year=2020,
+            name_threshold=0.0,
+        )
+        == []
+    )
+
+
+# --- Metron: the ±1 year-retry loop -----------------------------------------
+
+
+def _metron_source() -> MetronOnlineSource:
+    return MetronOnlineSource(
+        OnlineSourceCredentials(user="u", password="p"), OnlineSettings()
+    )
+
+
+def _metron_profile() -> ComicProfile:
+    return ComicProfile(series="Foo Comics", issue="5", year=2020)
+
+
+def test_metron_year_retry_loop_propagates_abort(monkeypatch) -> None:
+    """The Y-1 retry must not swallow an abort to give Y+1 a turn."""
+    src = _metron_source()
+    calls: list[int | None] = []
+
+    def fake_fetch(session, profile, *, cover_year_override, include_volume):
+        calls.append(cover_year_override)
+        if cover_year_override is None:
+            return []  # year-exact miss → the retry cascade runs
+        raise _abort()
+
+    monkeypatch.setattr(src, "_fetch_candidates_by_name", fake_fetch)
+
+    with pytest.raises(OnlineLookupAbortedError):
+        src._search_with_year_retry(_NO_SESSION, _metron_profile(), include_volume=True)
+
+    # Aborted on the first retry; Y+1 never got its turn.
+    assert calls == [None, 2019]
+
+
+def test_metron_year_retry_loop_still_tries_the_sibling_year(monkeypatch) -> None:
+    """An ordinary retry failure still lets the other ±1 year run."""
+    src = _metron_source()
+    calls: list[int | None] = []
+
+    def fake_fetch(session, profile, *, cover_year_override, include_volume):
+        calls.append(cover_year_override)
+        if cover_year_override == 2019:
+            msg = "metron 500"
+            raise RuntimeError(msg)
+        return []
+
+    monkeypatch.setattr(src, "_fetch_candidates_by_name", fake_fetch)
+
+    assert (
+        src._search_with_year_retry(_NO_SESSION, _metron_profile(), include_volume=True)
+        == []
+    )
+    assert calls == [None, 2019, 2021]

--- a/tests/unit/test_online_result_contract.py
+++ b/tests/unit/test_online_result_contract.py
@@ -1,0 +1,443 @@
+"""
+Online-lookup result-contract tests.
+
+Three defects lived in the gap between "we decided to accept a candidate"
+and "the follow-up fetch actually landed":
+
+1. The pinned-id fast paths (``--id`` and the stored-id refresh) returned
+   an unconditional win, so a failed fetch reported ``written`` with
+   nothing written.
+2. ``record_auto_write`` and the ``AutoWritten`` event fired before the
+   fetch, so the summary and the event stream counted wins that never
+   happened.
+3. The prompt loop was unbounded and indexed the candidate list with an
+   unchecked selector-supplied integer.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from comicbox.box import Comicbox
+from comicbox.box.online_lookup import (
+    _MAX_PROMPT_ROUNDS,
+    ComicboxOnlineLookup,
+    _series_fingerprint,
+)
+from comicbox.events import AutoWritten, Event, FileFinished
+from comicbox.formats import MetadataFormats
+from comicbox.formats.base.online import outcome_stats
+from comicbox.formats.base.online.profile import (
+    Candidate,
+    CandidateSummary,
+    ComicProfile,
+)
+from comicbox.formats.sources import MetadataSources
+
+if TYPE_CHECKING:
+    from comicbox.formats.base.online.selector import SelectorContext
+
+
+class _FetchFailedError(Exception):
+    """Stand-in for any source-side failure of the issue fetch."""
+
+
+def setup_function() -> None:
+    outcome_stats.reset()
+
+
+def _payload(issue_id: int) -> dict:
+    return {
+        "id": issue_id,
+        "number": "5",
+        "cover_date": "2020-04-01",
+        "modified": "2020-04-02T12:00:00Z",
+        "publisher": {"id": 1, "name": "Quality Comics"},
+        "series": {"id": 1, "name": "Foo Comics", "year_began": 2020, "volume": 1},
+    }
+
+
+def _candidate(issue_id: int, *, volume_id: int | None = None) -> Candidate:
+    return Candidate(
+        source="metron",
+        issue_id=issue_id,
+        summary=CandidateSummary(
+            series="Foo Comics",
+            issue="5",
+            year=2020,
+            publisher="Quality Comics",
+            page_count=24,
+            cover_url=None,
+            variant_label=None,
+        ),
+        volume_id=volume_id,
+    )
+
+
+class _FakeMetron:
+    """Metron stand-in whose ``get()`` can be made to fail."""
+
+    name = "metron"
+    metadata_source = MetadataSources.METRON_API
+    metadata_format = MetadataFormats.METRON_API
+
+    def __init__(self, credentials, settings, *, candidates=(), fail_get=False) -> None:
+        self._credentials = credentials
+        self._candidates = list(candidates)
+        self._fail_get = fail_get
+        self.get_calls: list[int] = []
+        self.search_calls = 0
+        self.lookup_calls: list[tuple[int, str | None]] = []
+
+    def is_configured(self) -> bool:
+        return bool(self._credentials.user and self._credentials.password)
+
+    def get(self, issue_id: int) -> dict:
+        self.get_calls.append(issue_id)
+        if self._fail_get:
+            msg = f"metron is down (issue {issue_id})"
+            raise _FetchFailedError(msg)
+        return _payload(issue_id)
+
+    def search(self, profile) -> list[Candidate]:
+        self.search_calls += 1
+        return list(self._candidates)
+
+    def lookup_issue(self, volume_id: int, issue_number: str | None):
+        self.lookup_calls.append((volume_id, issue_number))
+        for cand in self._candidates:
+            if cand.volume_id == volume_id:
+                return cand
+        return None
+
+
+class _FakeCV:
+    """Comic Vine stand-in; records whether first-wins let it run."""
+
+    name = "comicvine"
+    metadata_source = MetadataSources.COMICVINE_API
+    metadata_format = MetadataFormats.COMICVINE_API
+
+    def __init__(self, credentials, settings) -> None:
+        self._credentials = credentials
+        self.get_calls: list[int] = []
+        self.search_calls = 0
+
+    def is_configured(self) -> bool:
+        return bool(self._credentials.key)
+
+    def get(self, issue_id: int) -> dict:
+        self.get_calls.append(issue_id)
+        return {"results": _payload(issue_id)}
+
+    def search(self, profile) -> list[Candidate]:
+        self.search_calls += 1
+        return [_candidate(999)]
+
+
+def _patch_metron(monkeypatch, **kwargs) -> list[_FakeMetron]:
+    instances: list[_FakeMetron] = []
+
+    def factory(creds, settings):
+        src = _FakeMetron(creds, settings, **kwargs)
+        instances.append(src)
+        return src
+
+    monkeypatch.setattr(
+        ComicboxOnlineLookup,
+        "_ONLINE_SOURCE_FACTORIES",
+        MappingProxyType({"metron": factory}),
+    )
+    return instances
+
+
+def _patch_both(monkeypatch, **kwargs) -> tuple[list[_FakeMetron], list[_FakeCV]]:
+    metrons: list[_FakeMetron] = []
+    cvs: list[_FakeCV] = []
+
+    def metron_factory(creds, settings):
+        src = _FakeMetron(creds, settings, **kwargs)
+        metrons.append(src)
+        return src
+
+    def cv_factory(creds, settings):
+        src = _FakeCV(creds, settings)
+        cvs.append(src)
+        return src
+
+    monkeypatch.setattr(
+        ComicboxOnlineLookup,
+        "_ONLINE_SOURCE_FACTORIES",
+        MappingProxyType({"metron": metron_factory, "comicvine": cv_factory}),
+    )
+    return metrons, cvs
+
+
+_PROFILE_MD = {
+    "comicbox": {
+        "series": {"name": "Foo Comics"},
+        "issue": {"name": "5"},
+        "date": {"year": 2020},
+        "publisher": {"name": "Quality Comics"},
+        "page_count": 24,
+    }
+}
+
+
+def _build_cb(**overrides: Any) -> Comicbox:
+    kwargs: dict[str, Any] = {
+        "online_sources": ["metron"],
+        "general": Namespace(metadata=_PROFILE_MD),
+        "auth": ["metron:user=u", "metron:pass=p"],
+    }
+    kwargs.update(overrides)
+    return Comicbox(config=Namespace(comicbox=Namespace(**kwargs)))
+
+
+def _run(cb: Comicbox) -> tuple[bool, list[Event]]:
+    events: list[Event] = []
+    cb.set_event_handler(events.append)
+    return cb.run_online_lookup(), events
+
+
+def _outcome(events: list[Event]) -> str | None:
+    for event in events:
+        if isinstance(event, FileFinished):
+            return event.outcome
+    return None
+
+
+# --- 1. a failed pinned fetch is not a win ----------------------------------
+
+
+def test_failed_explicit_id_fetch_reports_no_change(monkeypatch) -> None:
+    """--id whose fetch raises must not report ``written``."""
+    instances = _patch_metron(monkeypatch, fail_get=True)
+    cb = _build_cb(explicit_ids=["metron:42"])
+
+    applied, events = _run(cb)
+
+    assert instances[0].get_calls == [42]
+    assert applied is False
+    assert _outcome(events) == "no_change"
+    assert not [e for e in events if isinstance(e, AutoWritten)]
+    # Nothing landed, so nothing is counted -- not even as an id-fetch.
+    assert outcome_stats.has_any_activity() is False
+
+
+def test_successful_explicit_id_fetch_still_reports_written(monkeypatch) -> None:
+    """The success path is unchanged: applied, announced, counted."""
+    instances = _patch_metron(monkeypatch)
+    cb = _build_cb(explicit_ids=["metron:42"])
+
+    applied, events = _run(cb)
+
+    assert instances[0].get_calls == [42]
+    assert applied is True
+    assert _outcome(events) == "written"
+    assert [e.candidate_summary for e in events if isinstance(e, AutoWritten)] == ["42"]
+    assert "1 fetched by --id" in "\n".join(outcome_stats.summary_lines())
+
+
+def test_failed_explicit_id_fetch_still_claims_the_comic(monkeypatch) -> None:
+    """
+    A pinned id the user gave us suppresses the sibling source either way.
+
+    ``applied`` and ``claimed`` are separate signals: the run honestly
+    reports that nothing was written, but Comic Vine is still kept from
+    fuzzy-matching a comic whose exact issue the user already named.
+    """
+    metrons, cvs = _patch_both(monkeypatch, fail_get=True)
+    cb = _build_cb(
+        online_sources=["metron", "comicvine"],
+        explicit_ids=["metron:42"],
+        auth=["metron:user=u", "metron:pass=p", "comicvine:key=k"],
+    )
+
+    applied, events = _run(cb)
+
+    assert metrons[0].get_calls == [42]
+    assert applied is False
+    assert _outcome(events) == "no_change"
+    # Claimed: CV never searched behind the failed pin.
+    assert cvs[0].search_calls == 0
+    assert cvs[0].get_calls == []
+
+
+def test_failed_stored_id_refresh_reports_no_change(monkeypatch) -> None:
+    """The stored-id fast path has the same contract as --id."""
+    instances = _patch_metron(monkeypatch, fail_get=True)
+    md = {
+        "comicbox": {
+            **_PROFILE_MD["comicbox"],
+            "identifiers": {"metron": {"key": "77"}},
+        }
+    }
+    cb = _build_cb(general=Namespace(metadata=md))
+
+    applied, events = _run(cb)
+
+    assert instances[0].get_calls == [77]
+    assert instances[0].search_calls == 0
+    assert applied is False
+    assert _outcome(events) == "no_change"
+    assert not [e for e in events if isinstance(e, AutoWritten)]
+
+
+def test_successful_stored_id_refresh_reports_written(monkeypatch) -> None:
+    """A landed stored-id refresh is an auto-write, counted as one."""
+    instances = _patch_metron(monkeypatch)
+    md = {
+        "comicbox": {
+            **_PROFILE_MD["comicbox"],
+            "identifiers": {"metron": {"key": "77"}},
+        }
+    }
+    cb = _build_cb(general=Namespace(metadata=md))
+
+    applied, events = _run(cb)
+
+    assert instances[0].get_calls == [77]
+    assert applied is True
+    assert _outcome(events) == "written"
+    assert [e.candidate_summary for e in events if isinstance(e, AutoWritten)] == ["77"]
+
+
+# --- 2. outcome recording happens only after the fetch lands ----------------
+
+
+def test_failed_auto_write_fetch_records_nothing(monkeypatch) -> None:
+    """A cold-path AUTO_WRITE whose fetch fails is not counted or announced."""
+    instances = _patch_metron(monkeypatch, candidates=[_candidate(101)], fail_get=True)
+    cb = _build_cb()
+
+    applied, events = _run(cb)
+
+    assert instances[0].search_calls == 1
+    assert instances[0].get_calls == [101]
+    assert applied is False
+    assert _outcome(events) == "no_change"
+    assert not [e for e in events if isinstance(e, AutoWritten)]
+    assert outcome_stats.has_any_activity() is False
+
+
+def test_failed_series_cache_accept_records_nothing(monkeypatch) -> None:
+    """The warm series-cache path funnels through the same chokepoint."""
+    instances = _patch_metron(
+        monkeypatch, candidates=[_candidate(101, volume_id=42)], fail_get=True
+    )
+    fingerprint = _series_fingerprint(
+        ComicProfile(series="Foo Comics", year=2020, publisher="Quality Comics")
+    )
+    cb = _build_cb()
+    cb.set_series_cache({("metron", fingerprint): 42})
+
+    applied, events = _run(cb)
+
+    assert instances[0].lookup_calls == [(42, "5")]
+    # A source-side failure on the warm path degrades to the cold-path
+    # search (documented in _try_series_cache_lookup), which re-picks the
+    # same issue and fails the same way. Neither attempt may be counted.
+    assert instances[0].get_calls == [101, 101]
+    assert applied is False
+    assert not [e for e in events if isinstance(e, AutoWritten)]
+    assert outcome_stats.has_any_activity() is False
+
+
+def test_failed_prompt_choice_fetch_is_not_counted_as_accepted(monkeypatch) -> None:
+    """A prompt-chosen candidate whose fetch fails isn't a prompt-accepted win."""
+    instances = _patch_metron(
+        monkeypatch,
+        candidates=[_candidate(101), _candidate(102)],
+        fail_get=True,
+    )
+
+    def selector(profile, candidates, ctx):
+        return ("choose", 0)
+
+    cb = _build_cb()
+    cb.set_online_selector(selector)
+
+    applied, _events = _run(cb)
+
+    assert instances[0].get_calls == [101]
+    assert applied is False
+    assert outcome_stats.has_any_activity() is False
+
+
+# --- 3. the prompt loop is bounded, and its index is checked ----------------
+
+
+@pytest.mark.parametrize("index", [2, 7, -1, -5])
+def test_prompt_choose_out_of_range_index_is_declined(monkeypatch, index) -> None:
+    """
+    An out-of-range selector index skips instead of tagging.
+
+    Negative indices are the dangerous half: Python reads them as valid
+    from-the-end lookups, so an unchecked -1 silently tags the comic with
+    the last candidate nobody chose.
+    """
+    instances = _patch_metron(
+        monkeypatch, candidates=[_candidate(101), _candidate(102)]
+    )
+
+    def selector(profile, candidates, ctx):
+        return ("choose", index)
+
+    cb = _build_cb()
+    cb.set_online_selector(selector)
+
+    applied, _events = _run(cb)
+
+    assert instances[0].get_calls == []
+    assert applied is False
+    assert "declined 1" in "\n".join(outcome_stats.summary_lines())
+
+
+def test_prompt_choose_in_range_index_still_works(monkeypatch) -> None:
+    """The bounds check doesn't get in the way of a legitimate choice."""
+    instances = _patch_metron(
+        monkeypatch, candidates=[_candidate(101), _candidate(102)]
+    )
+
+    def selector(profile, candidates, ctx):
+        return ("choose", 1)
+
+    cb = _build_cb()
+    cb.set_online_selector(selector)
+
+    applied, _events = _run(cb)
+
+    assert instances[0].get_calls == [102]
+    assert applied is True
+
+
+def test_prompt_loop_caps_repeated_session_changes(monkeypatch) -> None:
+    """
+    A selector that only ever asks for session changes must terminate.
+
+    ``set_policy`` / ``set_unattended`` re-resolve and re-prompt, so a
+    callback that never returns a terminal action span the loop forever.
+    """
+    instances = _patch_metron(
+        monkeypatch, candidates=[_candidate(101), _candidate(102)]
+    )
+    calls: list[SelectorContext] = []
+
+    def selector(profile, candidates, ctx):
+        calls.append(ctx)
+        return ("set_policy", "ask")
+
+    cb = _build_cb()
+    cb.set_online_selector(selector)
+
+    applied, _events = _run(cb)
+
+    assert len(calls) == _MAX_PROMPT_ROUNDS
+    assert applied is False
+    assert instances[0].get_calls == []
+    assert "declined 1" in "\n".join(outcome_stats.summary_lines())


### PR DESCRIPTION
Audit of the online lookup result contract. Four defects, a test for each.

## 1. Failed pinned-id fetches reported success

`--id` and the stored-id refresh returned an unconditional `True`, and [`_fetch_explicit_id`](comicbox/box/online_lookup.py:440) swallows its errors — so a fetch that never landed still drove `FileFinished.outcome="written"`, `OnlineResult.matched=True`, and the first-wins skip. A batch run counted the comic as tagged and rewrote it with its own existing metadata.

**Decision on the question posed: yes, these are two separate signals.** `_SourceOutcome` now carries:

- `applied` — metadata actually landed. The only signal allowed to report success; feeds `run_online_lookup()`, `FileFinished.outcome`, and `OnlineResult.matched` (whose docstring already promised exactly this).
- `claimed` — the source consumed a pinned identity (a `--id` pin, or an id a prior tag stored on the file). Gates the first-wins skip *only*.

Keeping the claim separate preserves today's fan-out: when the user or the file names an exact issue, a transient API failure must not hand the comic to a sibling source's fuzzy guess. Folding it into the return value is precisely what made a failed pin surface as `written`.

## 2. Outcome recording moved behind a single chokepoint

`record_auto_write` and `AutoWritten` fired *before* `_accept_candidate`, in two places. Rather than reorder each call site, every accepting path now funnels through one `_accept()` that fetches first and records, emits, and populates the series cache only on success — so the mismatch is structurally impossible. `record_prompt_accepted` and `record_explicit_id` get the same treatment.

## 3. Prompt loop bounded, candidate index checked

The `while True` loop only continues on `set_unattended` / `set_policy`, so a selector that never returns a terminal action spun forever. Capped at `_MAX_PROMPT_ROUNDS = 8`, then declines. (This is a loop bound, not a match-quality threshold — `tasks/` holds no calibration doc for it; the only file there is the schema-v3 handoff.)

`candidates[payload]` is now range-checked, mirroring the `IndexError` guard in `OnlineSession._store_prompt_resolution`. Negative indices were the dangerous half: Python reads them as valid from-the-end lookups, so `-1` silently tagged the comic with the last candidate nobody chose.

## 4. Abort propagation

`OnlineLookupAbortedError` was swallowed by four broad handlers, turning "abort the run" into "skip this comic":

| Site | Was | Now |
| --- | --- | --- |
| `run.py` `_run_one` | logged, batch continued | re-raised |
| `run.py` `recurse` | logged, walked on | re-raised |
| `run.py` `_run_parallel` | logged per future | re-raised; queued futures cancelled |
| `comicvine_api` per-volume loop | `return []` | re-raised |
| `comicvine_api` volume filter-search | `return fuzzy` | re-raised |
| `metron_api` year-retry loop | `continue` | re-raised |

All follow the pattern already in `OnlineSource.lookup_issue`. The ComicVine volume filter-search handler wasn't in the original list but swallows the same exception on the same call path, so leaving it would have kept abort unreliable.

**One limitation, stated plainly:** under `-j N` the collector cancels every queued file, but workers already in flight can't be interrupted from there — the pool joins them on the way out. A sibling worker blocked on `_PROMPT_LOCK` can therefore still prompt once after the abort. Fixing that needs a cross-thread abort signal, which is a larger design change than this audit; I left it out rather than introduce process-global state with cross-caller reset hazards (`OnlineSession` is long-lived in codex).

## Tests

24 new tests in `tests/unit/test_online_result_contract.py` and `tests/unit/test_online_abort_propagation.py`. Each defect gets both a failure case and a "the good path still works / ordinary errors still degrade" counterpart, so the abort re-raises can't quietly become "no batch resilience".

## Notes

- The stored-id refresh now records an auto-write. It previously recorded nothing, so successful refreshes were missing from the end-of-run summary; the chokepoint made the gap visible. Log output only.
- `ComicVineOnlineSource.get` and `run_online_lookup` each crossed radon rank C from the added branches. Both had a block extracted to stay under; no other rank-C item in the tree is mine.

## Verification

`make fix`, `make lint`, `make ty` all clean. Full suite: **1571 passed, 1 skipped** (the skip is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)