### PR TITLE
fix(merge): decouple the read merge from write settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -139,6 +139,19 @@
       `comicbox --rename` and `comicbox -P f` with no file ended in an
       ArchiveError traceback. The guard that turns those actions off existed but
       never ran for a CLI run, which passes settings already built.
+    - Reading metadata no longer depends on write settings. Every source's merge
+      strategy came from `write.mode`, so `--replace` changed what a plain read
+      returned, and under `update` the last source carrying a key dropped every
+      earlier source's contribution to it. Sources merge additively now; the
+      write mode applies only to metadata the caller supplied — the write API's
+      patch, `-m`, `--import` and the config's metadata block.
+    - What an online lookup fetched survives a write. The lookup runs once per
+      archive and the post-write cache reset discarded its results, so
+      `--online --write … --rename` named the file from pre-online metadata.
+      Metadata added through the API now survives in full, not just the first
+      one.
+    - `add_metadata(md, fmt=…)` accepts every format instead of raising on the
+      ones no source declares, like the online formats.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/box/dump.py
+++ b/comicbox/box/dump.py
@@ -128,20 +128,23 @@ class ComicboxDump(ComicboxPages):
         Re-seed the box caches from the now-rewritten archive.
 
         Everything parsed from the old archive bytes is stale after a
-        write; only the caller-injected API source survives (it didn't
-        come from the file). Lives here rather than in the archive write
-        layer so file I/O stays decoupled from the source-cache
-        lifecycle.
+        write, but the sources that never came from the file can't be
+        rebuilt by re-reading it: the caller-injected API metadata, and
+        whatever the online lookup fetched. The lookup is once-per-box
+        (``_online_lookup_done_flag`` outlives this reset), so dropping
+        its sources here left the post-write rename — and any other
+        read after a write — deciding on pre-online metadata, minus
+        whatever the written formats happened to carry back.
+
+        Lives here rather than in the archive write layer so file I/O
+        stays decoupled from the source-cache lifecycle.
         """
-        old_api_source_data_list = self._sources.get(MetadataSources.API)
-        if old_api_source_data_list:
-            old_api_source_data = old_api_source_data_list[0]
-            old_api_source_metadata = old_api_source_data.data
-            old_api_source_format = old_api_source_data.fmt
-        else:
-            old_api_source_metadata = None
-            old_api_source_format = None
-        self._reset_archive(old_api_source_format, old_api_source_metadata)
+        keep_sources = {
+            source: source_data_list
+            for source in self.SOURCES_SET_ELSEWHERE
+            if (source_data_list := self._sources.get(source))
+        }
+        self._reset_archive(None, None, keep_sources)
 
     def dump(self, formats: frozenset[MetadataFormats] | None = None) -> None:
         """Write metadata according to config.write settings."""

--- a/comicbox/box/init.py
+++ b/comicbox/box/init.py
@@ -125,7 +125,13 @@ class ComicboxInit:
         self._metadata: MappingProxyType = MappingProxyType({})  # pyright: ignore[reportUninitializedInstanceVariable]
 
     def _reset_archive(
-        self, fmt: MetadataFormats | None, metadata: Mapping | str | bytes | None
+        self,
+        fmt: MetadataFormats | None,
+        metadata: Mapping | str | bytes | None,
+        keep_sources: Mapping[
+            MetadataSources, list[SourceData] | tuple[SourceData, ...]
+        ]
+        | None = None,
     ) -> None:
         self._archive_cls: Callable | None = None
         self._file_type: FileTypeEnum | None = None
@@ -143,9 +149,11 @@ class ComicboxInit:
 
         from comicbox.formats.sources import MetadataSources
 
+        # keep_sources carries the sources a reset can't rebuild — see
+        # ComicboxDump._reset_caches_after_write.
         self._sources: dict[
             MetadataSources, list[SourceData] | tuple[SourceData, ...]
-        ] = {}
+        ] = dict(keep_sources) if keep_sources else {}
         if metadata:
             self._sources[MetadataSources.API] = [SourceData(metadata, fmt=fmt)]
         self._loaded: dict[MetadataSources, tuple[LoadedMetadata, ...]] = {}

--- a/comicbox/box/merge.py
+++ b/comicbox/box/merge.py
@@ -1,12 +1,16 @@
 """Merge Metadata Methods."""
 
 from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 from comicbox.box.online_lookup import ComicboxOnlineLookup
 from comicbox.config.settings import WriteMode
 from comicbox.formats.comicbox.schema import ComicboxSchemaMixin
 from comicbox.formats.sources import MetadataSources
 from comicbox.merge import AdditiveMerger, Merger, ReplaceMerger, UpdateMerger
+
+if TYPE_CHECKING:
+    from comicbox.formats import MetadataFormats
 
 # Map the public WriteMode enum onto the existing merger classes. The
 # three modes correspond 1:1; see WriteMode docstring for semantics.
@@ -16,31 +20,64 @@ _MERGER_BY_MODE: dict[WriteMode, type[Merger]] = {
     WriteMode.REPLACE: ReplaceMerger,
 }
 
+# Sources whose metadata the caller supplied to *this* run: the write
+# API's patch, `-m` on the command line, `--import` files, and the
+# config's own metadata block. `write.mode` describes how that supplied
+# metadata overlays the comic's existing tags, so it applies to exactly
+# these. Everything else — the archive's own files, its comment, its
+# filename, an online lookup's answer — is metadata comicbox discovered,
+# and discovery is always accumulated additively.
+_PATCH_SOURCES = frozenset(
+    {
+        MetadataSources.CONFIG,
+        MetadataSources.CLI,
+        MetadataSources.IMPORT_FILE,
+        MetadataSources.API,
+    }
+)
+
 
 class ComicboxMerge(ComicboxOnlineLookup):
     """Merge Metadata Methods."""
 
-    def _merge_metadata_by_source(
-        self, source: MetadataSources, merged_md: dict, merger: type[Merger]
-    ) -> None:
-        """Order the source md list by format precedence."""
-        format_dict = {}
-        # Set the format dict order to be the one declared in source.formats
-        for fmt in reversed(source.value.formats):
-            format_dict[fmt] = []
-        if normalized_md_list := self.get_normalized_metadata(source):
-            # load the mds into the format dict by format.
-            for loaded in normalized_md_list:
-                if loaded.fmt:
-                    format_dict[loaded.fmt] += [loaded.metadata]
-            # load the mds into the source list in format order.
-            for format_normalized_md_list in format_dict.values():
-                for normalized_md in format_normalized_md_list:
-                    merger.merge(merged_md, normalized_md)
-
-    def _resolve_merger(self) -> type[Merger]:
+    @staticmethod
+    def _order_normalized_md_by_format(
+        source: MetadataSources, normalized_md_list: tuple
+    ) -> list:
         """
-        Pick the merger class for this write based on WriteSettings.
+        Order one source's normalized metadatas by format precedence.
+
+        Declared-first wins, so the buckets are seeded in reverse and the
+        highest-precedence format is merged last. A format the source
+        doesn't declare gets a bucket of its own at the end: the public
+        `add_metadata(md, fmt=...)` accepts any format, including the
+        online ones no source lists, and a fixed-key lookup raised
+        KeyError on all of them. Same for the `fmt is None` bucket, which
+        used to be dropped outright.
+        """
+        format_dict: dict[MetadataFormats | None, list] = {
+            fmt: [] for fmt in reversed(source.value.formats)
+        }
+        for loaded in normalized_md_list:
+            format_dict.setdefault(loaded.fmt, []).append(loaded.metadata)
+        return [md for md_list in format_dict.values() for md in md_list]
+
+    def _merge_metadata_by_source(
+        self, source: MetadataSources, merged_sub_md: dict, merger: type[Merger]
+    ) -> None:
+        """Merge one source's metadatas into the accumulator, format order."""
+        normalized_md_list = self.get_normalized_metadata(source)
+        if not normalized_md_list:
+            return
+        for normalized_md in self._order_normalized_md_by_format(
+            source, normalized_md_list
+        ):
+            if sub_md := normalized_md.get(ComicboxSchemaMixin.ROOT_TAG):
+                merger.merge(merged_sub_md, sub_md)
+
+    def _resolve_patch_merger(self) -> type[Merger]:
+        """
+        Pick the merger class for caller-supplied metadata.
 
         ``write.mode`` is the authoritative knob; the legacy ``write.replace``
         bool is honored as a back-compat alias for ``mode=update`` when the
@@ -54,16 +91,33 @@ class ComicboxMerge(ComicboxOnlineLookup):
             mode = WriteMode.UPDATE
         return _MERGER_BY_MODE[mode]
 
+    def _merger_for_source(self, source: MetadataSources) -> type[Merger]:
+        """
+        Cross-source reads are additive; only a patch honors ``write.mode``.
+
+        Selecting every source's merger from ``write.mode`` made a plain
+        read depend on write settings — `to_dict()` returned different
+        metadata under `--replace` — and under `update` it was lossy:
+        `dict.update` at the root meant the last source carrying a key
+        dropped every earlier source's contribution to it wholesale.
+        """
+        if source in _PATCH_SOURCES:
+            return self._resolve_patch_merger()
+        return AdditiveMerger
+
     def _set_merged_metadata(self) -> None:
         """Overlay the metadatas in precedence order."""
         # Order the md list by source precedence (config-overridable;
         # falls back to the MetadataSources enum order when unset).
-        merged_md = {ComicboxSchemaMixin.ROOT_TAG: {}}
-        merger = self._resolve_merger()
+        merged_sub_md: dict = {}
         sources = self._config.read.merge_order or MetadataSources
         for source in sources:
-            self._merge_metadata_by_source(source, merged_md, merger)
-        self._merged_metadata = MappingProxyType(merged_md)
+            self._merge_metadata_by_source(
+                source, merged_sub_md, self._merger_for_source(source)
+            )
+        self._merged_metadata = MappingProxyType(
+            {ComicboxSchemaMixin.ROOT_TAG: merged_sub_md}
+        )
 
     def get_merged_metadata(self) -> MappingProxyType:
         """Get merged normalized metadata."""

--- a/comicbox/box/metadata.py
+++ b/comicbox/box/metadata.py
@@ -35,13 +35,14 @@ class ComicboxMetadata(ComicboxComputed):
         # nested objects the _merged_metadata cache still references.
         merged_md = deepcopy(dict(merged_md))
 
+        # Mergers act on the mapping they're handed, so unwrap the root
+        # tag here — the same shape _set_computed_metadata already merges
+        # each computed delta into.
+        merged_sub_md = merged_md.setdefault(ComicboxSchemaMixin.ROOT_TAG, {})
         for computed_data in computed_md:
             computed_sub_data = computed_data.metadata.get(ComicboxSchemaMixin.ROOT_TAG)
             if computed_sub_data and computed_data.merger:
-                computed_data.merger.merge(
-                    merged_md,
-                    computed_data.metadata,
-                )
+                computed_data.merger.merge(merged_sub_md, computed_sub_data)
         self._set_computed_merged_metadata_delete(merged_md)
         self._metadata = MappingProxyType(merged_md)
         self._metadata_dict_formats = self._dict_formats

--- a/comicbox/merge/__init__.py
+++ b/comicbox/merge/__init__.py
@@ -1,11 +1,20 @@
-"""Recursive merging for containers."""
+"""
+Recursive merging for containers.
+
+Every ``Merger`` merges *at the level of the mapping it is handed*: none
+of them knows about the comicbox root tag. Callers holding root-wrapped
+metadata unwrap it first (see ``ComicboxMerge._merge_metadata_by_source``
+and ``ComicboxMetadata._set_computed_merged_metadata``). Before, only
+``UpdateMerger`` reached into ROOT_TAG, so the same merger object meant
+two different things depending on which call site used it — and handing
+it the sub-metadata the other mergers take silently dropped the merge.
+"""
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, MutableMapping
 
 from typing_extensions import override
 
-from comicbox.formats.comicbox.schema import ComicboxSchemaMixin
 from comicbox.merge.mergedeep import Strategy, merge
 
 
@@ -15,7 +24,7 @@ class Merger(ABC):
     @staticmethod
     @abstractmethod
     def merge(dest: MutableMapping, *sources: Mapping) -> MutableMapping:
-        """Implement a merge method."""
+        """Merge sources into dest, left to right, and return dest."""
         raise NotImplementedError
 
 
@@ -47,9 +56,7 @@ class UpdateMerger(Merger):
     @override
     @staticmethod
     def merge(dest: MutableMapping, *sources: Mapping) -> MutableMapping:
-        """Merge with update."""
-        dest_sub_md = dest.get(ComicboxSchemaMixin.ROOT_TAG, {})
+        """Shallowly update dest with each source's top level keys."""
         for source in sources:
-            source_sub_md = source.get(ComicboxSchemaMixin.ROOT_TAG, {})
-            dest_sub_md.update(source_sub_md)
+            dest.update(source)
         return dest

--- a/tests/unit/test_box_cache_invalidation.py
+++ b/tests/unit/test_box_cache_invalidation.py
@@ -9,13 +9,17 @@ from typing import TYPE_CHECKING
 import pytest
 
 from comicbox.box import Comicbox
+from comicbox.config import get_config
 from comicbox.formats import MetadataFormats
 from comicbox.formats.base.schemas.cache import get_schema
 from comicbox.formats.comicbox.schema.yaml import ComicboxYamlSchema
+from comicbox.formats.sources import MetadataSources
 from tests.const import CIX_CBZ_SOURCE_PATH
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from comicbox.config.settings import ComicboxSettings
 
 
 @pytest.fixture
@@ -92,3 +96,51 @@ def test_mupdf_config_key_present() -> None:
     """The natural spelling."""
     keys = MetadataFormats.PDF.value.config_keys
     assert "mupdf" in keys
+
+
+def _cix_write_config() -> ComicboxSettings:
+    return get_config({"comicbox": {"write": {"formats": ["cix"]}}})
+
+
+def test_online_sources_survive_a_write(tmp_cbz: Path) -> None:
+    """
+    A write must not discard what the online lookup fetched.
+
+    The post-write reset kept only the API source, but the lookup is
+    once-per-box (`_online_lookup_done_flag` outlives the reset), so the
+    online sources were gone for good — leaving the post-write rename,
+    and every later read, on pre-online metadata minus whatever the
+    written formats happened to carry back. `sort_name` is Metron-only,
+    so re-reading the ComicInfo.xml this write produced can't recover it.
+    """
+    payload = {
+        "metron_api": {
+            "id": 99,
+            "series": {"name": "Online Series", "sort_name": "Online Series, The"},
+        }
+    }
+    with Comicbox(tmp_cbz, config=_cix_write_config()) as cb:
+        cb.add_source(
+            MetadataSources.METRON_API, payload, fmt=MetadataFormats.METRON_API
+        )
+        before = cb.to_dict()["comicbox"]["series"]
+        cb.dump()
+        after = cb.to_dict()["comicbox"]["series"]
+    assert before["sort_name"] == "Online Series, The"
+    assert after == before
+
+
+def test_every_added_api_metadata_survives_a_write(tmp_cbz: Path) -> None:
+    """
+    All added API metadata is carried across the write, not just the first.
+
+    The reset re-seeded the API source from `_sources[API][0]`, so a
+    second add_metadata() was dropped on the floor by any write.
+    """
+    with Comicbox(tmp_cbz, config=_cix_write_config()) as cb:
+        cb.add_metadata({"comicbox": {"publisher": {"name": "AddedPub"}}})
+        cb.add_metadata({"comicbox": {"series": {"sort_name": "Zed, The"}}})
+        cb.dump()
+        after = cb.to_dict()["comicbox"]
+    assert after["publisher"]["name"] == "AddedPub"
+    assert after["series"]["sort_name"] == "Zed, The"

--- a/tests/unit/test_merge_precedence.py
+++ b/tests/unit/test_merge_precedence.py
@@ -1,0 +1,210 @@
+"""
+End-to-end merge precedence: which source wins, and which format inside it.
+
+`read.merge_order` had tests at the config-parsing layer only — nothing
+asserted which metadata actually came out the other end. These pin the
+two orderings the merge is built on: `MetadataSources` order (overridable
+by `read.merge_order`) across sources, and `reversed(source.formats)`
+within one source.
+
+The fixture carries the same field in three places at three precedence
+levels: `ComicInfo.xml` (series A) and `comicbox.json` (series B) are both
+the ARCHIVE_FILE source, and the archive comment (series C) is
+ARCHIVE_COMMENT.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox.box import Comicbox
+from comicbox.box.init import LoadedMetadata
+from comicbox.box.merge import ComicboxMerge
+from comicbox.config import get_config
+from comicbox.config.settings import ComicboxSettings, WriteMode
+from comicbox.formats import MetadataFormats
+from comicbox.formats.sources import MetadataSources
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_COMIC_INFO = """<?xml version="1.0" encoding="utf-8"?>
+<ComicInfo>
+  <Series>A</Series>
+  <Writer>Joe</Writer>
+</ComicInfo>
+"""
+_COMICBOX_JSON = json.dumps(
+    {
+        "comicbox": {
+            "series": {"name": "B"},
+            "credits": {"Wally": {"roles": {"Inker": {}}}},
+        }
+    }
+)
+_COMIC_BOOK_INFO = json.dumps(
+    {"appID": "test", "ComicBookInfo/1.0": {"series": "C", "numberOfVolumes": 4}}
+).encode()
+
+# The filename parses to series "Merge Precedence"; ARCHIVE_FILENAME sits
+# below both metadata sources by default, so it only shows up when an
+# explicit merge_order promotes it.
+_STEM = "Merge Precedence #001 (2001)"
+
+
+@pytest.fixture
+def cbz(tmp_path: Path) -> Path:
+    """Build a CBZ carrying series A, B and C in three different places."""
+    path = tmp_path / f"{_STEM}.cbz"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("page-0.jpg", b"not-a-real-jpeg")
+        zf.writestr("ComicInfo.xml", _COMIC_INFO)
+        zf.writestr("comicbox.json", _COMICBOX_JSON)
+        zf.comment = _COMIC_BOOK_INFO
+    return path
+
+
+def _read(path: Path, config: ComicboxSettings | None = None) -> dict:
+    with Comicbox(path, config=config) as cb:
+        return dict(cb.to_dict()["comicbox"])
+
+
+def _merge_order(*names: str) -> ComicboxSettings:
+    return get_config({"comicbox": {"read": {"merge_order": list(names)}}})
+
+
+def _write_mode(mode: WriteMode) -> ComicboxSettings:
+    """Set write.mode the way the public write API does."""
+    config = get_config()
+    return replace(config, write=replace(config.write, mode=mode))
+
+
+###########################
+# Source & format ordering #
+###########################
+
+
+def test_default_order_prefers_comicbox_json_over_comic_info(cbz: Path) -> None:
+    """Within ARCHIVE_FILE, the earlier-declared format wins: B over A."""
+    assert _read(cbz)["series"]["name"] == "B"
+
+
+def test_default_order_prefers_archive_files_over_the_comment(cbz: Path) -> None:
+    """ARCHIVE_FILE outranks ARCHIVE_COMMENT, so C never surfaces as the name."""
+    series = _read(cbz)["series"]
+    assert series["name"] == "B"
+    # The comment still contributes what nothing above it set.
+    assert series["volume_count"] == 4
+
+
+def test_explicit_merge_order_matching_the_default_changes_nothing(
+    cbz: Path,
+) -> None:
+    """Spelling out the default relative order yields the default winner."""
+    config = _merge_order("ARCHIVE_FILENAME", "ARCHIVE_COMMENT", "ARCHIVE_FILE")
+    assert _read(cbz, config)["series"]["name"] == "B"
+
+
+def test_reversed_merge_order_lets_the_comment_win(cbz: Path) -> None:
+    """Promoting ARCHIVE_COMMENT past ARCHIVE_FILE makes C the winner."""
+    config = _merge_order("ARCHIVE_FILENAME", "ARCHIVE_FILE", "ARCHIVE_COMMENT")
+    assert _read(cbz, config)["series"]["name"] == "C"
+
+
+def test_unlisted_sources_are_appended_below_the_listed_ones(cbz: Path) -> None:
+    """
+    merge_order lists a prefix; the rest keep enum order *after* it.
+
+    Naming only the two metadata sources leaves ARCHIVE_FILENAME in the
+    appended remainder — above both — so the filename parse wins.
+    """
+    config = _merge_order("ARCHIVE_FILE", "ARCHIVE_COMMENT")
+    assert _read(cbz, config)["series"]["name"] == "Merge Precedence"
+
+
+def _loaded(fmt: MetadataFormats | None, name: str) -> LoadedMetadata:
+    return LoadedMetadata({"comicbox": {"series": {"name": name}}}, None, fmt)
+
+
+def test_formats_outside_the_source_sort_last_instead_of_raising() -> None:
+    """
+    A format the source doesn't declare gets its own bucket, at the end.
+
+    `add_metadata(md, fmt=...)` accepts any format, including the online
+    ones no source's tuple lists, and the fixed-key bucket lookup raised
+    KeyError on every one of them. `fmt=None` was dropped outright.
+    Undeclared formats merge last, so an explicitly-passed format outranks
+    the source's own.
+    """
+    order = ComicboxMerge._order_normalized_md_by_format(
+        MetadataSources.API,
+        (
+            _loaded(MetadataFormats.METRON_API, "online"),
+            _loaded(MetadataFormats.COMIC_INFO, "declared"),
+            _loaded(None, "unknown"),
+        ),
+    )
+    names = [md["comicbox"]["series"]["name"] for md in order]
+    assert names == ["declared", "online", "unknown"]
+
+
+def test_add_metadata_with_an_online_format_merges(cbz: Path) -> None:
+    """The public API path that used to raise KeyError now wins the merge."""
+    payload = {"metron_api": {"id": 7, "series": {"name": "Online"}}}
+    with Comicbox(cbz) as cb:
+        cb.add_metadata(payload, fmt=MetadataFormats.METRON_API)
+        assert cb.to_dict()["comicbox"]["series"]["name"] == "Online"
+
+
+#################################
+# Read merge vs. write settings #
+#################################
+
+
+@pytest.mark.parametrize("mode", list(WriteMode))
+def test_reads_are_identical_under_every_write_mode(cbz: Path, mode: WriteMode) -> None:
+    """
+    `to_dict()` must not depend on how a hypothetical write would merge.
+
+    Under `update` the cross-source merge was `dict.update` at the root,
+    so comicbox.json's `credits` replaced ComicInfo's wholesale and Joe
+    vanished from a plain read.
+    """
+    md = _read(cbz, _write_mode(mode))
+    assert md == _read(cbz)
+    assert set(md["credits"]) == {"Joe", "Wally"}
+
+
+def test_legacy_replace_bool_does_not_change_a_read(cbz: Path) -> None:
+    """The deprecated `write.replace` alias is a write knob too."""
+    config = get_config({"comicbox": {"write": {"replace": True}}})
+    assert _read(cbz, config) == _read(cbz)
+
+
+@pytest.mark.parametrize(
+    ("mode", "expect_sibling"),
+    [
+        (WriteMode.ADDITIVE, True),
+        (WriteMode.REPLACE, True),
+        (WriteMode.UPDATE, False),
+    ],
+)
+def test_write_mode_still_governs_the_supplied_patch(
+    cbz: Path, mode: WriteMode, *, expect_sibling: bool
+) -> None:
+    """
+    The patch keeps its documented per-mode semantics against the archive.
+
+    `update` replaces `series` wholesale — dropping the `volume_count`
+    the archive comment supplied — while the deep modes keep it.
+    """
+    patch = {"comicbox": {"series": {"name": "D"}}}
+    with Comicbox(cbz, config=_write_mode(mode), metadata=patch) as cb:
+        series = cb.to_dict()["comicbox"]["series"]
+    assert series["name"] == "D"
+    assert ("volume_count" in series) is expect_sibling

--- a/tests/unit/test_mergedeep.py
+++ b/tests/unit/test_mergedeep.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections import Counter
 
-from comicbox.merge import AdditiveMerger, ReplaceMerger, UpdateMerger
+import pytest
+
+from comicbox.merge import AdditiveMerger, Merger, ReplaceMerger, UpdateMerger
 from comicbox.merge.mergedeep import Strategy, merge
 
 #############
@@ -137,25 +139,27 @@ def test_replace_merger_wraps_replace_strategy() -> None:
     assert dest == {"a": [9], "n": {"b": [8]}}
 
 
-def test_update_merger_shallow_updates_under_root_tag() -> None:
-    """UpdateMerger does a shallow dict.update inside the comicbox root tag."""
-    dest = {"comicbox": {"a": 1, "b": {"deep": 1}}}
-    result = UpdateMerger.merge(dest, {"comicbox": {"b": {"other": 2}, "c": 3}})
+def test_update_merger_shallow_updates_the_mapping_it_is_given() -> None:
+    """UpdateMerger does a shallow dict.update at the level it is handed."""
+    dest = {"a": 1, "b": {"deep": 1}}
+    result = UpdateMerger.merge(dest, {"b": {"other": 2}, "c": 3})
     assert result is dest
     # Shallow: the nested 'b' dict is replaced wholesale, not deep-merged.
-    assert dest == {"comicbox": {"a": 1, "b": {"other": 2}, "c": 3}}
+    assert dest == {"a": 1, "b": {"other": 2}, "c": 3}
 
 
-def test_update_merger_without_root_tag_is_a_noop() -> None:
+@pytest.mark.parametrize("merger", [AdditiveMerger, ReplaceMerger, UpdateMerger])
+def test_every_merger_shares_one_shape_contract(merger: type[Merger]) -> None:
     """
-    UpdateMerger silently drops sources when dest lacks the root tag.
+    All three mergers merge into the mapping they are handed.
 
-    # NOTE: dest.get(ROOT_TAG, {}) creates a throwaway dict that is
-    # updated and discarded, so merging into a dest without a 'comicbox'
-    # key loses the source data. Pinning current behavior; callers must
-    # pre-shape dest with the root tag.
+    UpdateMerger used to reach into the comicbox root tag on its own, so
+    the sub-metadata shape its siblings take was silently dropped:
+    dest.get(ROOT_TAG, {}) built a throwaway dict, updated it, and
+    discarded it. Callers unwrap the root tag now; nothing here knows
+    about it.
     """
     dest: dict = {}
-    result = UpdateMerger.merge(dest, {"comicbox": {"a": 1}})
+    result = merger.merge(dest, {"a": 1})
     assert result is dest
-    assert dest == {}
+    assert dest == {"a": 1}


### PR DESCRIPTION
Audits merge correctness (B1 from the complexity survey). A5 — the online
lookup outcome work this overlaps — landed first in #178, so
`_online_lookup_done_flag` semantics here are the post-#178 ones.

## 1. Read merge decoupled from write config

`_set_merged_metadata` resolved one merger from `config.write.mode` and
used it for *every* source, so `to_dict()` returned different metadata
depending on write settings. Under `update` it was also lossy: `dict.update`
at ROOT_TAG meant the last source carrying a key dropped every earlier
source's contribution to it — ComicInfo's `credits` vanished when
comicbox.json carried its own.

Cross-source merges are now always additive. `write.mode` still governs the
metadata the caller supplied to this run — the write API's patch, `-m`,
`--import`, and the config's metadata block — which is what its docstring
describes and what `tests/unit/test_write_api.py` pins. Discovered metadata
(archive files, comment, filename, online) accumulates additively.

## 2. KeyError on out-of-source formats

`format_dict[loaded.fmt]` used a fixed key set seeded from
`source.value.formats`, so any format the source doesn't declare raised.
Reachable from the public API:

```python
cb.add_metadata({"metron_api": {...}}, fmt=MetadataFormats.METRON_API)
cb.to_dict()  # KeyError: MetadataFormats.METRON_API
```

Defaulting the bucket rather than validating in `add_source`: passing a
payload in a known format is a legitimate use of the public API, and the
online formats no source declares are exactly the ones a caller would hand
in that way. Undeclared formats — and the `fmt is None` case, which was
dropped outright — sort after the source's declared ones, so an explicitly
passed format outranks the source's own.

## 3. End-to-end merge-precedence tests

New `tests/unit/test_merge_precedence.py`. Fixture: a CBZ with series `A` in
`ComicInfo.xml`, `B` in `comicbox.json` (both the ARCHIVE_FILE source) and
`C` in the archive comment (ARCHIVE_COMMENT). Covers the default order,
an explicit `read.merge_order` matching it, a reversed one, and the
appended-remainder rule — pinning both the source order and the
`reversed(source.value.formats)` intra-source rule, neither of which had a
test outside the config parser.

## 4. Online sources surviving `_reset_archive`

`_reset_caches_after_write` kept only the API source, but
`_online_lookup_done_flag` survives the reset and the lookup is
once-per-box, so it could never re-run: `--online --write … --rename` named
the file from pre-online metadata, minus whatever the written formats
happened to carry back. Decision: yes, they should survive — they didn't
come from the file, exactly like the API source. Both ride a `keep_sources`
argument through `_reset_archive`, keyed off `SOURCES_SET_ELSEWHERE` (the
sources `_set_source_metadata` can't rebuild).

The old re-seed also read `_sources[API][0]`, so every `add_metadata` after
the first was dropped by any write. Carrying the source lists verbatim fixes
that too.

## 5. One Merger shape contract

`UpdateMerger` reached into ROOT_TAG while `AdditiveMerger` /
`ReplaceMerger` merge whatever mapping they're given — and the same merger
abstraction is called both ways (`box/metadata.py` root-wrapped,
`box/computed/*` unwrapped). Handing `UpdateMerger` the sub-metadata shape
built a throwaway dict, updated it and discarded it.

All three now merge at the level they're handed; `box/merge.py` and
`box/metadata.py` unwrap the root tag themselves, matching what
`_set_computed_metadata` already did.

## Verification

`make fix`, `make lint`, `make ty`, `make typecheck` clean;
1635 passed, 1 skipped. Every new regression test was confirmed failing on
`develop` and passing here — the ordering tests pass on both, as intended
(they pin correct-but-untested behavior).

## Noted, not fixed

`config/__init__.py::_build_write_settings` never reads `write.mode`, and
the confuse template has no `write.mode` key — the field is reachable only
through `write_metadata(mode=...)`, its documented home. Adding a config/CLI
surface for it would be a feature, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
