### PR TITLE
fix(computed): five pipeline defects, and one explicit ordered registry

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,15 @@
       one.
     - `add_metadata(md, fmt=…)` accepts every format instead of raising on the
       ones no source declares, like the online formats.
+    - A page whose archive entry reports no size no longer drops every computed
+      field for the comic.
+    - A date part that cannot exist, like a 30th of February, is dropped instead
+      of being kept.
+    - A notes stamp naming a database of more than one word — `Comic Vine`,
+      `Grand Comics Database`, `League of Comic Geeks` — is read, whatever its
+      case. An unrecognized name is no longer read as ComicVine.
+    - An issue naming a suffix but no number, like `1234AU`, gets its number.
+    - A notes timestamp nothing can parse leaves `updated_at` unset.
 
 - Features
     - Web urls in the Notes field are read into `urls`.

--- a/comicbox/box/computed/__init__.py
+++ b/comicbox/box/computed/__init__.py
@@ -1,6 +1,29 @@
-"""Computed metadata methods."""
+"""
+Computed metadata methods, and the ordered pipeline that runs them.
 
-from collections.abc import Callable, Mapping
+Each computed action reads the merged metadata snapshot and returns a delta.
+The delta is merged back into that snapshot before the next action runs, so
+order is part of the contract rather than an implementation detail:
+``identifiers from urls`` must see the urls ``urls from notes`` collected,
+``urls`` must see every identifier the earlier actions found, and
+``Tagger Stamp`` must run after both because it bakes the finished
+identifiers into the notes text it writes.
+
+That order used to be an accident of the mixin MRO. Each of the nine modules
+in this package spliced its own actions into the inherited ``COMPUTED_ACTIONS``
+mapping with a dict splat, so reading the pipeline meant walking the
+inheritance chain backwards - and ``pages`` spliced its two actions in *front*
+of the inherited ones while the other eight appended, which is the only reason
+the page actions run first. ``COMPUTED_ACTIONS`` below is that same order,
+written out once, in one place.
+
+Actions are registered by method *name*, not by the function object lifted out
+of a class body. The splat captured unbound functions, so a subclass overriding
+a computed method was silently never called; ``getattr(self, name)`` dispatches
+through the instance like every other method call.
+"""
+
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -43,6 +66,15 @@ class ComputedData:
 
     label: str
     metadata: Mapping | None
+    merger: type[Merger] | None = AdditiveMerger
+
+
+@dataclass(frozen=True)
+class ComputedAction:
+    """One step of the computed pipeline."""
+
+    label: str
+    method_name: str
     merger: type[Merger] | None = AdditiveMerger
 
 
@@ -143,62 +175,122 @@ class ComicboxComputed(ComicboxComputedStoriesTitle):
             return {REPRINTS_KEY: new_reprints}
         return None
 
-    def _get_delete_keys(self, _sub_data: Mapping) -> tuple | None:
-        if not self._config.general.delete_keys:
-            return None
-        return tuple(sorted(self._config.general.delete_keys | self._extra_delete_keys))
+    def _all_delete_keys(self) -> frozenset[str]:
+        """
+        Every key path the delete pass must remove.
 
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                # Order is important here
-                **ComicboxComputedStoriesTitle.COMPUTED_ACTIONS,
-                "from reprint names": (
-                    _get_computed_from_reprint_names,
-                    ReplaceMerger,
-                ),
-                "from reprints": (_get_computed_from_reprints, ReplaceMerger),
-                "from scan_info": (_get_computed_from_scan_info, AdditiveMerger),
-                "Delete Keys": (_get_delete_keys, None),
-            }
-        )
+        The config's own delete_keys, plus the ones the computed pass earned
+        as it ran: a date part that cannot be part of any real date names
+        itself here rather than surviving into the metadata.
+        """
+        return frozenset(self._config.general.delete_keys | self._extra_delete_keys)
+
+    def _get_delete_keys(self, _sub_data: Mapping) -> tuple | None:
+        delete_keys = self._all_delete_keys()
+        if not delete_keys:
+            return None
+        return tuple(sorted(delete_keys))
+
+    # Order is the contract. See the module docstring.
+    COMPUTED_ACTIONS: tuple[ComputedAction, ...] = (
+        # What the archive itself says, independent of every other action.
+        ComputedAction(
+            "Page Count", "_get_computed_page_count_metadata", ReplaceMerger
+        ),
+        ComputedAction("Pages", "_get_computed_pages_metadata", ReplaceMerger),
+        # Identifiers, weakest source last: a url names an id more plainly
+        # than notes prose, and notes prose more plainly than a tag.
+        ComputedAction("urls from notes", "_get_computed_urls_from_notes"),
+        ComputedAction("identifiers from urls", "_get_computed_identifiers_from_urls"),
+        ComputedAction("from notes", "get_computed_from_notes"),
+        ComputedAction("from tags", "_get_computed_from_tags"),
+        ComputedAction("normalize identifier keys", "_normalize_all_identifier_keys"),
+        # Synthesize the urls the identifiers imply, then stamp the finished
+        # identifiers into notes.
+        ComputedAction("urls", "_get_computed_urls", ReplaceMerger),
+        ComputedAction("Tagger Stamp", "_get_tagger_stamp", ReplaceMerger),
+        # Field derivations. Each reads one branch of the tree and writes
+        # another, so they only depend on the merged metadata.
+        ComputedAction("from manga_volume", "_get_computed_from_manga_volume"),
+        ComputedAction("from issue", "_get_computed_from_issue"),
+        ComputedAction("from issue.number & issue.suffix", "_get_computed_issue"),
+        ComputedAction(
+            "from alternative_issue", "_get_computed_from_alternative_issue"
+        ),
+        ComputedAction(
+            "from alternative_issue.number & alternative_issue.suffix",
+            "_get_computed_alternative_issue",
+        ),
+        ComputedAction("from date", "_get_computed_from_date"),
+        # title & stories feed each other; whichever the book has fills the
+        # other, and the second action sees the first one's result.
+        ComputedAction("from title", "_get_computed_from_title"),
+        ComputedAction("from stories", "_get_computed_from_stories"),
+        ComputedAction(
+            "from reprint names", "_get_computed_from_reprint_names", ReplaceMerger
+        ),
+        ComputedAction("from reprints", "_get_computed_from_reprints", ReplaceMerger),
+        ComputedAction("from scan_info", "_get_computed_from_scan_info"),
+        # Reports the delete pass's key paths for --print; deletion itself
+        # happens in ComicboxMetadata, after every action has run.
+        ComputedAction("Delete Keys", "_get_delete_keys", None),
     )
 
     def _set_computed_metadata(self) -> None:
         computed_list = []
-        merged_md = self.get_merged_metadata()
         # Deep copy: actions receive sub_data and some (reprints) merge
         # entries in place; without the copy they'd silently mutate the
         # cached merged metadata they're supposed to derive from.
-        sub_data = deepcopy(dict(merged_md.get(ComicboxSchemaMixin.ROOT_TAG, {})))
+        computed_merged_md = deepcopy(dict(self.get_merged_metadata()))
+        sub_data: dict[str, Any] = computed_merged_md.setdefault(
+            ComicboxSchemaMixin.ROOT_TAG, {}
+        )
+        # Actions add to this as they run; a recompute starts over.
+        self._extra_delete_keys = set()
 
         # Compute each
-        for label, actions in self.COMPUTED_ACTIONS.items():
-            method, merger = actions
-            sub_md = method(self, sub_data)
+        for action in self.COMPUTED_ACTIONS:
+            method = getattr(self, action.method_name)
+            sub_md = method(sub_data)
             if not sub_md:
                 continue
 
-            if merger:
+            if action.merger:
                 # Actions derive from each other: normalized keys build urls,
                 # and both are stamped into notes. Merge the delta into the
-                # snapshot so later actions see it. The copy keeps the stored
-                # delta from aliasing the snapshot a later action may change.
-                merger.merge(sub_data, deepcopy(sub_md))
+                # snapshot so later actions see it. That accumulated snapshot
+                # *is* the computed metadata — ComicboxMetadata reads it back
+                # instead of replaying every delta onto a second copy. The
+                # copy keeps the stored delta from aliasing the snapshot a
+                # later action may change.
+                action.merger.merge(sub_data, deepcopy(sub_md))
 
             md = {ComicboxSchemaMixin.ROOT_TAG: sub_md}
-            computed_data = ComputedData(label, md, merger)
+            computed_data = ComputedData(action.label, md, action.merger)
             computed_list.append(computed_data)
 
         # Set values
         self._computed = tuple(computed_list)
+        self._computed_merged_metadata = MappingProxyType(computed_merged_md)
         self._computed_dict_formats = self._dict_formats
 
-    def get_computed_metadata(self) -> tuple:
-        """Get the computed metadata for printing."""
-        # Recompute when the dict-format context changed: pages/page_count
-        # computation consults _dict_formats, so a result memoized under
-        # one to_dict() format must not leak into calls under another.
-        if not self._computed or self._computed_dict_formats != self._dict_formats:
+    def _ensure_computed_metadata(self) -> None:
+        """Recompute when the dict-format context changed."""
+        # pages/page_count computation consults _dict_formats, so a result
+        # memoized under one to_dict() format must not leak into calls under
+        # another.
+        if (
+            not self._computed_merged_metadata
+            or self._computed_dict_formats != self._dict_formats
+        ):
             self._set_computed_metadata()
+
+    def get_computed_metadata(self) -> tuple:
+        """Get the computed metadata deltas, labelled, for printing."""
+        self._ensure_computed_metadata()
         return self._computed
+
+    def get_computed_merged_metadata(self) -> MappingProxyType:
+        """Get the merged metadata with every computed delta already applied."""
+        self._ensure_computed_metadata()
+        return self._computed_merged_metadata

--- a/comicbox/box/computed/date.py
+++ b/comicbox/box/computed/date.py
@@ -1,8 +1,6 @@
 """Comicbox Computed Date tags."""
 
-from collections.abc import Callable
 from datetime import date
-from types import MappingProxyType
 from typing import Any
 
 from loguru import logger
@@ -15,7 +13,6 @@ from comicbox.formats.comicbox.schema import (
     MONTH_KEY,
     YEAR_KEY,
 )
-from comicbox.merge import AdditiveMerger, Merger
 
 _DATE_PART_KEYS = (YEAR_KEY, MONTH_KEY, DAY_KEY)
 
@@ -85,13 +82,3 @@ class ComicboxComputedDate(ComicboxComputedIssue):
         if not computed_date:
             return None
         return {DATE_KEY: computed_date}
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                # Order is important here
-                **ComicboxComputedIssue.COMPUTED_ACTIONS,
-                "from date": (_get_computed_from_date, AdditiveMerger),
-            }
-        )
-    )

--- a/comicbox/box/computed/identifiers.py
+++ b/comicbox/box/computed/identifiers.py
@@ -1,6 +1,6 @@
 """Comicbox computed identifiers."""
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any
 
@@ -32,7 +32,6 @@ from comicbox.identifiers.other import (
 from comicbox.identifiers.urns import (
     parse_urn_identifier,
 )
-from comicbox.merge import AdditiveMerger, Merger
 
 _IDENTIFIED_KEYS = (PUBLISHER_KEY, IMPRINT_KEY, SERIES_KEY)
 _IDENTIFIED_TAG_KEYS = (
@@ -170,16 +169,3 @@ class ComicboxComputedIdentifiers(ComicboxComputedNotes):
             if tag_deltas := self._key_deltas_for_multiple_tags(key, all_tags):
                 tree[key] = tag_deltas
         return tree or None
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                **ComicboxComputedNotes.COMPUTED_ACTIONS,
-                "from tags": (_get_computed_from_tags, AdditiveMerger),
-                "normalize identifier keys": (
-                    _normalize_all_identifier_keys,
-                    AdditiveMerger,
-                ),
-            }
-        )
-    )

--- a/comicbox/box/computed/issue.py
+++ b/comicbox/box/computed/issue.py
@@ -1,8 +1,6 @@
 """Comicbox Computed Issue tags."""
 
 import re
-from collections.abc import Callable
-from types import MappingProxyType
 from typing import Any
 
 from loguru import logger
@@ -21,7 +19,6 @@ from comicbox.formats.comicbox.schema import (
     VOLUME_KEY,
     VOLUME_NUMBER_TO_KEY,
 )
-from comicbox.merge import AdditiveMerger, Merger
 
 ISSUE_SUFFIX_KEYPATH = f"{ISSUE_KEY}.{ISSUE_SUFFIX_KEY}"
 _PARSE_ISSUE_MATCHER = re.compile(r"(\d*\.?\d*)(.*)")
@@ -71,7 +68,11 @@ class ComicboxComputedIssue(ComicboxComputedStamp):
         try:
             if (
                 issue_name
-                and (not is_empty(old_issue_number) or not old_issue_suffix)
+                # Parse when a part is *missing*. The number half of this
+                # guard was inverted, so an issue that named a suffix but no
+                # number — the one case where the name is the only place the
+                # number is written — never got parsed at all.
+                and (is_empty(old_issue_number) or not old_issue_suffix)
                 and (match := _PARSE_ISSUE_MATCHER.match(issue_name))
             ):
                 self._parse_issue_match(
@@ -148,28 +149,3 @@ class ComicboxComputedIssue(ComicboxComputedStamp):
         if not volume:
             return None
         return {VOLUME_KEY: volume}
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                **ComicboxComputedStamp.COMPUTED_ACTIONS,
-                "from manga_volume": (
-                    _get_computed_from_manga_volume,
-                    AdditiveMerger,
-                ),
-                "from issue": (_get_computed_from_issue, AdditiveMerger),
-                "from issue.number & issue.suffix": (
-                    _get_computed_issue,
-                    AdditiveMerger,
-                ),
-                "from alternative_issue": (
-                    _get_computed_from_alternative_issue,
-                    AdditiveMerger,
-                ),
-                "from alternative_issue.number & alternative_issue.suffix": (
-                    _get_computed_alternative_issue,
-                    AdditiveMerger,
-                ),
-            }
-        )
-    )

--- a/comicbox/box/computed/notes.py
+++ b/comicbox/box/computed/notes.py
@@ -1,17 +1,63 @@
-"""Computed metadata methods."""
+"""
+Read structured metadata back out of a free-text notes field.
+
+Most formats have one notes field and nowhere else to put a tagger name, a
+timestamp, a release date, a database id or a url, so taggers write all of
+them into that prose. This module parses each of those back into its own
+comicbox field.
+
+Grammar read here
+-----------------
+- ``Tagged with|by <tagger>[ <version>]`` -> ``tagger``
+- ``on <YYYY-MM-DD[ T]HH:MM:SS...>``      -> ``updated_at``
+- ``[RELDATE:<date>]``                    -> ``date.cover_date`` + parts
+- ``using info from <source>`` paired with ``[Issue ID <key>]``
+  -> ``identifiers[source]``  (ComicTagger's own stamp)
+- ``urn:<source>:<type>:<key>``           -> ``identifiers[source]``
+- ``[<source>:<type>:<key>]``, ``[CVDB1234]`` -> ``identifiers[source]``
+
+Urls in notes are read one step earlier, by ``url_identifiers``, because the
+stamp below replaces the whole notes text and a url that lived only in that
+prose would otherwise be gone.
+
+What the tagger stamp writes back
+---------------------------------
+``ComicboxComputedStamp._get_computed_notes_stamp`` rebuilds notes from
+scratch as ``Tagged with <tagger> on <ts> [Issue ID <comicvine key>]`` plus a
+urn for every identifier. It is a projection of the structured fields, not an
+edit of the text it replaces, so restamping is lossy *as text*. Each loss, and
+why it is not a loss of data:
+
+- ``[RELDATE:...]`` is not written back. The date it named was parsed into
+  ``date.cover_date``/``year``/``month``/``day``, which every write format
+  carries, so the date survives; only the prose spelling of it is dropped.
+- Urls are not written back. ``url_identifiers`` collected them into ``urls``
+  before the stamp ran, and ``urls`` is a real field.
+- ``using info from <source>`` is not written back. The source it named is
+  what each urn's first field says, so the fact survives in a form this
+  parser can read without a second clause to pair it with.
+- Bracketed ``[CVDB1234]``-style identifiers come back as urns. Different
+  spelling, same source, type and key.
+- ``[Issue ID <key>]`` is written for ComicVine only, for ComicTagger's
+  benefit. Comicbox reads its own ids back from the urns, which cover every
+  source.
+- Anything else a human wrote in notes is discarded. That is the one real
+  loss, and it is the point of the field being a stamp: the stamp is only
+  written when the caller asks comicbox to write, convert or export.
+"""
 
 import re
-from collections.abc import Callable
 from datetime import date
-from types import MappingProxyType
 from typing import Any
 
 from loguru import logger
 
 from comicbox.box.computed.url_identifiers import ComicboxComputedUrlIdentifiers
-from comicbox.enums.maps.identifiers import ID_SOURCE_NAME_MAP, get_id_source_by_alias
+from comicbox.enums.maps.identifiers import (
+    ID_SOURCE_NAME_RE_EXP,
+    get_id_source_by_alias,
+)
 from comicbox.formats.base.fields.time_fields import DateField, DateTimeField
-from comicbox.formats.base.schemas.cache import get_schema
 from comicbox.formats.comicbox.schema import (
     COVER_DATE_KEY,
     DATE_KEY,
@@ -23,7 +69,6 @@ from comicbox.formats.comicbox.schema import (
     UPDATED_AT_KEY,
     YEAR_KEY,
 )
-from comicbox.formats.comicbox.schema.yaml import ComicboxYamlSubSchema
 from comicbox.identifiers import IDENTIFIER_RE_EXP, match_id_source_str
 from comicbox.identifiers.identifiers import (
     create_identifier,
@@ -32,28 +77,30 @@ from comicbox.identifiers.urns import (
     URN_SCAN_EXP,
     parse_urn_identifier,
 )
-from comicbox.merge import AdditiveMerger, Merger
+from comicbox.merge import AdditiveMerger
 
 _DATE_KEYS = frozenset({COVER_DATE_KEY, YEAR_KEY, MONTH_KEY, DAY_KEY})
 _NOTES_TAGGER_VERSION_EXP = r"(?:\s(?:dev|test|[\d\.]+\S+))?"
-_NOTES_TAGGER_RE_EXP = (
-    r"(?:Tagged\s(?:with|by)\s(?P<tagger>\w+" + _NOTES_TAGGER_VERSION_EXP + "))"
+_NOTES_TAGGER_RE = re.compile(
+    r"(?:Tagged\s(?:with|by)\s(?P<tagger>\w+" + _NOTES_TAGGER_VERSION_EXP + "))",
+    flags=re.IGNORECASE,
 )
-_NOTES_TAGGER_RE = re.compile(_NOTES_TAGGER_RE_EXP)
-_NOTES_UPDATED_AT_RE_EXP = r"(?:\s+on\s(?P<updated_at>[12]\d{3}-[012]\d-[01]\d[\sT](?:[012]\d:\d{2}:\d{2}\S*)?))"
-_NOTES_UPDATED_AT_RE = re.compile(_NOTES_UPDATED_AT_RE_EXP)
-_NOTES_ORIGIN_RE_EXP = r"(?:\s+using info from (?P<origin>\w+))"
-_NOTES_IDENTIFIER_RE_EXP = r"(?:\s+\[Issue ID (?P<id_key>\w+)\])"
-_NOTES_RE_EXP = (
-    _NOTES_TAGGER_RE_EXP
-    + _NOTES_UPDATED_AT_RE_EXP
-    + r"?"
-    + _NOTES_ORIGIN_RE_EXP
-    + r"?"
-    + _NOTES_IDENTIFIER_RE_EXP
-    + r"?"
+_NOTES_UPDATED_AT_RE = re.compile(
+    r"(?:\s+on\s(?P<updated_at>[12]\d{3}-[012]\d-[01]\d[\sT](?:[012]\d:\d{2}:\d{2}\S*)?))",
+    flags=re.IGNORECASE,
 )
-_NOTES_RE = re.compile(_NOTES_RE_EXP, flags=re.IGNORECASE)
+# Every name and alias a source answers to, so the multi-word ones ("Comic
+# Vine", "Grand Comics Database", "League of Comic Geeks") match. A bare \w+
+# stopped at the first space and then resolved to nothing, which made this
+# whole clause dead for most of the databases comicbox knows.
+_NOTES_ORIGIN_RE = re.compile(
+    r"using\sinfo\sfrom\s(?P<origin>" + ID_SOURCE_NAME_RE_EXP + r")",
+    flags=re.IGNORECASE,
+)
+# ComicTagger writes the origin and the issue id at opposite ends of its
+# stamp, with the timestamp between them, so they are searched for
+# separately. Both spellings are distinctive enough to stand alone.
+_NOTES_ISSUE_ID_RE = re.compile(r"\[Issue ID (?P<id_key>\w+)\]", flags=re.IGNORECASE)
 # One grammar for urns, owned by the urns module that reads and writes them.
 # A hand-maintained copy here drifted: it accepted a one character namespace
 # and a trailing hyphen that the urn parser then rejected.
@@ -63,7 +110,6 @@ _NOTES_IDENTIFIER_EXTRA_EXP = r"\[" + IDENTIFIER_RE_EXP + r"\]"
 _NOTES_IDENTIFIER_EXTRA_RE = re.compile(
     _NOTES_IDENTIFIER_EXTRA_EXP, flags=re.IGNORECASE
 )
-_NOTES_KEYS = (TAGGER_KEY, UPDATED_AT_KEY)
 _NOTES_RELDATE_RE = re.compile(r"\[RELDATE:(?P<reldate>\S+)\]")
 # Field instances are stateless parsers; one of each is enough.
 _DATE_FIELD = DateField()
@@ -73,34 +119,21 @@ _DATETIME_FIELD = DateTimeField()
 class ComicboxComputedNotes(ComicboxComputedUrlIdentifiers):
     """Computed metadata methods for notes field."""
 
-    def _set_computed_notes_key(
-        self,
-        sub_data: dict[str, Any],
-        key: str,
-        match: re.Match[str],
-        md: dict[str, Any],
-    ) -> None:
-        schema = get_schema(ComicboxYamlSubSchema, path=self._path)
-        if not sub_data.get(key) and (new_value := match.group(key)):
-            field = schema.fields.get(key)
-            if not field:
-                return
-            new_value = field.deserialize(new_value)
-            md[key] = new_value
-
-    def _get_computed_notes_keys_comictagger(
-        self, notes: str, sub_data: dict[str, Any], md: dict[str, Any]
-    ) -> dict:
+    @staticmethod
+    def _get_computed_notes_comictagger_identifier(notes: str) -> dict:
+        """Read the source & issue id out of a ComicTagger style stamp."""
         identifiers = {}
-        match = _NOTES_RE.search(notes)
-        if not match:
-            return identifiers
-        for key in _NOTES_KEYS:
-            self._set_computed_notes_key(sub_data, key, match, md)
+        origin_match = _NOTES_ORIGIN_RE.search(notes)
+        id_key_match = _NOTES_ISSUE_ID_RE.search(notes)
         if (
-            (origin := match.group("origin"))
-            and (id_source := ID_SOURCE_NAME_MAP.inverse.get(origin))
-            and (id_key := match.group("id_key"))
+            origin_match
+            and id_key_match
+            # default=None: an unrecognized origin names no source. The
+            # default would silently file every one of them under ComicVine.
+            and (
+                id_source := get_id_source_by_alias(origin_match.group("origin"), None)
+            )
+            and (id_key := id_key_match.group("id_key"))
             and (identifier := create_identifier(id_source.value, id_key))
         ):
             identifiers[id_source.value] = identifier
@@ -143,9 +176,7 @@ class ComicboxComputedNotes(ComicboxComputedUrlIdentifiers):
         self, sub_data: dict[str, Any], notes: str, sub_md: dict[str, Any]
     ) -> None:
         extra_identifiers = self._get_computed_notes_extra_identifiers(notes)
-        comictagger_identifiers = self._get_computed_notes_keys_comictagger(
-            notes, sub_data, sub_md
-        )
+        comictagger_identifiers = self._get_computed_notes_comictagger_identifier(notes)
         urn_identifiers = self._get_computed_notes_urn_identifiers(notes)
         explicit_identifiers = sub_data.get(IDENTIFIERS_KEY, {})
         pruned_notes_identifiers = {}
@@ -194,8 +225,9 @@ class ComicboxComputedNotes(ComicboxComputedUrlIdentifiers):
             new_date.update(old_date)
             sub_md[DATE_KEY] = new_date
 
+    @staticmethod
     def _set_computed_notes_tagger(
-        self, sub_data: dict[str, Any], notes: str, sub_md: dict[Any, Any]
+        sub_data: dict[str, Any], notes: str, sub_md: dict[Any, Any]
     ) -> None:
         if sub_data.get(TAGGER_KEY):
             # Do not overwrite an explicit tagger
@@ -206,11 +238,11 @@ class ComicboxComputedNotes(ComicboxComputedUrlIdentifiers):
         match_group = match.group("tagger")
         if not match_group:
             return
-        tagger = match.group("tagger").strip()
-        sub_md[TAGGER_KEY] = tagger
+        sub_md[TAGGER_KEY] = match_group.strip()
 
+    @staticmethod
     def _set_computed_notes_updated_at(
-        self, sub_data: dict[str, Any], notes: str, sub_md: dict[str, Any]
+        sub_data: dict[str, Any], notes: str, sub_md: dict[str, Any]
     ) -> None:
         if sub_data.get(UPDATED_AT_KEY):
             # Do not overwrite an explicit updated_at
@@ -222,8 +254,11 @@ class ComicboxComputedNotes(ComicboxComputedUrlIdentifiers):
         if not match_group:
             return
         dttm_str = match_group.strip()
-        updated_at = _DATETIME_FIELD._deserialize(dttm_str)  # noqa: SLF001
-        sub_md[UPDATED_AT_KEY] = updated_at
+        # The pattern admits impossible dates ("2020-19-19"), which the field
+        # warns about and returns None for. Writing that None back would
+        # replace a missing updated_at with an explicitly null one.
+        if updated_at := _DATETIME_FIELD._deserialize(dttm_str):  # noqa: SLF001
+            sub_md[UPDATED_AT_KEY] = updated_at
 
     def get_computed_from_notes(self, sub_data: dict[str, Any]) -> dict | None:
         """Parse the tagger, updated_at & identifier from notes if not already set."""
@@ -242,15 +277,3 @@ class ComicboxComputedNotes(ComicboxComputedUrlIdentifiers):
         if not sub_md:
             return None
         return sub_md
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                **ComicboxComputedUrlIdentifiers.COMPUTED_ACTIONS,
-                "from notes": (
-                    get_computed_from_notes,
-                    AdditiveMerger,
-                ),
-            }
-        )
-    )

--- a/comicbox/box/computed/pages.py
+++ b/comicbox/box/computed/pages.py
@@ -1,6 +1,6 @@
 """Comicbox Computed Pages."""
 
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping
 from sys import maxsize
 from types import MappingProxyType
 from typing import Any
@@ -17,7 +17,7 @@ from comicbox.formats.comicbox.schema import (
     PAGE_TYPE_KEY,
     PAGES_KEY,
 )
-from comicbox.merge import AdditiveMerger, Merger, ReplaceMerger
+from comicbox.merge import AdditiveMerger
 
 _ENABLE_PAGE_COMPUTE_ATTRS = MappingProxyType(
     {
@@ -56,15 +56,22 @@ class ComicboxComputedPages(ComicboxComputedUrls):
             return {PAGE_COUNT_KEY: real_page_count}
         return None
 
+    @staticmethod
     def _ensure_pages_front_cover_metadata(
-        self, pages: MutableMapping[int, dict[str, Any]]
+        pages: MutableMapping[int, dict[str, Any]],
     ) -> None:
         """Ensure there is a FrontCover page type in pages."""
+        if not pages:
+            return
         for page in pages.values():
             if page.get(PAGE_TYPE_KEY) == ComicInfoPageTypeEnum.FRONT_COVER:
                 return
 
-        pages[0][PAGE_TYPE_KEY] = ComicInfoPageTypeEnum.FRONT_COVER
+        # Index 0 is the front cover when it's there, but it need not be:
+        # a page whose archive entry reported no size gets no entry at all,
+        # and `pages[0]` then raised a KeyError that aborted the entire
+        # computed pass. The lowest page present is the cover.
+        pages[min(pages)][PAGE_TYPE_KEY] = ComicInfoPageTypeEnum.FRONT_COVER
 
     def _get_max_page_index(self) -> int:
         if self._path:
@@ -110,18 +117,11 @@ class ComicboxComputedPages(ComicboxComputedUrls):
                     computed_page[PAGE_SIZE_KEY] = size
                     pages[index] = computed_page
                 index += 1
+            # Inside the guard with the scan that feeds it: merging consults
+            # the archive too, and warn-and-skip is what every sibling action
+            # does with a bad archive.
+            if pages:
+                pages = self._get_computed_merged_pages_metadata(sub_md, pages)
         except Exception as exc:
             logger.warning(f"{self._path}: Compute pages metadata: {exc}")
-        if pages:
-            pages = self._get_computed_merged_pages_metadata(sub_md, pages)
         return {PAGES_KEY: pages}
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                "Page Count": (_get_computed_page_count_metadata, ReplaceMerger),
-                "Pages": (_get_computed_pages_metadata, ReplaceMerger),
-                **ComicboxComputedUrls.COMPUTED_ACTIONS,
-            }
-        )
-    )

--- a/comicbox/box/computed/stamp.py
+++ b/comicbox/box/computed/stamp.py
@@ -1,7 +1,6 @@
 """Comicbox Computed tagger, updated_at and notes stamps."""
 
 from datetime import datetime, timezone
-from types import MappingProxyType
 from typing import Any
 
 from comicbox.box.computed.pages import ComicboxComputedPages
@@ -15,7 +14,6 @@ from comicbox.formats.comicbox.schema import (
 )
 from comicbox.identifiers import ID_KEY_KEY, ID_TYPE_KEY
 from comicbox.identifiers.urns import to_urn_string
-from comicbox.merge import ReplaceMerger
 
 # A field instance is a stateless serializer; one is enough.
 _DATETIME_FIELD = DateTimeField()
@@ -110,10 +108,3 @@ class ComicboxComputedStamp(ComicboxComputedPages):
             return None
 
         return stamp_md
-
-    COMPUTED_ACTIONS = MappingProxyType(
-        {
-            **ComicboxComputedPages.COMPUTED_ACTIONS,
-            "Tagger Stamp": (_get_tagger_stamp, ReplaceMerger),
-        }
-    )

--- a/comicbox/box/computed/stories_title.py
+++ b/comicbox/box/computed/stories_title.py
@@ -1,15 +1,9 @@
 """Computed Stories and Title Methods."""
 
-from collections.abc import Callable
-from types import MappingProxyType
 from typing import Any
 
 from comicbox.box.computed.date import ComicboxComputedDate
 from comicbox.formats.comicbox.schema import STORIES_KEY, TITLE_KEY
-from comicbox.merge import (
-    AdditiveMerger,
-    Merger,
-)
 
 _TITLE_STORIES_DELIMITER = ";"
 _TITLE_STORIES_JOIN_DELIMITER = f"{_TITLE_STORIES_DELIMITER} "
@@ -51,14 +45,3 @@ class ComicboxComputedStoriesTitle(ComicboxComputedDate):
         if not stories:
             return None
         return {STORIES_KEY: stories}
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                # Order is important here
-                **ComicboxComputedDate.COMPUTED_ACTIONS,
-                "from title": (_get_computed_from_title, AdditiveMerger),
-                "from stories": (_get_computed_from_stories, AdditiveMerger),
-            }
-        )
-    )

--- a/comicbox/box/computed/url_identifiers.py
+++ b/comicbox/box/computed/url_identifiers.py
@@ -20,8 +20,6 @@ runs at the far end of the pipeline in ``urls``.
 """
 
 import re
-from collections.abc import Callable
-from types import MappingProxyType
 from typing import Any
 
 from comicbox.box.merge import ComicboxMerge
@@ -33,7 +31,6 @@ from comicbox.formats.comicbox.schema import (
 )
 from comicbox.identifiers import DEFAULT_ID_TYPE, ID_KEY_KEY, ID_TYPE_KEY
 from comicbox.identifiers.identifiers import get_identifier_url
-from comicbox.merge import AdditiveMerger, Merger
 
 _NOTES_URL_RE = re.compile(r"https?://[^\s<>\"']+", flags=re.IGNORECASE)
 # Notes are sentences. A url at the end of one takes the punctuation with it,
@@ -102,18 +99,3 @@ class ComicboxComputedUrlIdentifiers(ComicboxMerge):
         if not new_identifiers:
             return None
         return {IDENTIFIERS_KEY: new_identifiers}
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                "urls from notes": (
-                    _get_computed_urls_from_notes,
-                    AdditiveMerger,
-                ),
-                "identifiers from urls": (
-                    _get_computed_identifiers_from_urls,
-                    AdditiveMerger,
-                ),
-            }
-        )
-    )

--- a/comicbox/box/computed/urls.py
+++ b/comicbox/box/computed/urls.py
@@ -11,8 +11,6 @@ Reading ids out of urls, the other direction, runs at the head of the
 pipeline in ``url_identifiers``.
 """
 
-from collections.abc import Callable
-from types import MappingProxyType
 from typing import Any
 
 from comicbox.box.computed.identifiers import ComicboxComputedIdentifiers
@@ -22,7 +20,6 @@ from comicbox.formats.comicbox.schema import (
 )
 from comicbox.identifiers import DEFAULT_ID_TYPE, ID_KEY_KEY, ID_TYPE_KEY
 from comicbox.identifiers.identifiers import get_identifier_url
-from comicbox.merge import Merger, ReplaceMerger
 
 
 class ComicboxComputedUrls(ComicboxComputedIdentifiers):
@@ -55,12 +52,3 @@ class ComicboxComputedUrls(ComicboxComputedIdentifiers):
         if not url_list or url_list == list(sub_data.get(URLS_KEY) or ()):
             return None
         return {URLS_KEY: url_list}
-
-    COMPUTED_ACTIONS: MappingProxyType[str, tuple[Callable, type[Merger] | None]] = (
-        MappingProxyType(
-            {
-                **ComicboxComputedIdentifiers.COMPUTED_ACTIONS,
-                "urls": (_get_computed_urls, ReplaceMerger),
-            }
-        )
-    )

--- a/comicbox/box/metadata.py
+++ b/comicbox/box/metadata.py
@@ -20,7 +20,10 @@ class ComicboxMetadata(ComicboxComputed):
     def _set_computed_merged_metadata_delete(self, merged_md: dict[str, Any]) -> None:
         """Delete keys with glom."""
         sub_data = merged_md.get(ComicboxSchemaMixin.ROOT_TAG)
-        for key_path in sorted(self._config.general.delete_keys):
+        # The computed pass earns delete keys of its own — date parts that
+        # cannot form a real date. Deleting only the config's meant those
+        # were flagged and then kept.
+        for key_path in sorted(self._all_delete_keys()):
             try:
                 delete = Delete(key_path, ignore_missing=True)
                 glom(sub_data, delete)
@@ -28,21 +31,14 @@ class ComicboxMetadata(ComicboxComputed):
                 logger.warning(f"Could not delete key path {key_path}: {exc}")
 
     def _set_computed_merged_metadata(self) -> None:
-        merged_md = self.get_merged_metadata()
-        computed_md = self.get_computed_metadata()
-        # Deep copy, not dict(): the mergers below recurse into nested
-        # dicts, and a shallow copy would share (and mutate) the same
-        # nested objects the _merged_metadata cache still references.
-        merged_md = deepcopy(dict(merged_md))
-
-        # Mergers act on the mapping they're handed, so unwrap the root
-        # tag here — the same shape _set_computed_metadata already merges
-        # each computed delta into.
-        merged_sub_md = merged_md.setdefault(ComicboxSchemaMixin.ROOT_TAG, {})
-        for computed_data in computed_md:
-            computed_sub_data = computed_data.metadata.get(ComicboxSchemaMixin.ROOT_TAG)
-            if computed_sub_data and computed_data.merger:
-                computed_data.merger.merge(merged_sub_md, computed_sub_data)
+        # The computed pass already merged each delta into its own snapshot,
+        # in order, because every action has to see what the ones before it
+        # produced. Replaying the same deltas onto a second copy of the
+        # merged metadata here did that identical work twice.
+        # Deep copy, not dict(): the delete below reaches into nested dicts,
+        # and a shallow copy would mutate the ones the computed cache still
+        # references.
+        merged_md = deepcopy(dict(self.get_computed_merged_metadata()))
         self._set_computed_merged_metadata_delete(merged_md)
         self._metadata = MappingProxyType(merged_md)
         self._metadata_dict_formats = self._dict_formats

--- a/comicbox/enums/maps/identifiers.py
+++ b/comicbox/enums/maps/identifiers.py
@@ -1,5 +1,6 @@
 """Identifier maps."""
 
+import re
 from types import MappingProxyType
 from typing import Any
 
@@ -94,6 +95,17 @@ def get_id_source_by_alias(
 ) -> IdSources | None:
     """Get id source by alias."""
     return _ID_SOURCE_ALIAS_TO_SOURCE_MAP.get(id_source_alias.lower(), default)
+
+
+# An alternation matching any name a source answers to, for parsers that must
+# find a source name inside free text. Longest first so "Comic Vine" wins over
+# a shorter alias that prefixes it, and escaped because the domain aliases
+# contain dots. Pair it with get_id_source_by_alias, which is what resolves a
+# match; the two are the same vocabulary read in the two directions.
+ID_SOURCE_NAME_RE_EXP = r"|".join(
+    re.escape(alias)
+    for alias in sorted(_ID_SOURCE_ALIAS_TO_SOURCE_MAP, key=len, reverse=True)
+)
 
 
 def _build_source_alias_tree(

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -3,15 +3,20 @@
 from argparse import Namespace
 from datetime import date, datetime
 from decimal import Decimal
+from pathlib import Path
 from types import MappingProxyType
+from typing import Any
+from unittest.mock import patch
+from zipfile import ZipFile
 
 from dateutil.tz import tzutc
 
 from comicbox.box import Comicbox
+from comicbox.enums.comicinfo import ComicInfoPageTypeEnum
 from comicbox.formats import MetadataFormats
 from comicbox.formats.comic_info.schema import ComicInfoSchema
 from comicbox.formats.comicbox.schema import ComicboxSchemaMixin
-from tests.const import PRINT_CONFIG, TEST_METADATA_DIR
+from tests.const import PRINT_CONFIG, TEST_FILES_DIR, TEST_METADATA_DIR
 from tests.util import assert_diff
 
 DATE_FROM_NOTES_IMPORT = TEST_METADATA_DIR / "comicinfo-notes-date.xml"
@@ -267,3 +272,187 @@ def test_compute_issue_name() -> None:
         md = car.get_internal_metadata()
 
     assert_diff(ISSUE_WITH_PARTS, md)
+
+
+ISSUE_SUFFIX_NO_NUMBER_YAML = """
+comicbox:
+  issue:
+    name: "1234AU"
+    suffix: "AU"
+"""
+
+
+def test_compute_issue_number_from_name_with_a_suffix() -> None:
+    """A named issue that states a suffix but no number still gets a number."""
+    with Comicbox() as car:
+        car.add_metadata(ISSUE_SUFFIX_NO_NUMBER_YAML, MetadataFormats.COMICBOX_YAML)
+        md = car.get_internal_metadata()
+    issue = md[ComicboxSchemaMixin.ROOT_TAG]["issue"]
+    assert issue["number"] == Decimal(1234)
+    assert issue["suffix"] == "AU"
+    assert issue["name"] == "1234AU"
+
+
+IMPOSSIBLE_DAY_YAML = """
+comicbox:
+  date:
+    year: 2020
+    month: 2
+    day: 30
+"""
+IMPOSSIBLE_DAY_MD = MappingProxyType(
+    {ComicboxSchemaMixin.ROOT_TAG: {"date": {"year": 2020, "month": 2}}}
+)
+
+
+def test_compute_deletes_impossible_date_parts() -> None:
+    """A day that cannot exist is dropped, not merely flagged."""
+    with Comicbox() as car:
+        car.add_metadata(IMPOSSIBLE_DAY_YAML, MetadataFormats.COMICBOX_YAML)
+        md = car.get_internal_metadata()
+        dumped = car.to_dict()
+    assert_diff(IMPOSSIBLE_DAY_MD, md)
+    date_dict = dumped[ComicboxSchemaMixin.ROOT_TAG]["date"]
+    assert "day" not in date_dict
+    assert "cover_date" not in date_dict
+
+
+def _notes_md(notes: str) -> dict:
+    """Read one notes string through the computed pipeline."""
+    yaml = f'comicbox:\n  notes: "{notes}"\n'
+    with Comicbox() as car:
+        car.add_metadata(yaml, MetadataFormats.COMICBOX_YAML)
+        md = car.get_internal_metadata()
+    return dict(md[ComicboxSchemaMixin.ROOT_TAG])
+
+
+# ComicTagger writes the source it used between the tagger and the timestamp,
+# and most of the sources comicbox knows are named with more than one word.
+COMICTAGGER_NOTES_TMPL = (
+    "Tagged with ComicTagger 1.3.2a5 using info from {origin} "
+    "on 2022-04-16 15:52:26. [Issue ID 140529]"
+)
+
+
+def test_compute_notes_multi_word_origin() -> None:
+    """A multi-word source name in a ComicTagger stamp names its source."""
+    for origin, id_source in (
+        ("Comic Vine", "comicvine"),
+        ("Grand Comics Database", "grandcomicsdatabase"),
+        ("League of Comic Geeks", "leagueofcomicgeeks"),
+        ("Metron", "metron"),
+    ):
+        md = _notes_md(COMICTAGGER_NOTES_TMPL.format(origin=origin))
+        assert md["identifiers"] == {id_source: {"key": "140529"}}, origin
+
+
+def test_compute_notes_origin_is_case_insensitive() -> None:
+    """Source names are matched the way every other alias lookup matches."""
+    md = _notes_md(COMICTAGGER_NOTES_TMPL.format(origin="comic vine"))
+    assert md["identifiers"] == {"comicvine": {"key": "140529"}}
+
+
+def test_compute_notes_unknown_origin_names_no_source() -> None:
+    """An unrecognized source is not quietly filed under the default one."""
+    md = _notes_md(COMICTAGGER_NOTES_TMPL.format(origin="Nonesuch"))
+    assert "identifiers" not in md
+
+
+def test_compute_notes_unparsable_updated_at_is_not_written() -> None:
+    """A timestamp the pattern admits but no parser accepts is skipped."""
+    md = _notes_md("Tagged with ComicTagger on 2020-19-19 12:00:00")
+    assert md["tagger"] == "ComicTagger"
+    assert "updated_at" not in md
+
+
+# Everything the notes parser can read, in one string: a tagger, a timestamp,
+# a ComicTagger origin + issue id, a bracketed identifier, a urn, a RELDATE
+# and a url.
+ROUND_TRIP_NOTES = (
+    "Tagged with ComicTagger 1.3.2a5 using info from Grand Comics Database "
+    "on 2022-04-16 15:52:26. [Issue ID 555] [CVDB140529] urn:metron:issue:999 "
+    "[RELDATE:2025-04-11] see https://leagueofcomicgeeks.com/comic/1234/x too."
+)
+ROUND_TRIP_YAML = f'comicbox:\n  notes: "{ROUND_TRIP_NOTES}"\n'
+STAMP_CONFIG = Namespace(
+    comicbox=Namespace(
+        write=Namespace(stamp=True), general=Namespace(tagger="comicbox test")
+    )
+)
+
+
+def test_compute_notes_survive_the_tagger_stamp() -> None:
+    """
+    Everything the notes parser reads survives the stamp that replaces notes.
+
+    The stamp rebuilds the notes text from the structured fields, so the text
+    itself changes. What must not change is the data: see the audit in the
+    comicbox.box.computed.notes module docstring for each difference and why
+    it is a difference in spelling rather than a loss.
+    """
+    with Comicbox(config=STAMP_CONFIG) as car:
+        car.add_metadata(ROUND_TRIP_YAML, MetadataFormats.COMICBOX_YAML)
+        md = dict(car.get_internal_metadata()[ComicboxSchemaMixin.ROOT_TAG])
+
+    # Every id the notes named, from all three of its grammars.
+    assert md["identifiers"] == {
+        "grandcomicsdatabase": {"key": "555"},
+        "comicvine": {"key": "140529"},
+        "metron": {"key": "999"},
+        "leagueofcomicgeeks": {"key": "1234"},
+    }
+    # The url the prose carried, kept before the stamp overwrote the prose.
+    assert "https://leagueofcomicgeeks.com/comic/1234/x" in md["urls"]
+    # RELDATE, as a real date rather than a bracketed word.
+    assert md["date"]["cover_date"] == date(2025, 4, 11)
+    # The stamp is comicbox's own; it replaces the tagger it read.
+    assert md["tagger"] == "comicbox test"
+    # Every identifier comes back out of the rewritten notes as a urn.
+    notes = md["notes"]
+    for urn in (
+        "urn:comicvine:140529",
+        "urn:grandcomicsdatabase:555",
+        "urn:leagueofcomicgeeks:1234",
+        "urn:metron:999",
+    ):
+        assert urn in notes, urn
+    assert notes.startswith("Tagged with comicbox test on ")
+
+
+def _one_image_cbz(tmp_path: Path, count: int) -> Path:
+    """Build a cbz of real images and nothing else, so pages compute fresh."""
+    images = sorted((TEST_FILES_DIR / "Captain Science 001").glob("*.jpg"))[:count]
+    archive_path = tmp_path / "computed-pages.cbz"
+    with ZipFile(archive_path, "w") as zf:
+        for image in images:
+            zf.write(image, image.name)
+    return archive_path
+
+
+PAGES_CONFIG = Namespace(comicbox=Namespace(compute=Namespace(pages=True)))
+
+
+def test_compute_pages_without_a_first_page(tmp_path: Path) -> None:
+    """A missing page 0 marks the first page present, and never aborts."""
+    archive_path = _one_image_cbz(tmp_path, 3)
+    with Comicbox(archive_path, config=PAGES_CONFIG) as car:
+        real_get_info_size = car._get_info_size
+        skipped = []
+
+        def sizeless_first_image(info: Any) -> int | None:
+            filename = car._get_info_fn(info)
+            if car.IMAGE_EXT_RE.search(filename) is not None and not skipped:
+                skipped.append(filename)
+                return None
+            return real_get_info_size(info)
+
+        with patch.object(car, "_get_info_size", sizeless_first_image):
+            car._dict_formats = frozenset({MetadataFormats.COMIC_INFO})
+            md = dict(car.get_internal_metadata()[ComicboxSchemaMixin.ROOT_TAG])
+
+    pages = md["pages"]
+    assert 0 not in pages
+    assert pages[min(pages)]["page_type"] == ComicInfoPageTypeEnum.FRONT_COVER
+    # The rest of the computed pass ran instead of being aborted by the
+    # missing page.
+    assert md["page_count"] == 3

--- a/tests/unit/test_computed_pipeline.py
+++ b/tests/unit/test_computed_pipeline.py
@@ -1,0 +1,80 @@
+"""The computed pipeline's order is a contract, so it is asserted here."""
+
+from unittest.mock import patch
+
+from comicbox.box import Comicbox
+from comicbox.box.computed import ComicboxComputed
+from comicbox.merge import AdditiveMerger, ReplaceMerger
+
+# The exact pipeline, in order. Every entry is a decision — see the
+# comicbox.box.computed module docstring for why each one sits where it does.
+# Changing this list means changing behavior; changing it by accident, which
+# splicing the order together across nine class bodies invited, means changing
+# behavior by accident.
+EXPECTED_ACTIONS = (
+    ("Page Count", "_get_computed_page_count_metadata", ReplaceMerger),
+    ("Pages", "_get_computed_pages_metadata", ReplaceMerger),
+    ("urls from notes", "_get_computed_urls_from_notes", AdditiveMerger),
+    ("identifiers from urls", "_get_computed_identifiers_from_urls", AdditiveMerger),
+    ("from notes", "get_computed_from_notes", AdditiveMerger),
+    ("from tags", "_get_computed_from_tags", AdditiveMerger),
+    ("normalize identifier keys", "_normalize_all_identifier_keys", AdditiveMerger),
+    ("urls", "_get_computed_urls", ReplaceMerger),
+    ("Tagger Stamp", "_get_tagger_stamp", ReplaceMerger),
+    ("from manga_volume", "_get_computed_from_manga_volume", AdditiveMerger),
+    ("from issue", "_get_computed_from_issue", AdditiveMerger),
+    ("from issue.number & issue.suffix", "_get_computed_issue", AdditiveMerger),
+    ("from alternative_issue", "_get_computed_from_alternative_issue", AdditiveMerger),
+    (
+        "from alternative_issue.number & alternative_issue.suffix",
+        "_get_computed_alternative_issue",
+        AdditiveMerger,
+    ),
+    ("from date", "_get_computed_from_date", AdditiveMerger),
+    ("from title", "_get_computed_from_title", AdditiveMerger),
+    ("from stories", "_get_computed_from_stories", AdditiveMerger),
+    ("from reprint names", "_get_computed_from_reprint_names", ReplaceMerger),
+    ("from reprints", "_get_computed_from_reprints", ReplaceMerger),
+    ("from scan_info", "_get_computed_from_scan_info", AdditiveMerger),
+    ("Delete Keys", "_get_delete_keys", None),
+)
+
+
+def test_computed_action_order() -> None:
+    """The registry is the pipeline, in the exact order it runs."""
+    actions = tuple(
+        (action.label, action.method_name, action.merger)
+        for action in ComicboxComputed.COMPUTED_ACTIONS
+    )
+    assert actions == EXPECTED_ACTIONS
+
+
+def test_computed_action_methods_resolve() -> None:
+    """Every registered name is a real method on the box."""
+    with Comicbox() as car:
+        for action in ComicboxComputed.COMPUTED_ACTIONS:
+            method = getattr(car, action.method_name, None)
+            assert callable(method), action.method_name
+
+
+def test_computed_action_labels_are_unique() -> None:
+    """Labels name a phase in --print output, so two may not collide."""
+    labels = [action.label for action in ComicboxComputed.COMPUTED_ACTIONS]
+    assert len(labels) == len(set(labels))
+
+
+def test_computed_actions_dispatch_through_the_instance() -> None:
+    """
+    An override of a computed method is the one that runs.
+
+    The registry used to hold the plain function objects lifted out of each
+    class body, so dispatch bypassed the instance entirely and an override was
+    silently never called.
+    """
+    sentinel = {"title": "overridden"}
+    with (
+        Comicbox() as car,
+        patch.object(car, "_get_computed_from_title", return_value=sentinel) as mock,
+    ):
+        car.get_computed_metadata()
+    assert mock.call_count == 1


### PR DESCRIPTION
Five confirmed bugs in the computed pass, then the structural change that makes the pass readable enough to have caught them.

## Fixes

**Impossible date parts were flagged and then kept.** `computed/date.py` added `date.day` / `date.month` to `_extra_delete_keys`, but `ComicboxMetadata._set_computed_merged_metadata_delete` only ever read `config.general.delete_keys`, so the whole path was dead. Both are read now, and the `Delete Keys` print phase reports both. The set is also reset per computed pass rather than accumulating across recomputes.

```
$ comicbox -P cp -m 'comicbox: {date: {year: 2020, month: 2, day: 30}}'
before: date: {day: 30, month: 2, year: 2020}
after:  date: {month: 2, year: 2020}
```

**The notes origin clause was dead for most databases.** `(?P<origin>\w+)` stops at the first space, so `Comic Vine`, `Grand Comics Database` and `League of Comic Geeks` never matched, and `ID_SOURCE_NAME_MAP.inverse.get()` is case-sensitive unlike `get_id_source_by_alias`. The pattern is now built from the same alias vocabulary that resolves it (new `ID_SOURCE_NAME_RE_EXP`, longest-first and escaped), and resolves with `default=None` so an unrecognized origin is not silently filed under ComicVine.

The origin and the issue id are also searched separately now. ComicTagger writes them on either side of the timestamp — `Tagged with ComicTagger 1.3.2a5 using info from Comic Vine on 2022-04-16 15:52:26. [Issue ID 140529]` — which the old fixed-order combined pattern could not match at all. That combined pattern was also re-parsing `tagger` and `updated_at` that the standalone parsers had already read, so it is gone.

**An inverted issue guard.** `(not is_empty(old_issue_number) or not old_issue_suffix)` reads "there is a number", but the branch exists to parse a *missing* one. An issue with a name and a suffix but no number — the one case where the name is the only place the number is written — never got parsed.

**An unguarded `pages[0]` outside the try/except.** `index` advances for every image but only sizeable images get an entry, so a page whose archive entry reports no size leaves a gap. `pages[0]` then raised `KeyError: 0` from *outside* the guard every sibling action has, aborting the entire computed pass — page count, identifiers, dates, everything. It marks the lowest page present now, and the merge call moved inside the guard that feeds it.

**Notes round-trip audit.** Enumerated everything the parser reads (tagger, `updated_at`, `RELDATE`, urns, bracketed identifiers, the ComicTagger origin/issue-id pair, urls) against what the stamp writes back. One real behavioral gap: an unparsable timestamp wrote `updated_at = None` instead of leaving it unset. The rest are spelling differences rather than data losses — the date survives in `date.*`, urls in `urls`, the origin in each urn's source field — and each is enumerated with its reason in the `computed/notes.py` module docstring. A test walks a notes string carrying all six grammars through a stamp rewrite and asserts the structured fields survive.

## Ordering contract

Each of the nine modules spliced its actions into the inherited mapping with a dict splat, so the pipeline order could only be read by walking the MRO backwards — and `pages.py` prepended while the other eight appended, which is the only reason the page actions run first. That is now one ordered `COMPUTED_ACTIONS` registry in `computed/__init__.py`, with the reason each group sits where it does, and `tests/unit/test_computed_pipeline.py` asserting the exact order. The order is unchanged.

Actions register by method *name*, which also fixes dispatch. The splat captured the plain function objects lifted out of each class body, so `method(self, sub_data)` bypassed the instance and an override of a computed method was silently never called. `getattr(self, name)` dispatches normally; a test asserts it.

## Collapsed delta application

The computed pass merges each delta into its own snapshot because every action has to see the ones before it. `ComicboxMetadata` then replayed the same deltas, in the same order, onto a second deep copy of the merged metadata. It reads the finished snapshot back instead — one merge pass rather than two, same deep-copy count.

## Verification

`make fix`, `make lint`, `make ty` clean. Full suite: 1647 passed, 1 skipped. The three radon rank-C entries under `box/computed/` are unchanged from `origin/develop` (verified against the pristine files).

Each of bugs 1–4 was reproduced against `origin/develop` before the fix and is covered by a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
