### PR TITLE
fix(config): four silent config defects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,25 @@
       that writes the format.
     - A MetronInfo `AlternativeName`'s `id` attribute is read. The schema
       dropped it before the transform that handles it ever saw it.
+    - `-c/--config` loads the file it names. The flag parsed into
+      `general.config`, the loader looked for it one level up under `config`,
+      and a `suppress` around the lookup hid the mismatch, so every alternate
+      config file was silently ignored in favor of the defaults.
+    - An unknown `--online` source name is an error instead of a silent
+      widening. Unknown names were dropped with a warning; when every name was
+      unknown, the empty result was the "all sources" sentinel, so a typo like
+      `--online metrn` queried every configured database rather than the one
+      that was asked for. `COMICBOX_ONLINE_SOURCES` and the
+      `online.lookup.sources` config key are checked the same way.
+    - The solo-viable auto-write floor is back at the auto-write threshold.
+      `OnlineTuningSettings.auto_threshold` had drifted to 0.85 while the config
+      file, the `--auto-threshold` help and the matcher all said 0.95, and the
+      solo floor was defined off it, so a lone mediocre match could be written
+      without a prompt — the failure that floor exists to prevent.
+    - Actions needing an archive warn instead of raising when there is no path.
+      `comicbox --rename` and `comicbox -P f` with no file ended in an
+      ArchiveError traceback. The guard that turns those actions off existed but
+      never ran for a CLI run, which passes settings already built.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/box/init.py
+++ b/comicbox/box/init.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, ClassVar
 from zipremove import ZipFile, is_zipfile
 
 from comicbox._pdf import PDF_ENABLED
-from comicbox.config.settings import ComicboxSettings
 from comicbox.enums.comicbox import FileTypeEnum
 from comicbox.exceptions import UnsupportedArchiveTypeError
 
@@ -29,6 +28,7 @@ if TYPE_CHECKING:
 
     from comicbox.box.archive.archiveinfo import InfoType
     from comicbox.box.types import ArchiveType
+    from comicbox.config.settings import ComicboxSettings
     from comicbox.formats import MetadataFormats
     from comicbox.formats.sources import MetadataSources
 else:
@@ -98,15 +98,18 @@ class ComicboxInit:
         ``comicbox.logger.init_logging`` themselves.
         """
         self._path = self._validate_path(path)
-        if isinstance(config, ComicboxSettings):
-            self._config: ComicboxSettings = config
-        else:
-            # Lazy import: comicbox.config imports comicbox.formats which
-            # transitively imports this module — keep the top-level import
-            # graph acyclic.
-            from comicbox.config import get_config
+        # Lazy import: comicbox.config imports comicbox.formats which
+        # transitively imports this module — keep the top-level import
+        # graph acyclic.
+        from comicbox.config import get_config
 
-            self._config = get_config(config, path=self._path, box=True)
+        # An already-built ComicboxSettings goes through get_config too.
+        # Its fast path skips the confuse rebuild but still applies
+        # post_process_set_for_path, which turns off file-requiring
+        # options when there's no path. Short-circuiting around it here
+        # was what made that guard dead for every CLI run: Runner builds
+        # a ComicboxSettings once and hands it to each Comicbox.
+        self._config: ComicboxSettings = get_config(config, path=self._path, box=True)
         self._reset_archive(fmt, metadata)
 
     def _reset_loaded_forward_caches(self) -> None:

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 
 from comicbox._pdf import PAGE_FORMAT_VALUES, PDF_ENABLED
 from comicbox.cli.epilog import build_epilog
+from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD
 
 # Tracks one-shot stderr warnings so we don't spam users on repeated flag use.
 _WARNED_FLAGS: set[str] = set()
@@ -562,7 +563,8 @@ def _add_online_tuning_group(parser: ArgumentParser) -> None:
         dest="auto_threshold",
         help=(
             "Global auto-write threshold in [green][0, 1][/green]. Default "
-            "[green]0.95[/green]. Per-source overrides via YAML only."
+            f"[green]{DEFAULT_AUTO_THRESHOLD}[/green]. "
+            "Per-source overrides via YAML only."
         ),
     )
     group.add_argument(

--- a/comicbox/config/online.py
+++ b/comicbox/config/online.py
@@ -30,6 +30,7 @@ from typing import Any, TypeVar
 from loguru import logger
 
 from comicbox.config.settings import (
+    DEFAULT_AUTO_THRESHOLD,
     CacheMode,
     Effort,
     MatchMode,
@@ -351,7 +352,9 @@ def _build_tuning(
         online_block.tuning.auto_threshold,
     )
     auto_threshold = (
-        float(auto_threshold_raw) if auto_threshold_raw is not None else 0.95
+        float(auto_threshold_raw)
+        if auto_threshold_raw is not None
+        else DEFAULT_AUTO_THRESHOLD
     )
     effort_raw = _coalesce(
         cli("effort"), online_env.get("effort"), online_block.tuning.effort
@@ -406,25 +409,31 @@ def _split_source_names(value: Any) -> tuple[str, ...]:
 
 def _normalize_sources(value: Any, *, origin: str) -> tuple[str, ...] | None:
     """
-    Normalize a sources list from env/config into an ordered tuple.
+    Normalize a sources list from CLI/env/config into an ordered tuple.
 
     Returns None when the value is absent (fall through to the next
     layer), ALL_SOURCES when it's empty or contains the ``all``
     sentinel, and otherwise an order-preserving dedupe of the listed
-    names. Unknown names warn and drop rather than failing the run.
+    names.
+
+    Unknown names raise. Dropping them used to leave an all-unknown
+    selection empty, which is the ALL_SOURCES sentinel — so a typo in
+    ``--online metrn`` silently widened the run to *every* source
+    instead of narrowing it to the one the user asked for. Matches
+    ``--id``/``--series-id``, which have always rejected unknown names.
     """
     if value is None:
         return None
     names = _split_source_names(value)
     if not names or "all" in names:
         return ALL_SOURCES
-    unknown = tuple(n for n in names if n not in SOURCE_NAMES)
-    if unknown:
-        logger.warning(
-            f"online: ignoring unknown source(s) {', '.join(unknown)} from "
-            f"{origin}; known: {', '.join(SOURCE_NAMES)}"
+    if unknown := tuple(n for n in names if n not in SOURCE_NAMES):
+        reason = (
+            f"{origin}: unknown source(s) {', '.join(unknown)}; "
+            f"known: {', '.join(SOURCE_NAMES)}"
         )
-    return tuple(n for n in names if n in SOURCE_NAMES)
+        raise ValueError(reason)
+    return names
 
 
 def _resolve_runtime_sources(

--- a/comicbox/config/read.py
+++ b/comicbox/config/read.py
@@ -1,21 +1,40 @@
 """Read and layer config sources."""
 
-import contextlib
 from argparse import Namespace
 from collections.abc import Mapping
+from pathlib import Path
 
 from confuse import Configuration
 from loguru import logger
 
 
+def _config_path(args: Namespace | Mapping) -> str | Path | None:
+    """
+    Pull ``comicbox.general.config`` out of either args shape.
+
+    ``-c/--config`` parses to the ``general_config`` dest, which
+    ``post_process_args`` folds into ``args.comicbox.general.config``.
+    Look it up explicitly: a blanket ``suppress(AttributeError)`` here
+    is what let the key path drift out of sync silently.
+    """
+    if isinstance(args, Namespace):
+        comicbox = getattr(args, "comicbox", None)
+        general = getattr(comicbox, "general", None)
+        return getattr(general, "config", None)
+    comicbox = args.get("comicbox")
+    if not isinstance(comicbox, Mapping):
+        return None
+    general = comicbox.get("general")
+    if not isinstance(general, Mapping):
+        return None
+    config_fn = general.get("config")
+    return config_fn if isinstance(config_fn, str | Path) else None
+
+
 def _add_config_file(args: Namespace | Mapping, config: Configuration) -> None:
-    with contextlib.suppress(AttributeError, KeyError):
-        if config_fn := (
-            args.comicbox.config
-            if isinstance(args, Namespace)
-            else args["comicbox"]["config"]
-        ):
-            config.set_file(config_fn)
+    if config_fn := _config_path(args):
+        # confuse's set_file takes a str; the config key accepts either.
+        config.set_file(str(config_fn))
 
 
 def read_config_sources(

--- a/comicbox/config/settings.py
+++ b/comicbox/config/settings.py
@@ -85,16 +85,21 @@ class CacheMode(str, Enum):
     REFRESH = "refresh"
 
 
+# Global auto-write threshold. The single source of truth for this
+# number: ``config_default.yaml`` must declare the same value, and
+# ``tests/unit/test_config_defaults_drift.py`` proves it still does.
+DEFAULT_AUTO_THRESHOLD = 0.95
+
 # Built-in defaults for per-source tuning knobs. Internal — not surfaced
 # in user-facing CLI/docs but available as per-source YAML overrides.
 DEFAULT_MIN_CONFIDENCE = 0.50
 DEFAULT_DISAMBIGUATION_MARGIN = 0.10
 # Solo-viable auto-write floor. When the matcher returns exactly one
 # candidate clearing ``min_confidence``, ``AUTO``/``EAGER`` modes
-# auto-write only if it also clears this floor. Default equals the
-# global confidence threshold (0.95), so solo cases need the same bar
-# as multi-candidate unambiguous wins.
-DEFAULT_SOLO_THRESHOLD = 0.85
+# auto-write only if it also clears this floor. Equals the global
+# auto-write threshold, so solo cases need the same bar as
+# multi-candidate unambiguous wins.
+DEFAULT_SOLO_THRESHOLD = DEFAULT_AUTO_THRESHOLD
 
 
 @dataclass(frozen=True, slots=True)
@@ -314,7 +319,7 @@ class OnlineTuningSettings:
     """Global tuning defaults plus per-source overrides."""
 
     # Global defaults.
-    auto_threshold: float = 0.85
+    auto_threshold: float = DEFAULT_AUTO_THRESHOLD
     effort: Effort = Effort.BALANCED
     retry_budget: int = 5
 

--- a/comicbox/formats/base/online/matcher.py
+++ b/comicbox/formats/base/online/matcher.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Final
 from loguru import logger
 
 from comicbox.config.settings import (
+    DEFAULT_AUTO_THRESHOLD,
     MatchMode,
     resolve_auto_threshold,
     resolve_disambiguation_margin,
@@ -64,7 +65,7 @@ W_COVER = 0.20
 # Default constant kept here for the rank() default-arg signature; the
 # matcher reads per-source values via `resolve_*` helpers in `_resolve_policy`
 # and `_should_invoke_hashing` so per-source overrides take effect.
-_DEFAULT_CONFIDENCE_THRESHOLD = 0.95
+_DEFAULT_CONFIDENCE_THRESHOLD = DEFAULT_AUTO_THRESHOLD
 
 
 class ResolutionKind(str, Enum):

--- a/tests/unit/test_config_defaults_drift.py
+++ b/tests/unit/test_config_defaults_drift.py
@@ -1,0 +1,255 @@
+"""
+The dataclass defaults and ``config_default.yaml`` must not drift apart.
+
+comicbox declares every default twice: once as a ``ComicboxSettings``
+dataclass default and once in ``config_default.yaml``. The YAML wins at
+runtime (``get_config`` builds from the confuse view), so a dataclass
+default that disagrees is a silent lie — it only surfaces for code that
+constructs the dataclass directly.
+
+That is exactly how ``OnlineTuningSettings.auto_threshold`` ended up at
+0.85 while the YAML, the ``--auto-threshold`` help text, and the
+matcher's own constant all said 0.95 — and, through
+``DEFAULT_SOLO_THRESHOLD``, dropped the solo-viable auto-write floor to
+a value Phase E was written to forbid.
+
+This test walks the two trees together in both directions:
+
+* every YAML key must have a dataclass field, with an equal default;
+* every dataclass field must have a YAML key, unless it's declared
+  below as runtime-only or structural.
+
+Two normalizations keep it about *values* rather than spelling:
+enums/paths/collections are reduced to comparable primitives, and any
+two "empty" defaults agree (``null`` vs ``False`` vs ``""`` vs ``[]``).
+Numbers are never empty, so ``0.85`` vs ``0.95`` still fails.
+
+Both exception maps are checked for staleness: fix a divergence without
+deleting its entry here and this test fails, so the lists can't rot into
+a permanent excuse.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from comicbox.config.online import _parse_ttl
+from comicbox.config.settings import (
+    ComicboxSettings,
+    ComputeSettings,
+    ConvertSettings,
+    GeneralSettings,
+    OnlineSettings,
+    PrintSettings,
+    ReadSettings,
+    WriteSettings,
+)
+from comicbox.version import PACKAGE_NAME
+
+_DEFAULT_YAML_PATH = Path("comicbox/config_default.yaml")
+
+# Every group dataclass instantiated bare — this is the "what a
+# ComicboxSettings believes by itself" side of the comparison. A new
+# group without full defaults breaks here, on purpose.
+_DEFAULTS = ComicboxSettings(
+    general=GeneralSettings(),
+    read=ReadSettings(),
+    write=WriteSettings(),
+    print=PrintSettings(),
+    convert=ConvertSettings(),
+    compute=ComputeSettings(),
+    online=OnlineSettings(),
+)
+
+# YAML key -> dataclass field name, where they can't match.
+_FIELD_ALIASES = {"read.except": "except_formats"}
+
+# Paths whose YAML text needs decoding before comparison.
+_VALUE_DECODERS = {"online.cache.ttl": _parse_ttl}
+
+# YAML keys whose dataclass default deliberately differs. Keep the
+# reason; drop the entry when the divergence goes away.
+_KNOWN_DIVERGENCES = {
+    "read.formats": (
+        "The YAML enumerates the nine formats read by default. The "
+        "dataclass can't: MetadataFormats is a TYPE_CHECKING-only import "
+        "in settings.py (importing it for real would cycle through "
+        "comicbox.formats), so the field defaults to an empty frozenset "
+        "and the YAML is the only source of the real list."
+    ),
+    "online.auth": (
+        "Structural, not a value difference: the YAML nests one block "
+        "per source (metron:, comicvine:), the dataclass holds a single "
+        "OnlineAuthSettings.sources mapping keyed by source name. "
+        "test_no_credentials_are_defaulted_in_yaml covers the leaves."
+    ),
+}
+
+# Dataclass fields with no YAML key, and why they don't need one.
+_NO_YAML_KEY = {
+    "write.mode": "Derived from the deprecated `replace` bool at build time.",
+    "online.lookup.enabled": "Runtime-only: set by --online, never persisted.",
+    "online.lookup.ids": "Runtime-only: set by --id.",
+    "online.lookup.series_ids": "Runtime-only: set by --series-id.",
+    "online.auth.sources": "See the online.auth divergence note above.",
+    "all_write_formats": "Computed by compute_config().",
+    "read_filename_formats": "Computed by compute_config().",
+    "read_file_formats": "Computed by compute_config().",
+    "read_metadata_lower_filenames": "Computed by compute_config().",
+    "is_read_comments": "Computed by compute_config().",
+    "is_skip_computed_from_tags": "Computed by compute_config().",
+}
+
+
+def _load_yaml_defaults() -> dict[str, Any]:
+    with _DEFAULT_YAML_PATH.open(encoding="utf-8") as yaml_file:
+        return yaml.safe_load(yaml_file)[PACKAGE_NAME]
+
+
+def _is_empty(value: Any) -> bool:
+    """Treat every flavor of "unset" as the same. Numbers are never empty."""
+    if value is None or value is False:
+        return True
+    return (
+        isinstance(value, str | tuple | list | set | frozenset | Mapping) and not value
+    )
+
+
+def _normalize(value: Any) -> Any:
+    """Reduce a default to something comparable across YAML and Python."""
+    if _is_empty(value):
+        return None
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _normalize(item) for key, item in value.items()}
+    if isinstance(value, set | frozenset | tuple | list):
+        return tuple(sorted(str(_normalize(item)) for item in value))
+    # str / bool / int / float / timedelta compare as themselves.
+    return value
+
+
+def _walk(yaml_node: Mapping[str, Any], settings: Any, prefix: str = "") -> None:
+    """Compare one YAML mapping against the dataclass that mirrors it."""
+    field_names = {f.name for f in fields(settings)}
+    seen: set[str] = set()
+
+    for key, yaml_value in yaml_node.items():
+        path = f"{prefix}{key}"
+        if path in _KNOWN_DIVERGENCES:
+            # Still record the field so the reverse check stays honest.
+            seen.add(_FIELD_ALIASES.get(path, key))
+            continue
+        name = _FIELD_ALIASES.get(path, key)
+        assert name in field_names, (
+            f"{path}: config_default.yaml declares a key with no "
+            f"ComicboxSettings field. Add the field or drop the key."
+        )
+        seen.add(name)
+        value = getattr(settings, name)
+        if is_dataclass(value) and isinstance(yaml_value, Mapping):
+            _walk(yaml_value, value, f"{path}.")
+            continue
+        decoder = _VALUE_DECODERS.get(path)
+        decoded = decoder(yaml_value) if decoder else yaml_value
+        assert _normalize(decoded) == _normalize(value), (
+            f"{path}: config_default.yaml says {yaml_value!r} but the "
+            f"dataclass default is {value!r}. The YAML wins at runtime, so "
+            f"the dataclass is lying to anyone who builds it directly."
+        )
+
+    for name in field_names - seen:
+        path = f"{prefix}{name}"
+        assert path in _NO_YAML_KEY, (
+            f"{path}: ComicboxSettings field with no config_default.yaml "
+            f"key. Add the key, or declare it in _NO_YAML_KEY with a reason."
+        )
+
+
+def test_dataclass_defaults_match_yaml_defaults() -> None:
+    """Every shared default agrees, in both directions."""
+    _walk(_load_yaml_defaults(), _DEFAULTS)
+
+
+def test_auto_threshold_default_agrees_everywhere() -> None:
+    """
+    The specific drift that motivated this file, pinned by name.
+
+    The generic walk above covers it, but this failure message is the
+    one worth reading when someone edits a threshold.
+    """
+    from comicbox.config.settings import (
+        DEFAULT_AUTO_THRESHOLD,
+        DEFAULT_SOLO_THRESHOLD,
+        OnlineTuningSettings,
+    )
+
+    yaml_value = _load_yaml_defaults()["online"]["tuning"]["auto_threshold"]
+    assert OnlineTuningSettings().auto_threshold == DEFAULT_AUTO_THRESHOLD
+    assert yaml_value == DEFAULT_AUTO_THRESHOLD
+    # Phase E's solo-viable floor is defined as "the same bar as a
+    # multi-candidate unambiguous win". Below it, a lone mediocre
+    # candidate auto-writes silently.
+    assert DEFAULT_SOLO_THRESHOLD == DEFAULT_AUTO_THRESHOLD
+
+
+def test_no_credentials_are_defaulted_in_yaml() -> None:
+    """The auth blocks are exempt from the walk, so check them directly."""
+    auth = _load_yaml_defaults()["online"]["auth"]
+    for source, block in auth.items():
+        for key, value in block.items():
+            assert value is None, (
+                f"online.auth.{source}.{key} ships a non-null default "
+                f"({value!r}). Credentials must never have one."
+            )
+
+
+def test_divergence_exceptions_are_not_stale() -> None:
+    """
+    Every declared exception must still describe a real divergence.
+
+    Without this, fixing a drift leaves a dead entry behind that would
+    hide the next one at the same path.
+    """
+    yaml_defaults = _load_yaml_defaults()
+    for path in _KNOWN_DIVERGENCES:
+        node: Any = yaml_defaults
+        settings: Any = _DEFAULTS
+        parts = path.split(".")
+        for part in parts[:-1]:
+            node = node[part]
+            settings = getattr(settings, part)
+        leaf = parts[-1]
+        assert leaf in node, f"{path}: declared as divergent but gone from the YAML."
+        name = _FIELD_ALIASES.get(path, leaf)
+        if not hasattr(settings, name):
+            continue  # structural: no field to compare against.
+        yaml_value = node[leaf]
+        value = getattr(settings, name)
+        if is_dataclass(value) and isinstance(yaml_value, Mapping):
+            continue  # structural subtree.
+        assert _normalize(yaml_value) != _normalize(value), (
+            f"{path}: no longer diverges. Delete its _KNOWN_DIVERGENCES entry."
+        )
+
+
+def test_no_yaml_key_exceptions_are_not_stale() -> None:
+    """A field listed as YAML-less must really be absent from the YAML."""
+    yaml_defaults = _load_yaml_defaults()
+    for path in _NO_YAML_KEY:
+        node: Any = yaml_defaults
+        parts = path.split(".")
+        for part in parts[:-1]:
+            node = node.get(part, {})
+        assert parts[-1] not in node, (
+            f"{path}: now has a config_default.yaml key. Delete its "
+            f"_NO_YAML_KEY entry so its default gets compared."
+        )

--- a/tests/unit/test_config_file_option.py
+++ b/tests/unit/test_config_file_option.py
@@ -1,0 +1,109 @@
+"""
+End-to-end tests for ``-c/--config``: an alternate config file must bite.
+
+Regression: ``-c`` parses to the ``general_config`` argparse dest, which
+``post_process_args`` folds into ``args.comicbox.general.config``.
+``read_config_sources`` read ``args.comicbox.config`` — one level too
+shallow — inside a blanket ``contextlib.suppress(AttributeError,
+KeyError)``. The lookup raised, the suppress swallowed it, and every
+``-c`` run silently used the built-in defaults. Nothing warned, and no
+test compared behavior with and without the flag.
+
+These tests assert on *resulting settings*, not on the key path, so they
+stay honest if the args reshaping moves again.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+import pytest
+from confuse import ConfigReadError
+
+from comicbox.cli import get_args
+from comicbox.config import get_config
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+# Values deliberately unlike the config_default.yaml defaults
+# (recurse False, dest_path ".", jobs 1, auto_threshold 0.95).
+_ALT_CONFIG = """
+comicbox:
+  general:
+    recurse: True
+    dest_path: /tmp/comicbox-alt-dest
+    jobs: 4
+  online:
+    tuning:
+      auto_threshold: 0.42
+"""
+
+
+@pytest.fixture
+def alt_config(tmp_path: Path) -> Path:
+    """Write an alternate config file that differs from every default."""
+    path = tmp_path / "alt.yaml"
+    path.write_text(_ALT_CONFIG)
+    return path
+
+
+def _assert_is_default(args: Namespace | Mapping) -> None:
+    settings = get_config(args)
+    assert settings.general.recurse is False
+    assert str(settings.general.dest_path) == "."
+    assert settings.general.jobs == 1
+    assert settings.online.tuning.auto_threshold == 0.95
+
+
+def _assert_is_alternate(args: Namespace | Mapping) -> None:
+    settings = get_config(args)
+    assert settings.general.recurse is True
+    assert str(settings.general.dest_path) == "/tmp/comicbox-alt-dest"
+    assert settings.general.jobs == 4
+    assert settings.online.tuning.auto_threshold == 0.42
+
+
+def test_baseline_without_config_flag() -> None:
+    """Without ``-c`` the bundled defaults win. Pins the contrast case."""
+    _assert_is_default(Namespace(comicbox=get_args(("comicbox", "x.cbz"))))
+
+
+def test_cli_config_file_changes_behavior(alt_config: Path) -> None:
+    """``-c FILE`` through the real CLI parser must change the settings."""
+    cns = get_args(("comicbox", "-c", str(alt_config), "x.cbz"))
+    _assert_is_alternate(Namespace(comicbox=cns))
+
+
+def test_long_config_flag_changes_behavior(alt_config: Path) -> None:
+    """``--config FILE`` is the same path as ``-c``."""
+    cns = get_args(("comicbox", "--config", str(alt_config), "x.cbz"))
+    _assert_is_alternate(Namespace(comicbox=cns))
+
+
+def test_mapping_config_file_changes_behavior(alt_config: Path) -> None:
+    """The Mapping args shape honors the same nested key."""
+    _assert_is_alternate({"comicbox": {"general": {"config": str(alt_config)}}})
+
+
+def test_cli_args_still_beat_the_config_file(alt_config: Path) -> None:
+    """
+    Layering order survives the fix: CLI args sit above the ``-c`` file.
+
+    ``read_config_sources`` adds the ``-c`` file before ``set_args``, so
+    an explicit flag must still win over the same key in the file.
+    """
+    cns = get_args(("comicbox", "-c", str(alt_config), "-j", "7", "x.cbz"))
+    settings = get_config(Namespace(comicbox=cns))
+    assert settings.general.jobs == 7  # CLI beats the file
+    assert settings.general.recurse is True  # file still supplies the rest
+
+
+def test_missing_config_file_errors(tmp_path: Path) -> None:
+    """A ``-c`` path that doesn't exist must fail loudly, not fall back."""
+    missing = tmp_path / "nope.yaml"
+    cns = get_args(("comicbox", "-c", str(missing), "x.cbz"))
+    with pytest.raises(ConfigReadError):
+        get_config(Namespace(comicbox=cns))

--- a/tests/unit/test_config_no_path_guard.py
+++ b/tests/unit/test_config_no_path_guard.py
@@ -1,0 +1,75 @@
+"""
+The no-path guard must fire for a pre-built ``ComicboxSettings`` too.
+
+``post_process_set_for_path`` turns off the options that need an archive
+(cbz, rename, page/cover extraction, writes, the file-type/file-names
+print phases) and warns once, so a pathless run ends with a readable
+message instead of an exception from deep inside the archive layer.
+
+It was dead for every CLI run. ``Runner`` builds one ``ComicboxSettings``
+and hands the same object to each ``Comicbox``, and ``Comicbox.__init__``
+short-circuited on ``isinstance(config, ComicboxSettings)`` — skipping
+``get_config``, and with it the guard. Only the Namespace/Mapping
+constructor paths (i.e. tests and library callers) ever saw it. So
+``comicbox --rename`` with no path raised ArchiveWriteError with a
+traceback rather than warning that rename needs a file.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from comicbox import cli
+from comicbox.box import Comicbox
+from comicbox.config import get_config
+from comicbox.print import PrintPhases
+from tests.const import CIX_CBZ_SOURCE_PATH
+
+
+def _settings(**convert: object):
+    """Build real settings for a pathless run with convert actions on."""
+    return get_config(Namespace(comicbox=Namespace(convert=Namespace(**convert))))
+
+
+def test_prebuilt_settings_still_hit_the_guard() -> None:
+    """A ComicboxSettings passed straight in must be path-post-processed."""
+    settings = _settings(rename=True, cbz=True)
+    # Sanity: the guard hasn't fired yet — get_config's box=False default
+    # leaves the actions on for a Runner that hasn't picked a file.
+    assert settings.convert.rename is True
+    assert settings.convert.cbz is True
+
+    with Comicbox(None, config=settings) as car:
+        assert car._config.convert.rename is False
+        assert car._config.convert.cbz is False
+
+
+def test_guard_leaves_settings_alone_when_a_path_is_present() -> None:
+    """With a real archive the actions must survive untouched."""
+    settings = _settings(cbz=True)
+    with Comicbox(CIX_CBZ_SOURCE_PATH, config=settings) as car:
+        assert car._config.convert.cbz is True
+
+
+def test_pathless_print_phases_are_dropped() -> None:
+    """file-type / file-names can't be printed without a file."""
+    settings = get_config(Namespace(comicbox=Namespace(print=Namespace(phases="tfp"))))
+    assert PrintPhases.FILE_TYPE in settings.print.phases
+
+    with Comicbox(None, config=settings) as car:
+        phases = car._config.print.phases
+        assert PrintPhases.FILE_TYPE not in phases
+        assert PrintPhases.FILE_NAMES not in phases
+        # The metadata phase doesn't need a file, so it stays.
+        assert PrintPhases.METADATA in phases
+
+
+def test_pathless_cli_run_warns_instead_of_raising() -> None:
+    """
+    End-to-end: the CLI path that used to traceback now warns.
+
+    ``comicbox --rename`` with no paths reached ``rename_file()`` and
+    raised ArchiveWriteError. Nothing in the serial run loop catches it,
+    so the user got a stack trace for a plain usage mistake.
+    """
+    cli.main(("comicbox", "--rename", "--cbz"))  # must not raise

--- a/tests/unit/test_config_online_sources.py
+++ b/tests/unit/test_config_online_sources.py
@@ -1,0 +1,81 @@
+"""
+Unknown online source names must fail loudly, not widen the run.
+
+Regression: ``_normalize_sources`` warned about unknown names and
+dropped them. When *every* name was unknown the survivors were the
+empty tuple — which is the ``ALL_SOURCES`` sentinel meaning "query every
+configured source". So ``--online metrn`` (a typo) didn't narrow the run
+to Metron, it silently broadened it to Metron *and* Comic Vine, burning
+API budget on a source the user never named. The same collapse applied
+to the env and config-file layers.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from comicbox.cli import get_args
+from comicbox.config import get_config
+from comicbox.formats.base.online import SOURCE_NAMES
+
+
+def _settings_for_online(value: str):
+    return get_config(Namespace(comicbox=get_args(("comicbox", "-o", value, "x.cbz"))))
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["bogus", "metrn", "bogus,nonsense", "metron,bogus", "bogus,metron"],
+)
+def test_unknown_cli_source_raises(value: str) -> None:
+    """Any unknown name in ``--online`` aborts, even alongside a valid one."""
+    with pytest.raises(ValueError, match="unknown source"):
+        _settings_for_online(value)
+
+
+def test_unknown_source_error_names_the_flag_and_the_valid_set() -> None:
+    """The message has to be actionable: what was wrong, what's allowed."""
+    with pytest.raises(ValueError, match="unknown source") as exc_info:
+        _settings_for_online("metrn")
+    message = str(exc_info.value)
+    assert "--online" in message
+    assert "metrn" in message
+    for name in SOURCE_NAMES:
+        assert name in message
+
+
+def test_known_source_selects_only_that_source() -> None:
+    """The whole point of naming a source: nothing else runs."""
+    settings = _settings_for_online("metron")
+    assert settings.online.lookup.enabled is True
+    assert settings.online.lookup.sources == ("metron",)
+
+
+def test_all_sentinel_still_selects_everything() -> None:
+    """``--online all`` keeps meaning "every configured source"."""
+    settings = _settings_for_online("all")
+    assert settings.online.lookup.enabled is True
+    # None / the empty ALL_SOURCES tuple both mean "every source".
+    assert not settings.online.lookup.sources
+
+
+def test_empty_source_list_still_selects_everything() -> None:
+    """An empty value names nothing, so it keeps meaning "every source"."""
+    settings = _settings_for_online("")
+    assert settings.online.lookup.enabled is True
+    assert not settings.online.lookup.sources
+
+
+def test_unknown_env_source_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The env layer collapses the same way; it has to raise too."""
+    monkeypatch.setenv("COMICBOX_ONLINE_SOURCES", "bogus")
+    with pytest.raises(ValueError, match="unknown source"):
+        get_config(Namespace(comicbox=get_args(("comicbox", "-o", "x.cbz"))))
+
+
+def test_unknown_config_file_source_raises() -> None:
+    """So does a stale ``online.lookup.sources`` key in a config file."""
+    with pytest.raises(ValueError, match="unknown source"):
+        get_config({"comicbox": {"online": {"lookup": {"sources": ["bogus"]}}}})

--- a/tests/unit/test_online.py
+++ b/tests/unit/test_online.py
@@ -287,12 +287,21 @@ def test_online_cli_all_overrides_durable_selection(
     assert cfg.online.lookup.sources is None
 
 
-def test_online_sources_unknown_names_warn_and_drop(
+def test_online_sources_unknown_names_raise(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """
+    An unknown source name aborts instead of being dropped.
+
+    Dropping was silent in both directions: a mixed list quietly
+    narrowed (asking for comicvine + gcd got only comicvine), and an
+    all-unknown list left the empty ALL_SOURCES sentinel behind, which
+    widened the run to every source. See
+    tests/unit/test_config_online_sources.py.
+    """
     monkeypatch.setenv("COMICBOX_ONLINE_SOURCES", "comicvine,grand_comics_db")
-    cfg = get_config()
-    assert cfg.online.lookup.sources == ("comicvine",)
+    with pytest.raises(ValueError, match="unknown source"):
+        get_config()
 
 
 def test_first_wins_defaults_true() -> None:


### PR DESCRIPTION
Four config defects that all failed the same way: no error, no warning, wrong behavior. Each was reproduced before the fix and re-checked after.

## 1. `-c/--config` was ignored entirely

`-c` parses to the `general_config` dest, which `post_process_args` folds into `args.comicbox.general.config`. `comicbox/config/read.py` looked up `args.comicbox.config` — one level too shallow — inside a blanket `suppress(AttributeError, KeyError)` that swallowed the resulting `AttributeError`. Every alternate config file silently lost to the defaults.

Before / after, same file setting `recurse`, `dest_path`, `jobs` and `auto_threshold`:

```
before:  recurse: False  dest: .              auto_threshold: 0.95
after:   recurse: True   dest: /tmp/altdest   auto_threshold: 0.42
```

The key is now looked up explicitly for both args shapes, and the suppress that hid the mismatch is gone — a missing `-c` file raises `ConfigReadError` instead of silently falling back.

## 2. An unknown `--online` source *widened* the run

`_normalize_sources` warned about unknown names and dropped them. When every name was unknown the survivors were the empty tuple — which is the `ALL_SOURCES` sentinel meaning "query every configured source". So `--online metrn` didn't narrow the run to Metron, it broadened it to Metron **and** Comic Vine, spending API budget on a source the user never named. A mixed list (`comicvine,grand_comics_db`) narrowed silently instead.

Unknown names now raise, at all three layers (`--online`, `COMICBOX_ONLINE_SOURCES`, `online.lookup.sources`), matching `--id`/`--series-id` which have always rejected them:

```
ValueError: --online: unknown source(s) metrn; known: metron, comicvine
```

**This is the one behavior change with a blast radius beyond the bug:** a config file or env var naming a stale source now fails the run instead of warning. That is deliberate — leaving those layers as warn-and-drop would have preserved the identical collapse-to-ALL bug there. Easy to narrow to the CLI layer only if you'd rather.

## 3. `auto_threshold` was declared four times and disagreed once

`config_default.yaml`, `config/online.py`'s fallback, the `--auto-threshold` help text and the matcher's own constant all said `0.95`. `OnlineTuningSettings.auto_threshold` said `0.85`.

That is not just cosmetic. `DEFAULT_SOLO_THRESHOLD` is documented as "equals the global confidence threshold, so solo cases need the same bar as multi-candidate unambiguous wins" — but was hardcoded to `0.85` as well, dropping Phase E's solo-viable floor into the exact band it was written to catch. With the shipped defaults, the 0.881-scoring lone candidate from `test_solo_viable_below_floor_prompts_under_normal` (the Groo / Wanted Dossier silent-failure pattern) auto-wrote:

```
score 0.8812  ->  ResolutionKind.AUTO_WRITE     # before
score 0.8812  ->  ResolutionKind.PROMPT         # after
```

The existing matcher tests missed this by pinning the floor explicitly ("this test documents the gating mechanism, not whatever the global default happens to be") rather than exercising the default.

All four sites now read a single `DEFAULT_AUTO_THRESHOLD`, and the parser's help text interpolates it instead of restating it.

## 4. The no-path guard was dead for every CLI run

`post_process_set_for_path` turns off options that need an archive and warns once. `Runner` builds one `ComicboxSettings` and hands the same object to each `Comicbox`, and `Comicbox.__init__` short-circuited on `isinstance(config, ComicboxSettings)` — skipping `get_config`, and with it the guard. Only the Namespace/Mapping constructor paths (tests, library callers) ever saw it.

So a plain usage mistake produced a stack trace:

```
comicbox --rename    ArchiveWriteError: Cannot rename archive without a path.   (traceback)
comicbox -P f        ArchiveError: Cannot read archive without a path.          (traceback)
```

Now:

```
WARNING | Cannot perform action 'rename' without an archive path.
WARNING | No action performed
```

**Verdict: restore it.** The fix routes pre-built settings through `get_config` too — its `ComicboxSettings` fast path skips the confuse rebuild but still applies the guard, so this deletes the branch rather than adding one. Every in-tree call site that passes a `ComicboxSettings` also passes a real path, where the guard is a no-op.

## Tests

- **`test_config_file_option.py`** — the end-to-end `-c` test that was missing. Asserts on *resulting settings*, not the key path, so it stays honest if the args reshaping moves again. Covers both args shapes, CLI args still beating the `-c` file, and a missing file erroring.
- **`test_config_defaults_drift.py`** — walks the dataclass defaults against `config_default.yaml` in both directions: every YAML key needs a field with an equal default, every field needs a YAML key unless declared runtime-only or structural. Enums/paths/collections normalize to comparable primitives and any two "empty" defaults agree (`null` vs `False` vs `""` vs `[]`), but numbers are never empty so `0.85` vs `0.95` fails. Both exception maps are staleness-checked, so fixing a divergence without deleting its entry fails the test.
- **`test_config_online_sources.py`** — unknown names rejected at CLI, env and config layers; `all` and empty still mean every source.
- **`test_config_no_path_guard.py`** — pre-built settings hit the guard, a real path leaves settings untouched, and the pathless CLI run no longer raises.

Each new test was confirmed to fail against the unfixed code: the drift test reports the 0.85 mismatch by name, and three of the four guard tests fail with the short-circuit reinstated.

`test_online_sources_unknown_names_warn_and_drop` asserted the old drop-silently contract; it's updated to expect the error and renamed.

## Checks

`make fix`, `make lint`, `make ty` all clean. Full suite: **1617 passed, 1 skipped** — re-run after rebasing onto current `develop` (#177, #178).

Note: the `effort` and `api-budget` knobs were left alone — they govern API fan-out only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
