### PR TITLE
fix(online): couple the solo floor to the configured bar; stop a measured cover losing to an unexamined one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -135,6 +135,17 @@
       file, the `--auto-threshold` help and the matcher all said 0.95, and the
       solo floor was defined off it, so a lone mediocre match could be written
       without a prompt — the failure that floor exists to prevent.
+    - The solo-viable auto-write floor follows the auto-write threshold that is
+      actually configured. It read a fixed 0.95 whatever the setting said, so
+      raising `--auto-threshold` left a lone match under the new bar writing
+      itself anyway, through a back door no setting could close.
+    - A cover comicbox measured is no longer overruled by one it never looked
+      at. When two records match the metadata equally well, comicbox prefers the
+      canonical volume unless the covers say otherwise — but a candidate past
+      the cover-checking cutoff counted as "covers alike" rather than "not
+      checked", and won the tie against a candidate whose cover actually matched
+      the comic. A candidate that was checked and simply has no cover still
+      yields to the canonical volume as before.
     - Actions needing an archive warn instead of raising when there is no path.
       `comicbox --rename` and `comicbox -P f` with no file ended in an
       ArchiveError traceback. The guard that turns those actions off existed but

--- a/comicbox/config/settings.py
+++ b/comicbox/config/settings.py
@@ -94,12 +94,9 @@ DEFAULT_AUTO_THRESHOLD = 0.95
 # in user-facing CLI/docs but available as per-source YAML overrides.
 DEFAULT_MIN_CONFIDENCE = 0.50
 DEFAULT_DISAMBIGUATION_MARGIN = 0.10
-# Solo-viable auto-write floor. When the matcher returns exactly one
-# candidate clearing ``min_confidence``, ``AUTO``/``EAGER`` modes
-# auto-write only if it also clears this floor. Equals the global
-# auto-write threshold, so solo cases need the same bar as
-# multi-candidate unambiguous wins.
-DEFAULT_SOLO_THRESHOLD = DEFAULT_AUTO_THRESHOLD
+# The solo-viable auto-write floor has no constant of its own: it
+# *is* the source's resolved ``auto_threshold`` unless a per-source
+# ``solo_threshold`` overrides it. See ``resolve_solo_threshold``.
 
 
 @dataclass(frozen=True, slots=True)
@@ -374,9 +371,25 @@ def resolve_disambiguation_margin(settings: OnlineSettings, source_name: str) ->
 
 
 def resolve_solo_threshold(settings: OnlineSettings, source_name: str) -> float:
-    """Per-source override > built-in default. Not user-exposed today."""
+    """
+    Per-source override > this source's resolved ``auto_threshold``.
+
+    Phase E's floor is defined as "the same bar as a multi-candidate
+    unambiguous win", so it tracks whatever auto-write bar this source
+    actually runs at — global, per-source, CLI or env. A constant here
+    would silently decouple the two: raising ``auto_threshold`` to 0.98
+    left a lone 0.96-scoring candidate auto-writing through a 0.95 back
+    door that no configuration could close, and lowering it left the
+    floor stricter than the bar it mirrors.
+
+    Lowering ``solo_threshold`` per source is the only way to make
+    ``AUTO``/``EAGER``'s solo carve-out reach below the auto-write bar
+    (see ``_policy_auto_writes``).
+    """
     override = _tuning_for(settings, source_name).solo_threshold
-    return override if override is not None else DEFAULT_SOLO_THRESHOLD
+    if override is not None:
+        return override
+    return resolve_auto_threshold(settings, source_name)
 
 
 def resolve_rate_limit(

--- a/comicbox/formats/base/online/matcher.py
+++ b/comicbox/formats/base/online/matcher.py
@@ -191,6 +191,23 @@ def final_score(candidate: Candidate, *, hash_used: bool) -> float:
     same — `_METADATA_WEIGHT_SUM` (0.80) is still the metadata's
     share of the blended budget, regardless of which signals
     contributed to producing the md value.
+
+    Known asymmetry (audited 2026-08-31, deliberately not retuned here
+    — see the matcher scoring audit under
+    ``tasks/online-tagging/calibration-notes/``): an un-hashed
+    candidate is scored on raw metadata while a hashed one is scored on
+    `0.80*md + 0.20*cover`, and both are compared against the same
+    `auto_threshold`. Measuring a cover therefore *moves* the bar a
+    candidate has to clear: it holds a bar T only while
+    `cover >= (T - 0.80*md) / 0.20`. At the shipped T=0.95 that is
+    cover >= 0.75 for a flawless md=1.0, and unreachable for any
+    md < 0.9375 — while an un-hashed sibling with the same metadata
+    keeps its md and clears T unmeasured. In the 2026-05-17 bigmedia
+    run 48% of 548 measured cover scores were below 0.75, and the
+    blend lowered the top candidate's score in 114 of 306 hashed
+    fixtures. Retuning the weights (or renormalising the un-hashed
+    side) changes which files get written to, so it needs a
+    calibration run, not a patch.
     """
     if not hash_used or candidate.cover_score is None:
         return candidate.metadata_score
@@ -222,11 +239,22 @@ def _policy_auto_writes(
     The pre-Phase-E behavior is recoverable by setting the threshold
     to `min_confidence` (default 0.50), which makes any solo candidate
     above the min_confidence bar auto-write.
+
+    The floor defaults to this source's resolved `auto_threshold`
+    (``resolve_solo_threshold``), and at that default the carve-out is
+    subsumed: `solo_viable` means every other candidate is below
+    `min_confidence` (0.50), so a top clearing a >= 0.50 threshold is
+    also more than `disambiguation_margin` clear of the runner-up, i.e.
+    already `unambig`. AUTO therefore behaves exactly like CAREFUL out
+    of the box; the carve-out only widens it once a user lowers
+    `solo_threshold` for a source. That is the intended reading of
+    "no more permissive than CAREFUL unless the user opts in" — not a
+    dead branch to delete.
     """
     unambig = top_score >= confidence_threshold and gap >= disambiguation_margin
     # Solo-viable auto-write requires the lone candidate clear the floor.
-    # Default floor = global confidence threshold, so AUTO/EAGER's solo
-    # path is no more permissive than CAREFUL unless the user opts in
+    # Default floor = this source's auto-write threshold, so AUTO/EAGER's
+    # solo path is no more permissive than CAREFUL unless the user opts in
     # by lowering the per-source override.
     solo_viable_confident = solo_viable and top_score >= solo_confidence_threshold
     match policy:
@@ -306,17 +334,21 @@ def _top_k_for_hashing(candidate_count: int) -> int:
     """
     Adaptive cover-hash top-K (Phase J).
 
-    The bigmedia 2026-05-14 calibration showed that Phase H's broaden
-    retry caused 14 PROMPT-zone regressions: when broaden added
-    candidates with similar metadata scores, the previously-best
-    candidate dropped out of the fixed top-5 for hashing and lost its
-    cover boost.
+    K scales with the candidate count — hash half the list, floored at
+    5 (the original fixed constant), capped at 15 (cost budget). Cost:
+    at most 10 extra cover-hash fetches per fixture vs the original
+    K=5, and only when the candidate set is genuinely large. The cache
+    absorbs subsequent runs.
 
-    Adaptive K scales with the candidate count — hash half the list,
-    floored at 5 (the original constant), capped at 15 (cost budget).
-    Cost: at most 10 extra cover-hash fetches per fixture vs the
-    original K=5, only when the candidate set is genuinely large.
-    Cache absorbs subsequent runs.
+    Phase J was written to stop a large candidate set from pushing the
+    best candidate out of a fixed top-5 and costing it its cover boost.
+    The feature that produced those large sets — Phase H's broaden
+    retry — was reverted (`62a5725`, `b407815`), and Phase J itself
+    flipped zero outcomes on the corpus that motivated it. It stays as
+    a cost-bounded generalization of K=5 for any future feature that
+    returns wide candidate lists; a rank-boundary artifact is still a
+    real failure mode (see `_cover_diff_is_noise`), just not one this
+    corpus exercises.
 
     Examples:
       5 candidates  → K=5  (current behavior; small set)
@@ -395,16 +427,11 @@ _TIED_METADATA_BLEND_MARGIN: float = 0.02
 # answer's cover is genuinely a better match. Without this guard, the
 # tiebreak collapses them and the lower vol_id wins, which is wrong.
 #
-# Phase G (2026-05-14): tightened from 0.05 → 0.03. The bigmedia
-# calibration surfaced two tied-dupe cases (Fallen Son: Death of Cap
-# America 2007, Hawkeye Freefall 2020) where cover diffs of 0.00 and
-# 0.03 fell within the old noise margin and let the lower-vol-id
-# tiebreak fire, picking the wrong record. Tightening to 0.03 still
-# treats the Watchmen-vs-dupe case (cover diff 0.03 between near-
-# identical scans) as noise (≤ 0.03 = noise), but pulls the boundary
-# in slightly. Doesn't fix Hawkeye Freefall (cover diff exactly 0.03)
-# directly — would need 0.02 for that, but 0.02 risks breaking the
-# Watchmen canonical-volume tiebreak. Conservative tightening.
+# Phase G (2026-05-14) tightened this from 0.05 to 0.03 against the
+# bigmedia calibration; 0.02 would also catch Hawkeye Freefall (cover
+# diff exactly 0.03) but risks breaking the Watchmen canonical-volume
+# tiebreak, so the boundary stayed conservative. The run-by-run
+# reasoning lives in `tasks/online-tagging/calibration-notes/`.
 _COVER_DIFF_NOISE_MARGIN: float = 0.03
 
 
@@ -412,15 +439,41 @@ def _cover_diff_is_noise(a: Candidate, b: Candidate) -> bool:
     """
     Decide whether the cover-score gap between two candidates is hash noise.
 
-    Returns True when the gap is small enough to be hash artifact rather
-    than disambiguation signal. When either candidate's cover_score is
-    missing, we can't compute a diff — fall back to "noise" so the
-    volume_id tiebreak still applies (no cover signal at all means
-    cover wasn't helping anyway).
+    Returns True when the gap is small enough to be hash artifact
+    rather than disambiguation signal, so the volume_id tiebreak can
+    override it.
+
+    A missing `cover_score` is not one case but two, and they answer
+    this question differently:
+
+    - **No cover signal to be had.** Neither candidate was hashed
+      (hashing never fired), or the one that wasn't scored *was*
+      hashed and came back empty — no `cover_url`, a fetch failure, an
+      undecodable image. Cover genuinely isn't helping here, so treat
+      the pair as tied and let volume_id decide, as before.
+    - **Not computed.** The unscored candidate sits outside the
+      hashing top-K (`_top_k_for_hashing`), so its cover was never
+      looked at. Its silence is our cost cap talking, not evidence of
+      similarity — and collapsing the pair would let a candidate no
+      one measured beat one whose cover we *did* measure against the
+      local copy, on volume id alone. Keep the measured signal: not
+      noise.
+
+    The second case needs at least 6 candidates to arise (K >= 5) plus
+    an exact metadata-score tie across the K boundary, so it is narrow
+    — but it is the one case where the tiebreak discards a real
+    measurement instead of breaking a real tie.
     """
-    if a.cover_score is None or b.cover_score is None:
+    if a.cover_score is not None and b.cover_score is not None:
+        return abs(a.cover_score - b.cover_score) <= _COVER_DIFF_NOISE_MARGIN
+    if a.cover_score is None and b.cover_score is None:
+        # No cover signal on either side — nothing for the tiebreak to
+        # override, so let volume_id decide as it always has.
         return True
-    return abs(a.cover_score - b.cover_score) <= _COVER_DIFF_NOISE_MARGIN
+    unmeasured = a if a.cover_score is None else b
+    # One side measured. Its signal stands unless the other side was
+    # examined too and simply had no usable cover.
+    return unmeasured.cover_hash_attempted
 
 
 def _apply_tied_metadata_tiebreak(ranked: list[Candidate]) -> list[Candidate]:
@@ -442,10 +495,12 @@ def _apply_tied_metadata_tiebreak(ranked: list[Candidate]) -> list[Candidate]:
     - Requires blended scores within a small margin. Genuine
       score-spread (>0.02) means the matcher distinguished the
       candidates and we should trust that.
-    - Requires cover-score difference to be noise-level (<=0.05). When
-      one candidate's cover is a near-perfect Hamming match and the
-      other's is materially worse, that's the cover signal doing real
-      work — don't override.
+    - Requires the cover-score difference to be noise-level
+      (`_COVER_DIFF_NOISE_MARGIN`, 0.03), with an unmeasured cover
+      counting as noise only when nothing was measured for it to hide
+      behind (`_cover_diff_is_noise`). When one candidate's cover is a
+      near-perfect Hamming match and the other's is materially worse,
+      that's the cover signal doing real work — don't override.
 
     The three predicates together catch the "two records, same series +
     issue + year + publisher, different volume, near-identical covers"
@@ -539,7 +594,10 @@ def _apply_cover_hashing(
 
     K is adaptive (Phase J — see `_top_k_for_hashing`): for small
     candidate sets it stays at 5 (the historical constant); for larger
-    sets (Phase H broaden-retry, BALANCED budget) it scales up to 15.
+    sets (a BALANCED / THOROUGH budget over a multi-volume search) it
+    scales up to 15. Candidates inside K are marked
+    `cover_hash_attempted` whether or not a hash came back, so the
+    tiebreak can tell "this cover doesn't help" from "we never looked".
     """
     top_k = _top_k_for_hashing(len(ranked))
     rescored: list[Candidate] = []
@@ -547,9 +605,12 @@ def _apply_cover_hashing(
         if i >= top_k:
             rescored.append(c)
             continue
+        # Attempted from here on, whatever the outcome — the tiebreak
+        # reads this to tell an unhelpful cover from an unexamined one.
+        attempted = replace(c, cover_hash_attempted=True)
         cand_hash = _resolve_candidate_hash(c, candidate_hash_fetcher)
         if not cand_hash:
-            rescored.append(c)
+            rescored.append(attempted)
             continue
         try:
             cs = _cover_score(local_hash, cand_hash)
@@ -557,9 +618,9 @@ def _apply_cover_hashing(
             logger.warning(
                 f"online: cover hash failed for {c.source}:{c.issue_id}: {exc}"
             )
-            rescored.append(c)
+            rescored.append(attempted)
             continue
-        with_cover = replace(c, cover_score=cs)
+        with_cover = replace(attempted, cover_score=cs)
         rescored.append(
             replace(with_cover, score=final_score(with_cover, hash_used=True))
         )

--- a/comicbox/formats/base/online/profile.py
+++ b/comicbox/formats/base/online/profile.py
@@ -66,6 +66,13 @@ class Candidate:
     score: float = 0.0
     url: str = ""
     precomputed_cover_hash: str | None = None
+    # True once the matcher tried to hash this candidate's cover, whatever
+    # came of it. With `cover_score` it forms a tri-state the tiebreak
+    # needs: scored (attempted, comparable), attempted-but-unscored (the
+    # candidate has no usable cover — a real absence of signal), and
+    # never-attempted (outside the hashing top-K, so its absence is our
+    # cost cap talking, not the data).
+    cover_hash_attempted: bool = False
     # The parent container's id — CV's `volume.id`, Metron's `series.id`.
     # Two issues sharing a volume_id are siblings in the same series run;
     # this is what calibration uses to distinguish "variant cover of the

--- a/tasks/online-tagging/calibration-notes/2026-08-31-matcher-scoring-audit.md
+++ b/tasks/online-tagging/calibration-notes/2026-08-31-matcher-scoring-audit.md
@@ -1,0 +1,209 @@
+# 2026-08-31 — matcher scoring audit (desk audit, no new calibration run)
+
+A read of `comicbox/formats/base/online/matcher.py` and the threshold
+configuration around it, checked against the 2026-05-17 bigmedia outcomes still
+on disk (`tests/calibration/fixtures-bigmedia.outcomes.json`, gitignored and
+per-developer). No API calls were made and **no weights were retuned** — the
+scoring constants (`W_SERIES` … `W_COVER`, `_COVER_DIFF_NOISE_MARGIN`,
+`_TIED_METADATA_BLEND_MARGIN`) are untouched. Two behavioral fixes landed, both
+narrow and both provable without a live run; everything that would need one is
+written up under "What a calibration run should settle" below.
+
+`tasks/online-tagging/` was removed from the tree in `d38eadd` ("remove old
+tasks") and never reached `develop`. The historical notes cited here are
+readable at `git show d38eadd^:tasks/online-tagging/calibration-notes/<file>`.
+This file re-establishes the directory.
+
+## Phase archaeology
+
+The matcher's comments name phases with no surviving index. What each one was,
+and whether the code it justifies still exists:
+
+| Phase | What it did                                                     | Status today                                                                            |
+| ----- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| B     | api-budget matrix runs (`fast` vs `balanced`)                   | Superseded by `Effort`                                                                  |
+| D     | Series-name pre-filter before scoring                           | Live (`series_filter.py`)                                                               |
+| E     | Solo-viable auto-write floor                                    | Live. Floor shipped at 0.95 = the auto bar from day one (2026-05-12 note)               |
+| G     | Cover-diff noise margin tightened 0.05 → 0.03                   | Live (`_COVER_DIFF_NOISE_MARGIN`)                                                       |
+| H     | CV search broadens when the initial top scores weakly           | **Reverted** — `62a5725` (rev 1: 7 wins, 14 regressions), `b407815` (rev 2)             |
+| I     | Quality-relative cover-diff threshold                           | **Reverted** — `b33da25` (silently cost CV ~13 cases, 94.6% → 89.9%)                    |
+| J     | Adaptive cover-hash top-K (5 → count/2, capped 15)              | Live, but its motivation (H's wide candidate sets) is gone and it flipped zero outcomes |
+| K     | `metadata_score` renormalises over contributing signals (rev 2) | Live                                                                                    |
+
+Three comment blocks were still arguing from the reverted work; see "Stale
+prose" below.
+
+## Finding 1 — the solo floor had come loose from the auto bar
+
+`DEFAULT_SOLO_THRESHOLD` was `0.85` until #179 raised it to
+`DEFAULT_AUTO_THRESHOLD`. **That 0.85 was drift, not calibration**: the
+2026-05-12 slimlib note introduces Phase E with "a new
+`solo_confidence_threshold` (default 0.95 = same as the global confidence
+threshold)", and the value only ever disagreed because
+`OnlineTuningSettings.auto_threshold` had itself drifted to 0.85 and the solo
+constant mirrored it by hand.
+
+#179 fixed the value. The mirror itself survived: `resolve_solo_threshold`
+returned a module constant while `resolve_auto_threshold` resolved per-source →
+global → CLI → env. So the two agreed only at defaults:
+
+- `auto_threshold: 0.99` (globally, per source, `--auto-threshold`, or
+  `COMICBOX_ONLINE_AUTO_THRESHOLD`) left a lone 0.96-scoring candidate
+  auto-writing through a 0.95 back door **no setting could close**.
+- Lowering the bar left the floor stricter than the bar it is defined to mirror.
+
+`resolve_solo_threshold` now falls back to `resolve_auto_threshold` for the same
+source. Identical behavior at defaults (0.95 == 0.95); the constant is gone, so
+there is no second declaration left to drift.
+
+### The carve-out is subsumed at the default floor
+
+Worth writing down, because it reads like a bug and isn't: with the floor equal
+to the bar, Phase E's carve-out can never widen `AUTO`. `solo_viable` means
+every other candidate is below `min_confidence` (0.50), so a top that clears a
+bar ≥ 0.50 is also more than `disambiguation_margin` (0.10) clear of the
+runner-up — i.e. already `unambig`. **`AUTO` therefore behaves exactly like
+`CAREFUL` out of the box**, and the carve-out only does work once a user lowers
+`solo_threshold` for a source. `test_auto_matches_careful_at_default_settings`
+pins it.
+
+## Finding 2 — hashed and un-hashed candidates are judged on different scales
+
+`final_score` gives an un-hashed candidate its raw metadata score and a hashed
+one `0.80*md + 0.20*cover`, and `_resolve_policy` compares both against one
+`auto_threshold`. Measuring a cover therefore doesn't just rank a candidate — it
+moves the bar that candidate has to clear:
+
+    a hashed candidate holds bar T only while  cover >= (T - 0.80*md) / 0.20
+
+At the shipped T = 0.95:
+
+| md     | cover needed to hold 0.95 |
+| ------ | ------------------------- |
+| 1.0000 | 0.75                      |
+| 0.9800 | 0.83                      |
+| 0.9625 | 0.90                      |
+| 0.9500 | 0.95                      |
+| 0.9375 | 1.00                      |
+| 0.9125 | unreachable (1.10)        |
+
+Its un-hashed sibling — a thumbnail-quality local cover, a PDF with no readable
+cover page, a candidate with no `cover_url`, a fetch failure, or simply a rank
+past the hashing top-K — keeps its md and clears the bar unmeasured.
+
+Measured against the 2026-05-17 bigmedia outcomes (494 records, 310 with hashing
+fired, 548 candidate cover scores):
+
+- **48% of measured cover scores are below 0.75** — the break-even a _flawless_
+  md = 1.0 candidate needs just to stay where it already was.
+- The blend **lowered** the top candidate's score in 114 of 306 hashed fixtures
+  (raised 191, unchanged 1).
+- Counterfactually, had the bar been 0.90, 45 top candidates would have been
+  pushed below a bar their metadata alone cleared — **41 of them the correct
+  match**. At 0.85: 48 demoted, 24 correct.
+- At the real 0.95 bar the count is 0, for an uncomfortable reason: nothing in
+  this corpus reaches 0.95 either way (below).
+
+### Nobody reaches the bar
+
+| Source    | Outcomes with candidates | Max md | Max blended score | ≥ 0.95 |
+| --------- | ------------------------ | ------ | ----------------- | ------ |
+| ComicVine | 245                      | 0.9125 | 0.930             | 0      |
+| Metron    | 65                       | 0.8937 | 0.915             | 0      |
+
+CV's search results (`BasicIssue`) carry no publisher and no page count, so
+Phase K's asymmetric weak priors cap md at 0.9125; blending a perfect cover onto
+that reaches 0.930. **On this library the default policy prompts on every
+fixture and auto-writes nothing.** That is a defensible safety posture, but it
+is not what the docs describe, and it means the auto-write band has never been
+measured on real data — the notes that report "auto-write band 97.6% correct"
+are reporting the 0.85-0.95 band, which the shipped default sends to a prompt.
+The harness's band labels said "auto-write" for that band; they now derive from
+`DEFAULT_AUTO_THRESHOLD` (see `tests/calibration/run.py`).
+
+Fixing the asymmetry is a retune and is **not** done here. The candidate
+approaches, for a run to arbitrate:
+
+1. Renormalise the un-hashed side (score it out of `_METADATA_WEIGHT_SUM` too),
+   so hashing changes a candidate's rank without changing its bar.
+2. Hash every member of a tie group rather than a rank prefix, so comparisons
+   are always like-for-like.
+3. Separate bars for hashed and un-hashed candidates.
+4. Leave the blend alone and lower the default bar to something CV's md ceiling
+   can actually reach.
+
+Each moves auto-write behavior on users' files; none should ship on reasoning
+alone.
+
+## Finding 3 — "cover hash not computed" is not "no cover available"
+
+`_cover_diff_is_noise` treated any missing `cover_score` as noise, which lets
+`_apply_tied_metadata_tiebreak` collapse the pair and hand the win to the lower
+`volume_id`. Two very different situations were reaching that branch:
+
+- **No cover signal to be had** — nothing was hashed, or the unscored candidate
+  _was_ hashed and had no usable cover (no `cover_url`, fetch failure,
+  undecodable image). Cover genuinely isn't helping; volume id should decide, as
+  before.
+- **Not computed** — the unscored candidate sits outside `_top_k_for_hashing`,
+  so nobody looked at its cover. Treating that silence as "the covers are alike"
+  lets an unexamined record beat one whose cover we _did_ measure against the
+  local copy, on volume id alone.
+
+`Candidate.cover_hash_attempted` now records which happened, and only the first
+case counts as noise. Blast radius, deliberately small: it takes ≥ 6 candidates
+(K ≥ 5), an _exact_ metadata-score tie straddling the K boundary, and blended
+scores within `_TIED_METADATA_BLEND_MARGIN` (0.02) for the branch to be reached
+at all. Only 16 of 494 outcomes in the corpus even had ≥ 6 candidates, and the
+harness records just the top 3, so **the corpus can neither confirm nor refute
+this case** — the change rests on the code path, not on measurement. The two
+mixed hashed/un-hashed adjacent ties the data _does_ show (Akira 2000 #001,
+Ghost in the Shell 2009 #001) are the attempted-but-coverless case, whose
+behavior is unchanged.
+
+## Finding 4 — stale prose
+
+- `_apply_tied_metadata_tiebreak` documented the cover-diff guard as `<=0.05`;
+  Phase G tightened the constant to 0.03 in May.
+- `_top_k_for_hashing` and `_apply_cover_hashing` justified adaptive K by Phase
+  H's broaden retry, reverted in `62a5725` / `b407815`. Phase J also flipped
+  zero outcomes on the corpus that motivated it; it stays as a cost-bounded
+  generalization of K = 5, and now says so.
+- `settings.py` described the solo floor as equalling the auto-write threshold
+  directly above a constant that hardcoded it (fixed by #179; the coupling
+  itself is Finding 1).
+- The calibration report labelled 0.85-0.95 the "auto-write" band and 0.95-1.00
+  "very high". Labels now come from `DEFAULT_AUTO_THRESHOLD`.
+
+## What a calibration run should settle
+
+1. **Does anything reach 0.95?** Re-run bigmedia and read the top band. If it is
+   still empty, the default bar and the md ceiling are incompatible and one of
+   them has to move (Finding 2, option 4).
+2. **The blend, options 1-3 of Finding 2.** Run each against the same fixture
+   set; the metric that matters is per-band correctness at ≥ 0.95, not overall
+   accuracy — prompt-zone churn is not user-visible harm.
+3. **Whether the K-boundary tie ever fires in the wild.** Raise the harness's
+   recorded-candidate cap above 3 and log `cover_hash_attempted`; the case is
+   currently invisible.
+4. **Per-source bars.** Metron's md ceiling (0.8937) sits below CV's (0.9125) on
+   the same library; one global threshold is doing two different jobs.
+
+## Reproducing the numbers
+
+Against a finished outcomes file (paths are per-developer; the file is
+gitignored):
+
+```python
+import json
+
+WMD, WCOV = 0.80, 0.20
+data = json.load(open("tests/calibration/fixtures-bigmedia.outcomes.json"))
+hashed = [
+    (o, c) for o in data for c in o["top_candidates"] if c["cover_score"] is not None
+]
+covers = [c["cover_score"] for _, c in hashed]
+print(len(covers), sum(c < 0.75 for c in covers) / len(covers))
+tops = [o["top_candidates"][0] for o in data if o["top_candidates"]]
+print(max(c["metadata_score"] for c in tops), max(c["score"] for c in tops))
+```

--- a/tests/calibration/README.md
+++ b/tests/calibration/README.md
@@ -259,21 +259,31 @@ Sample output:
   fixtures missing expected metron id: 9
   accuracy on labeled fixtures: 95.7%
   by score band:
-    0.95-1.00 (very high): 142/142 correct (100%)
-    0.85-0.95 (auto-write): 32/35 correct (91%)
+    0.95-1.00 (auto-write): 142/142 correct (100%)
+    0.85-0.95 (near miss): 32/35 correct (91%)
     0.70-0.85 (prompt zone): 4/8 correct (50%)
     0.50-0.70 (solo-viable): 0/1 correct (0%)
 ```
+
+The top band's boundary is `DEFAULT_AUTO_THRESHOLD` (0.95), so the labels follow
+the shipped default bar. Notes written before 2026-08-31 label 0.85-0.95
+"auto-write"; that band has been the top of the prompt zone since the default
+threshold moved to 0.95, and its accuracy numbers say nothing about what
+comicbox writes unattended.
 
 What to look at:
 
 - **Top accuracy** — the headline number. Aim for ≥95% on a representative
   fixture set before declaring the matcher tuned.
-- **Per-band correctness** — the auto-write band (0.85-0.95) should be ≥99%
+- **Per-band correctness** — the auto-write band (≥ 0.95) should be ≥99%
   correct; if it's lower, the threshold is too low and comicbox is confidently
-  writing wrong tags. Raise the `--confidence-threshold` default.
-- **Prompt-zone accuracy** — the 0.70-0.85 band is where users see prompts.
-  \~50% correct is fine here; users veto bad ones manually.
+  writing wrong tags. Raise the `--auto-threshold` default.
+- **Prompt-zone accuracy** — the 0.50-0.95 bands are where users see prompts.
+  \~50% correct is fine there; users veto bad ones manually.
+- **An empty auto-write band is a finding too.** On the 2026-05-17 bigmedia run
+  nothing from either source reached 0.95 (CV topped out at 0.930, Metron at
+  0.915), so the default policy prompted on every fixture. See
+  [`../../tasks/online-tagging/calibration-notes/2026-08-31-matcher-scoring-audit.md`](../../tasks/online-tagging/calibration-notes/2026-08-31-matcher-scoring-audit.md).
 - **No candidates** — comicbox found nothing. May indicate: bad filename parse,
   source doesn't have the issue, or query is too strict (year off, volume off).
   The "Outcomes worth a look" section lists each one for hand-investigation.

--- a/tests/calibration/run.py
+++ b/tests/calibration/run.py
@@ -47,6 +47,7 @@ from typing_extensions import Self
 
 from comicbox.box import Comicbox
 from comicbox.config import get_config
+from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD
 from comicbox.formats.base.online.matcher import OnlineMatcher
 from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
 from comicbox.formats.metron_api.online_source import MetronOnlineSource
@@ -64,9 +65,18 @@ if TYPE_CHECKING:
 
 
 # Score bands for the report. Inclusive lower bound, exclusive upper.
+#
+# The top band's boundary is `DEFAULT_AUTO_THRESHOLD`, not a literal:
+# these labels say what the shipped default policy *does* with a score,
+# and the old hardcoded "0.85-0.95 (auto-write)" stopped being true the
+# day the default bar moved to 0.95. Calibration notes written against
+# the old labels credit the auto-write band with accuracy numbers that
+# actually belong to the top of the prompt zone. Bands below the bar
+# assume it sits at or above 0.85; a lower bar empties the second band
+# rather than mislabelling it.
 _SCORE_BANDS: tuple[tuple[float, float, str], ...] = (
-    (0.95, 1.001, "0.95-1.00 (very high)"),
-    (0.85, 0.95, "0.85-0.95 (auto-write)"),
+    (DEFAULT_AUTO_THRESHOLD, 1.001, f"{DEFAULT_AUTO_THRESHOLD:.2f}-1.00 (auto-write)"),
+    (0.85, DEFAULT_AUTO_THRESHOLD, f"0.85-{DEFAULT_AUTO_THRESHOLD:.2f} (near miss)"),
     (0.70, 0.85, "0.70-0.85 (prompt zone)"),
     (0.50, 0.70, "0.50-0.70 (solo-viable)"),
     (0.0, 0.50, "0.00-0.50 (below min_confidence)"),

--- a/tests/calibration/test_harness.py
+++ b/tests/calibration/test_harness.py
@@ -34,10 +34,10 @@ _make_fixture = make_fixture
 @pytest.mark.parametrize(
     ("score", "expected"),
     [
-        (0.99, "0.95-1.00 (very high)"),
-        (0.95, "0.95-1.00 (very high)"),
-        (0.90, "0.85-0.95 (auto-write)"),
-        (0.85, "0.85-0.95 (auto-write)"),
+        (0.99, "0.95-1.00 (auto-write)"),
+        (0.95, "0.95-1.00 (auto-write)"),
+        (0.90, "0.85-0.95 (near miss)"),
+        (0.85, "0.85-0.95 (near miss)"),
         (0.78, "0.70-0.85 (prompt zone)"),
         (0.55, "0.50-0.70 (solo-viable)"),
         (0.40, "0.00-0.50 (below min_confidence)"),
@@ -138,10 +138,10 @@ def test_aggregate_buckets_by_band() -> None:
         _outcome(score=0.92, correct=False),
     ]
     [report] = _aggregate(outcomes).values()
-    very_high = report.by_band["0.95-1.00 (very high)"]
-    auto_write = report.by_band["0.85-0.95 (auto-write)"]
-    assert very_high == {"correct": 2, "wrong": 0}
-    assert auto_write == {"correct": 1, "wrong": 1}
+    auto_band = report.by_band["0.95-1.00 (auto-write)"]
+    near_miss = report.by_band["0.85-0.95 (near miss)"]
+    assert auto_band == {"correct": 2, "wrong": 0}
+    assert near_miss == {"correct": 1, "wrong": 1}
 
 
 def test_format_report_renders_per_source() -> None:

--- a/tests/unit/test_config_defaults_drift.py
+++ b/tests/unit/test_config_defaults_drift.py
@@ -9,9 +9,11 @@ constructs the dataclass directly.
 
 That is exactly how ``OnlineTuningSettings.auto_threshold`` ended up at
 0.85 while the YAML, the ``--auto-threshold`` help text, and the
-matcher's own constant all said 0.95 — and, through
-``DEFAULT_SOLO_THRESHOLD``, dropped the solo-viable auto-write floor to
-a value Phase E was written to forbid.
+matcher's own constant all said 0.95 — and, through a second constant
+that mirrored it by hand, dropped the solo-viable auto-write floor to a
+value Phase E was written to forbid. That mirror is gone:
+``resolve_solo_threshold`` reads the source's resolved
+``auto_threshold``, and the test below pins the coupling.
 
 This test walks the two trees together in both directions:
 
@@ -188,8 +190,11 @@ def test_auto_threshold_default_agrees_everywhere() -> None:
     """
     from comicbox.config.settings import (
         DEFAULT_AUTO_THRESHOLD,
-        DEFAULT_SOLO_THRESHOLD,
+        OnlineSettings,
+        OnlineSourceTuning,
         OnlineTuningSettings,
+        resolve_auto_threshold,
+        resolve_solo_threshold,
     )
 
     yaml_value = _load_yaml_defaults()["online"]["tuning"]["auto_threshold"]
@@ -197,8 +202,28 @@ def test_auto_threshold_default_agrees_everywhere() -> None:
     assert yaml_value == DEFAULT_AUTO_THRESHOLD
     # Phase E's solo-viable floor is defined as "the same bar as a
     # multi-candidate unambiguous win". Below it, a lone mediocre
-    # candidate auto-writes silently.
-    assert DEFAULT_SOLO_THRESHOLD == DEFAULT_AUTO_THRESHOLD
+    # candidate auto-writes silently — so it tracks the threshold this
+    # source actually runs at, for every way of setting one.
+    for settings in (
+        OnlineSettings(),
+        OnlineSettings(tuning=OnlineTuningSettings(auto_threshold=0.99)),
+        OnlineSettings(tuning=OnlineTuningSettings(auto_threshold=0.70)),
+        OnlineSettings(
+            tuning=OnlineTuningSettings(
+                per_source={"metron": OnlineSourceTuning(auto_threshold=0.98)}
+            )
+        ),
+    ):
+        assert resolve_solo_threshold(settings, "metron") == resolve_auto_threshold(
+            settings, "metron"
+        )
+    # An explicit per-source solo_threshold still wins.
+    opted_in = OnlineSettings(
+        tuning=OnlineTuningSettings(
+            per_source={"metron": OnlineSourceTuning(solo_threshold=0.50)}
+        )
+    )
+    assert resolve_solo_threshold(opted_in, "metron") == 0.50
 
 
 def test_no_credentials_are_defaulted_in_yaml() -> None:

--- a/tests/unit/test_online_matcher.py
+++ b/tests/unit/test_online_matcher.py
@@ -626,15 +626,37 @@ def test_strict_unattended_skips_when_close() -> None:
     assert res.kind is ResolutionKind.SKIP
 
 
-def test_normal_accepts_solo_below_threshold() -> None:
-    """`--policy normal` (default) takes a sole viable candidate even below auto-write bar."""
+def test_normal_accepts_solo_below_threshold_only_when_floor_lowered() -> None:
+    """
+    AUTO's solo carve-out reaches below the auto-write bar only on opt-in.
+
+    The floor defaults to the source's `auto_threshold`, which makes
+    the carve-out equivalent to CAREFUL's `unambig` rule. Lowering
+    `solo_threshold` for the source is what buys "take a sole viable
+    candidate even below the auto-write bar".
+    """
     matcher = OnlineMatcher()
     candidates = [
         _candidate(issue_id=1, page_count=22),  # 0.7 weight on pages
     ]
     ranked = matcher.rank(_profile(), candidates)
+    assert 0.95 < ranked[0].score < 0.99
+
+    # Default floor (= the 0.99 auto_threshold): the lone candidate
+    # doesn't clear the bar, so it prompts.
     res = matcher.resolve(
         ranked, _settings(confidence_threshold=0.99), source_name="metron"
+    )
+    assert res.kind is ResolutionKind.PROMPT
+
+    # Opt in by lowering the floor for this source.
+    res = matcher.resolve(
+        ranked,
+        _settings(
+            confidence_threshold=0.99,
+            solo_confidence_threshold_per_source={"metron": 0.50},
+        ),
+        source_name="metron",
     )
     assert res.kind is ResolutionKind.AUTO_WRITE
     assert res.chosen is not None
@@ -1154,6 +1176,95 @@ def test_solo_confidence_floor_gates_eager_solo_carve_out() -> None:
     # 0.88 < 0.95 floor AND 0.88 < 0.99 confidence_threshold → PROMPT.
     res = matcher.resolve(ranked, settings_eager, "metron")
     assert res.kind is ResolutionKind.PROMPT
+
+
+# ------------- Phase E: the floor tracks the auto-write bar
+
+
+def test_solo_floor_tracks_a_raised_auto_threshold() -> None:
+    """
+    Raising `auto_threshold` raises the solo floor with it.
+
+    The floor is defined as "the same bar as a multi-candidate
+    unambiguous win". Reading it from a module constant instead of the
+    source's resolved threshold left a 0.95 back door open under a
+    stricter configuration: a lone 0.98-scoring candidate auto-wrote
+    for a user who had asked for 0.99, and no setting could close it.
+    """
+    matcher = OnlineMatcher()
+    candidates = [_candidate(issue_id=1, page_count=22)]
+    ranked = matcher.rank(_profile(), candidates)
+    # Above the old 0.95 constant, below the configured bar.
+    assert 0.95 < ranked[0].score < 0.99
+
+    res = matcher.resolve(
+        ranked, _settings(confidence_threshold=0.99), source_name="metron"
+    )
+    assert res.kind is ResolutionKind.PROMPT
+
+
+def test_solo_floor_tracks_a_per_source_auto_threshold() -> None:
+    """A per-source `auto_threshold` moves that source's solo floor only."""
+    matcher = OnlineMatcher()
+    candidates = [_candidate(issue_id=1, page_count=22)]
+    ranked = matcher.rank(_profile(), candidates)
+
+    settings = _settings(
+        confidence_threshold=0.85,
+        confidence_threshold_per_source={"metron": 0.99},
+    )
+    # metron runs at 0.99 — solo floor follows, so the 0.98 lone
+    # candidate prompts.
+    assert matcher.resolve(ranked, settings, "metron").kind is ResolutionKind.PROMPT
+    # comicvine still runs at the global 0.85 and auto-writes.
+    assert (
+        matcher.resolve(ranked, settings, "comicvine").kind is ResolutionKind.AUTO_WRITE
+    )
+
+
+def test_explicit_solo_threshold_still_wins_over_the_auto_threshold() -> None:
+    """An explicit per-source `solo_threshold` outranks the tracked default."""
+    matcher = OnlineMatcher()
+    candidates = [_candidate(issue_id=1, page_count=22)]
+    ranked = matcher.rank(_profile(), candidates)
+
+    res = matcher.resolve(
+        ranked,
+        _settings(
+            confidence_threshold=0.99,
+            solo_confidence_threshold_per_source={"metron": 0.50},
+        ),
+        source_name="metron",
+    )
+    assert res.kind is ResolutionKind.AUTO_WRITE
+
+
+def test_auto_matches_careful_at_default_settings() -> None:
+    """
+    With the floor at the auto bar, AUTO's solo carve-out adds nothing.
+
+    `solo_viable` means every other candidate is below `min_confidence`
+    (0.50), so a top that clears the threshold is also more than
+    `disambiguation_margin` clear of the runner-up — already `unambig`.
+    Pinning this keeps the equivalence a documented property instead of
+    a surprise the next time someone reads AUTO's rule.
+    """
+    matcher = OnlineMatcher()
+    lone = matcher.rank(_profile(), [_candidate(issue_id=1, year=2018, page_count=20)])
+    clean = matcher.rank(_profile(), [_candidate(issue_id=1)])
+    for ranked in (lone, clean):
+        # 0.85: the lone 0.88 candidate clears the bar. 0.99: it doesn't,
+        # which is where the carve-out used to make AUTO the looser mode.
+        for threshold in (0.85, 0.99):
+            settings_auto = _settings(
+                policy=Policy.NORMAL, confidence_threshold=threshold
+            )
+            settings_careful = _settings(
+                policy=Policy.STRICT, confidence_threshold=threshold
+            )
+            auto = matcher.resolve(ranked, settings_auto, "metron")
+            careful = matcher.resolve(ranked, settings_careful, "metron")
+            assert auto.kind is careful.kind
 
 
 # ------------- Phase J: adaptive top-K for cover hashing

--- a/tests/unit/test_online_matcher_scoring.py
+++ b/tests/unit/test_online_matcher_scoring.py
@@ -1,0 +1,274 @@
+"""
+Matcher scoring: which bar a candidate is judged against.
+
+The two halves of the 2026-08-31 scoring audit — what a missing cover
+score means to the volume-id tiebreak, and the different scales hashed
+and un-hashed candidates are scored on. See
+``tasks/online-tagging/calibration-notes/2026-08-31-matcher-scoring-audit.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from comicbox.config.settings import (
+    MatchMode,
+    OnlineLookupSettings,
+    OnlineSettings,
+    OnlineTuningSettings,
+    Prompts,
+)
+from comicbox.formats.base.online.matcher import (
+    OnlineMatcher,
+    ResolutionKind,
+    _apply_cover_hashing,
+    _cover_diff_is_noise,
+    final_score,
+)
+from comicbox.formats.base.online.profile import (
+    Candidate,
+    CandidateSummary,
+    ComicProfile,
+)
+
+_LOCAL_HASH = "0000000000000000"
+# 32 of 64 bits differ from _LOCAL_HASH → cover_score 0.5.
+_HALF_MATCH_HASH = "00000000ffffffff"
+_COVER_URL = "http://example.com/cover.jpg"
+
+
+def _profile() -> ComicProfile:
+    return ComicProfile(
+        series="Foo Comics",
+        issue="5",
+        issue_int=5,
+        year=2020,
+        publisher="Quality Comics",
+        page_count=24,
+    )
+
+
+def _candidate(
+    *,
+    issue_id: int = 1,
+    volume_id: int | None = None,
+    page_count: int | None = 24,
+    cover_url: str | None = None,
+) -> Candidate:
+    return Candidate(
+        source="metron",
+        issue_id=issue_id,
+        summary=CandidateSummary(
+            series="Foo Comics",
+            issue="5",
+            year=2020,
+            publisher="Quality Comics",
+            page_count=page_count,
+            cover_url=cover_url,
+            variant_label=None,
+        ),
+        volume_id=volume_id,
+    )
+
+
+def _settings(*, auto_threshold: float, match: MatchMode) -> OnlineSettings:
+    return OnlineSettings(
+        lookup=OnlineLookupSettings(match=match, prompts=Prompts.ASK),
+        tuning=OnlineTuningSettings(auto_threshold=auto_threshold),
+    )
+
+
+def _scored(
+    *, issue_id: int, volume_id: int, metadata_score: float, cover_url: str | None
+) -> Candidate:
+    """Build a pre-scored candidate as `_apply_cover_hashing` receives them."""
+    c = _candidate(issue_id=issue_id, volume_id=volume_id, cover_url=cover_url)
+    return replace(c, metadata_score=metadata_score, score=metadata_score)
+
+
+def _straddling_candidate_list(*, twin_cover_url: str | None) -> list[Candidate]:
+    """
+    Twelve candidates whose ranks 5 and 6 straddle the hashing top-K.
+
+    K = 12 // 2 = 6, so rank 5 is hashed and rank 6 is not. The two
+    carry identical metadata scores and differ only in volume id, with
+    the *unhashed* twin holding the lower (canonical-looking) one — the
+    shape where the volume_id tiebreak can discard a measured cover.
+    """
+    leaders = [
+        _scored(issue_id=i, volume_id=i, metadata_score=0.95, cover_url=_COVER_URL)
+        for i in range(5)
+    ]
+    measured = _scored(
+        issue_id=10, volume_id=500, metadata_score=0.91, cover_url=_COVER_URL
+    )
+    twin = _scored(
+        issue_id=20, volume_id=100, metadata_score=0.91, cover_url=twin_cover_url
+    )
+    tail = [
+        _scored(
+            issue_id=30 + i,
+            volume_id=900 + i,
+            metadata_score=0.60,
+            cover_url=_COVER_URL,
+        )
+        for i in range(5)
+    ]
+    return [*leaders, measured, twin, *tail]
+
+
+def _perfect_match_fetcher(url: str) -> str:
+    del url
+    return _LOCAL_HASH
+
+
+# ------------- cover hash: "not computed" is not "no cover"
+
+
+class TestCoverHashNotComputedVsUnavailable:
+    """`cover_score is None` means two different things; they differ here."""
+
+    def test_never_hashed_twin_does_not_collapse_a_measured_cover(self) -> None:
+        """
+        A candidate outside top-K can't win a tie on volume id alone.
+
+        Rank 5's cover is a perfect Hamming match against the local
+        copy; rank 6 has identical metadata, a lower volume id, and a
+        cover nobody looked at because the adaptive top-K stopped one
+        candidate short. Collapsing them treats "not computed" as "no
+        signal" and hands the win to the unexamined record.
+        """
+        result = _apply_cover_hashing(
+            _straddling_candidate_list(twin_cover_url=_COVER_URL),
+            local_hash=_LOCAL_HASH,
+            candidate_hash_fetcher=_perfect_match_fetcher,
+        )
+
+        measured, twin = result[5], result[6]
+        assert measured.issue_id == 10
+        assert measured.cover_score == 1.0
+        assert measured.cover_hash_attempted
+        # The twin was never examined: no score, and no attempt either.
+        assert twin.issue_id == 20
+        assert twin.cover_score is None
+        assert not twin.cover_hash_attempted
+        # Same metadata, blended gap inside the tie margin — the group
+        # would have formed if the missing cover counted as noise.
+        assert measured.metadata_score == twin.metadata_score
+        assert 0 < measured.score - twin.score <= 0.02
+
+    def test_hashed_twin_with_no_cover_still_yields_to_volume_id(self) -> None:
+        """
+        An examined candidate with no usable cover keeps the old fallback.
+
+        Same shape, but the twin sits *inside* the hashing top-K with no
+        `cover_url` at all. There is no cover signal to be had for it,
+        so the canonical-volume preference decides, exactly as before.
+        """
+        candidates = _straddling_candidate_list(twin_cover_url=None)
+        # Move the coverless twin inside K (rank 4) and a leader out.
+        candidates[4], candidates[6] = candidates[6], candidates[4]
+
+        result = _apply_cover_hashing(
+            candidates,
+            local_hash=_LOCAL_HASH,
+            candidate_hash_fetcher=_perfect_match_fetcher,
+        )
+
+        twin, measured = result[5], result[6]
+        assert twin.issue_id == 20
+        assert twin.cover_score is None
+        assert twin.cover_hash_attempted  # examined, just unusable
+        assert measured.issue_id == 10
+        # Lower volume id wins the tie, as it always has.
+        assert twin.volume_id == 100
+        assert measured.volume_id == 500
+
+    def test_cover_diff_is_noise_tri_state(self) -> None:
+        """The predicate directly, on all three shapes of a missing score."""
+        measured = replace(_candidate(issue_id=1), cover_score=1.0)
+        unexamined = replace(_candidate(issue_id=2), cover_hash_attempted=False)
+        coverless = replace(_candidate(issue_id=3), cover_hash_attempted=True)
+        close = replace(_candidate(issue_id=4), cover_score=0.98)
+        far = replace(_candidate(issue_id=5), cover_score=0.80)
+
+        # Two measured scores: the margin decides, in both orders.
+        assert _cover_diff_is_noise(measured, close)
+        assert not _cover_diff_is_noise(measured, far)
+        assert not _cover_diff_is_noise(far, measured)
+        # Neither measured: no signal at all.
+        assert _cover_diff_is_noise(unexamined, coverless)
+        # Measured vs examined-but-coverless: still no signal to compare.
+        assert _cover_diff_is_noise(measured, coverless)
+        assert _cover_diff_is_noise(coverless, measured)
+        # Measured vs never-examined: the measurement stands.
+        assert not _cover_diff_is_noise(measured, unexamined)
+        assert not _cover_diff_is_noise(unexamined, measured)
+
+
+# ------------- hashed / un-hashed scoring asymmetry (documented, not fixed)
+
+
+class TestHashedUnhashedAsymmetry:
+    """
+    Measuring a cover moves the bar a candidate has to clear.
+
+    Un-hashed candidates are scored on raw metadata; hashed ones on
+    `0.80*md + 0.20*cover`. Both are compared against one
+    `auto_threshold`. These tests pin the consequence so a future
+    calibration run has a stated baseline to move — they are not an
+    endorsement of the asymmetry.
+    """
+
+    def test_break_even_cover_for_the_shipped_bar(self) -> None:
+        """A hashed candidate holds bar T only while cover >= (T - 0.8*md)/0.2."""
+        perfect = replace(_candidate(), metadata_score=1.0, cover_score=0.75)
+        assert final_score(perfect, hash_used=True) == pytest.approx(0.95)
+        assert final_score(replace(perfect, cover_score=0.74), hash_used=True) < 0.95
+        # Below md 0.9375 the 0.95 bar is out of reach at any cover
+        # score — the ceiling CV's publisher/page-less search results
+        # actually live under.
+        cv_shaped = replace(_candidate(), metadata_score=0.9125, cover_score=1.0)
+        assert final_score(cv_shaped, hash_used=True) < 0.95
+        # Un-hashed, the same metadata score is the score.
+        assert final_score(cv_shaped, hash_used=False) == 0.9125
+
+    def test_same_candidate_auto_writes_unmeasured_and_prompts_measured(self) -> None:
+        """
+        One perfect-metadata candidate, two outcomes, decided by its cover.
+
+        Without a local cover to hash against (thumbnail library, PDF
+        with no readable page, cover fetch failure) the candidate keeps
+        md=1.0 and auto-writes. With a mediocre measured cover it lands
+        at 0.90 and prompts, on identical metadata.
+        """
+        matcher = OnlineMatcher()
+        # A perfect match plus a near-tie: the gap stays under the
+        # disambiguation margin, which is what invokes hashing at all.
+        candidates = [
+            _candidate(issue_id=1, volume_id=10, cover_url=_COVER_URL),
+            _candidate(issue_id=2, volume_id=20, page_count=22, cover_url=_COVER_URL),
+        ]
+        settings = _settings(auto_threshold=0.95, match=MatchMode.EAGER)
+
+        unmeasured = matcher.rank(_profile(), candidates)
+        assert unmeasured[0].score == pytest.approx(1.0)
+        assert (
+            matcher.resolve(unmeasured, settings, "metron").kind
+            is ResolutionKind.AUTO_WRITE
+        )
+
+        measured = matcher.rank(
+            _profile(),
+            candidates,
+            local_hash_provider=lambda: _LOCAL_HASH,
+            candidate_hash_fetcher=lambda _url: _HALF_MATCH_HASH,
+            threshold=0.95,
+        )
+        assert measured[0].cover_score == pytest.approx(0.5)
+        assert measured[0].score == pytest.approx(0.9)
+        assert (
+            matcher.resolve(measured, settings, "metron").kind is ResolutionKind.PROMPT
+        )


### PR DESCRIPTION
Audit of the matcher's scoring against `tests/calibration` and the calibration notes, which turn out not to be in the tree — `tasks/online-tagging/` was removed in `d38eadd` and never reached `develop`. They're readable at `git show d38eadd^:tasks/online-tagging/calibration-notes/<file>`, and this PR re-establishes the directory with a new note.

Two behavioral fixes, both provable without a live run. **No weights were retuned** — `W_SERIES`…`W_COVER`, `_COVER_DIFF_NOISE_MARGIN` and `_TIED_METADATA_BLEND_MARGIN` are untouched.

## 1. The solo floor had come loose from the auto bar

`DEFAULT_SOLO_THRESHOLD = 0.85` was **drift, not calibration**: the 2026-05-12 slimlib note introduces Phase E's floor as "default 0.95 = same as the global confidence threshold", and it only disagreed because `OnlineTuningSettings.auto_threshold` had itself drifted to 0.85. #179 fixed the value; the hand-written mirror survived. `resolve_solo_threshold` read a module constant while `resolve_auto_threshold` resolves per-source → global → CLI → env, so:

- `auto_threshold: 0.98` left a lone 0.96-scoring candidate auto-writing through a **0.95 back door no setting could close**.
- Lowering the bar left the floor stricter than the bar it is defined to mirror.

It now falls back to `resolve_auto_threshold` for the same source. Identical behavior at defaults; the constant is gone, so there is no second declaration to drift. The drift test pins the coupling across global, per-source, and explicit-override configurations.

Documented while there, because it reads like a bug: with the floor at the bar, Phase E's carve-out is subsumed — `solo_viable` implies every other candidate is below `min_confidence`, so a top clearing the threshold is already `unambig`. **`AUTO` behaves exactly like `CAREFUL` out of the box**, and the carve-out only widens it once a user lowers `solo_threshold`.

## 2. "Cover hash not computed" ≠ "no cover available"

`_cover_diff_is_noise` treated any missing `cover_score` as noise, so `_apply_tied_metadata_tiebreak` collapsed the pair and gave the win to the lower `volume_id`. Two situations reached that branch: a candidate that *was* hashed and had no usable cover (a real absence of signal), and one outside the hashing top-K that nobody looked at. `Candidate.cover_hash_attempted` tells them apart; only the first still counts as noise, so a cover measured against the local copy is no longer overruled by one that was never fetched.

Blast radius is small by construction: ≥ 6 candidates (K ≥ 5), an *exact* metadata-score tie straddling the K boundary, and blended scores within the 0.02 tie margin. Tested both ways — the requested rank &lt; K vs rank &gt; K case, and the attempted-but-coverless case whose behavior is unchanged.

## 3. Hashed vs un-hashed asymmetry — quantified, not changed

An un-hashed candidate is scored on raw metadata, a hashed one on `0.80*md + 0.20*cover`, both against one threshold. So a hashed candidate holds bar T only while `cover >= (T - 0.80*md) / 0.20`: at T = 0.95 that's cover ≥ 0.75 for a flawless md = 1.0, and unreachable below md 0.9375. Against the 2026-05-17 bigmedia outcomes:

- 48% of 548 measured cover scores are below 0.75.
- The blend lowered the top candidate's score in 114 of 306 hashed fixtures.
- Had the bar been 0.90, 45 tops would have been pushed under a bar their metadata cleared — 41 of them the correct match.
- At the real 0.95 bar the count is 0 because **nothing in the corpus reaches 0.95 either way** (CV tops out at 0.930, Metron at 0.915), so the default policy prompts on everything and the auto-write band has never been measured on real data.

Four candidate fixes and what a run should measure are in the note. None ship here — changing the blend changes which files get written.

## 4. Stale prose

- The tiebreak documented the cover-diff guard as `<=0.05`; Phase G tightened the constant to 0.03 in May.
- `_top_k_for_hashing` / `_apply_cover_hashing` justified adaptive K by Phase H's broaden retry, reverted in `62a5725` / `b407815` — and Phase J flipped zero outcomes on the corpus that motivated it.
- `settings.py`'s comment contradicting the value below it (already fixed by #179; the coupling is item 1).
- The calibration report labelled 0.85-0.95 the "auto-write" band, which the shipped bar sends to a prompt. Labels now derive from `DEFAULT_AUTO_THRESHOLD`, so notes can't credit the auto-write band with prompt-zone accuracy again.

## Verification

`make fix`, `make lint`, `make ty`, `make complexity` clean; `make test` 1644 passed, 1 skipped (pre-existing). The five new behavioral tests were checked against the pre-fix code and all five fail there.

No calibration run — it needs live Metron/ComicVine credentials and hours of API budget. The analysis above is over the outcomes file already on disk from the 2026-05-17 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)