### PR TITLE
test: close semantic gaps in the CLI selector, online degradation, runner and validate

### DIFF
--- a/tests/unit/test_online_degradation.py
+++ b/tests/unit/test_online_degradation.py
@@ -1,0 +1,507 @@
+"""
+Online source-failure degradation tests.
+
+The online engine is built to survive a flaky upstream: a source that
+raises mid-lookup logs a warning and degrades to "no metadata from this
+source", never taking the run down with it. The one exception is
+`OnlineLookupAbortedError`, which is a decision about the *run* (the
+user answered "abort", or a caller cancelled a retry sleep) and must
+propagate through every handler.
+
+Three failure surfaces are covered here:
+
+* `_run_search` — `source.search()` raising.
+* `_try_series_cache_lookup` — the box-level guard around
+  `source.lookup_issue()`.
+* `OnlineSource.lookup_issue` — the base-class wrapper around
+  `_lookup_issue_in_volume`. `tests/unit/test_series_cache.py` overrides
+  `lookup_issue` wholesale, so that wrapper never runs there.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from loguru import logger
+from typing_extensions import override
+
+from comicbox.box import Comicbox
+from comicbox.box.online_lookup import ComicboxOnlineLookup, _series_fingerprint
+from comicbox.config import get_config
+from comicbox.config.settings import OnlineSourceCredentials
+from comicbox.exceptions import OnlineLookupAbortedError
+from comicbox.formats import MetadataFormats
+from comicbox.formats.base.online import outcome_stats
+from comicbox.formats.base.online.profile import (
+    Candidate,
+    CandidateSummary,
+    ComicProfile,
+)
+from comicbox.formats.base.online.sources.base import OnlineSource
+from comicbox.formats.sources import MetadataSources
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+SERIES = "Foo Comics"
+PUBLISHER = "Quality Comics"
+YEAR = 2020
+VOLUME_ID = 42
+
+
+@pytest.fixture(autouse=True)
+def _reset_outcome_stats() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
+    """Counters are a process-wide singleton; isolate every test."""
+    outcome_stats.reset()
+    yield
+    outcome_stats.reset()
+
+
+@pytest.fixture
+def warnings() -> Iterator[list[str]]:
+    """Capture loguru WARNING-and-above messages."""
+    messages: list[str] = []
+    handler_id = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        yield messages
+    finally:
+        logger.remove(handler_id)
+
+
+# --- mock sources -----------------------------------------------------------
+
+
+def _issue_payload(issue_id: int) -> dict:
+    return {
+        "id": issue_id,
+        "number": "5",
+        "cover_date": "2020-04-01",
+        "modified": "2020-04-02T12:00:00Z",
+        "publisher": {"id": 1, "name": "Online Publisher"},
+        "series": {"id": 1, "name": "Online Series", "year_began": 2020, "volume": 1},
+    }
+
+
+def _make_candidate(
+    issue_id: int = 101, volume_id: int | None = VOLUME_ID
+) -> Candidate:
+    return Candidate(
+        source="metron",
+        issue_id=issue_id,
+        summary=CandidateSummary(
+            series=SERIES,
+            issue="5",
+            year=YEAR,
+            publisher=PUBLISHER,
+            page_count=24,
+            cover_url=None,
+            variant_label=None,
+        ),
+        volume_id=volume_id,
+    )
+
+
+class _FlakyMetron:
+    """Mock source whose `search`/`lookup_issue` raise on demand."""
+
+    name = "metron"
+    metadata_source = MetadataSources.METRON_API
+    metadata_format = MetadataFormats.METRON_API
+
+    def __init__(
+        self,
+        credentials,
+        settings,
+        *,
+        search_exc: BaseException | None = None,
+        lookup_exc: BaseException | None = None,
+    ) -> None:
+        self._credentials = credentials
+        self._settings = settings
+        self.search_exc = search_exc
+        self.lookup_exc = lookup_exc
+        self.search_calls = 0
+        self.lookup_calls: list[tuple[int, str | None]] = []
+        self.get_calls: list[int] = []
+
+    def is_configured(self) -> bool:
+        return True
+
+    def get(self, issue_id: int) -> dict:
+        self.get_calls.append(issue_id)
+        return _issue_payload(issue_id)
+
+    def search(self, profile) -> list[Candidate]:
+        self.search_calls += 1
+        if self.search_exc is not None:
+            raise self.search_exc
+        return [_make_candidate()]
+
+    def lookup_issue(
+        self, volume_id: int, issue_number: str | None
+    ) -> Candidate | None:
+        self.lookup_calls.append((volume_id, issue_number))
+        if self.lookup_exc is not None:
+            raise self.lookup_exc
+        return _make_candidate()
+
+
+class _WrapperMetron(OnlineSource):
+    """
+    A real `OnlineSource` so the base `lookup_issue` wrapper runs.
+
+    The mocks above replace `lookup_issue` outright, which is exactly
+    what leaves `sources/base.py`'s failure semantics untested.
+    """
+
+    name = "metron"
+    metadata_source = MetadataSources.METRON_API
+    metadata_format = MetadataFormats.METRON_API
+
+    def __init__(
+        self,
+        credentials,
+        settings,
+        *,
+        lookup_exc: BaseException | None = None,
+        implement_fast_path: bool = True,
+    ) -> None:
+        super().__init__(credentials, settings)
+        self.lookup_exc = lookup_exc
+        self.implement_fast_path = implement_fast_path
+        self.search_calls = 0
+        self.get_calls: list[int] = []
+
+    @override
+    def is_configured(self) -> bool:
+        return True
+
+    @override
+    def get(self, issue_id: int) -> dict[str, Any]:
+        self.get_calls.append(issue_id)
+        return _issue_payload(issue_id)
+
+    @override
+    def search(self, profile: ComicProfile) -> list[Candidate]:
+        self.search_calls += 1
+        return [_make_candidate()]
+
+    @override
+    def _lookup_issue_in_volume(
+        self, volume_id: int, issue_number: str | None
+    ) -> Candidate | None:
+        if not self.implement_fast_path:
+            return super()._lookup_issue_in_volume(volume_id, issue_number)
+        if self.lookup_exc is not None:
+            raise self.lookup_exc
+        return _make_candidate()
+
+
+def _patch_factory(monkeypatch: pytest.MonkeyPatch, build) -> list:
+    instances: list = []
+
+    def factory(creds, settings):
+        src = build(creds, settings)
+        instances.append(src)
+        return src
+
+    monkeypatch.setattr(
+        ComicboxOnlineLookup,
+        "_ONLINE_SOURCE_FACTORIES",
+        MappingProxyType({"metron": factory}),
+    )
+    return instances
+
+
+def _cli_metadata() -> dict:
+    return {
+        "comicbox": {
+            "series": {"name": SERIES},
+            "issue": {"name": "5"},
+            "date": {"year": YEAR},
+            "publisher": {"name": PUBLISHER},
+            "page_count": 24,
+        }
+    }
+
+
+def _build_cb() -> Comicbox:
+    args = Namespace(
+        comicbox=Namespace(
+            online_sources=["metron"],
+            general=Namespace(metadata=_cli_metadata()),
+            auth=["metron:user=u", "metron:pass=p"],
+        )
+    )
+    return Comicbox(config=args)
+
+
+def _warm_cache() -> dict:
+    fp = _series_fingerprint(
+        ComicProfile(series=SERIES, year=YEAR, publisher=PUBLISHER)
+    )
+    return {("metron", fp): VOLUME_ID}
+
+
+def _assert_untouched(cb: Comicbox) -> None:
+    """Assert no online metadata leaked into the merge."""
+    md = cb.get_merged_metadata()["comicbox"]
+    assert md["series"]["name"] == SERIES
+    assert md["publisher"]["name"] == PUBLISHER
+    assert "metron" not in md.get("identifiers", {})
+
+
+def _assert_applied(cb: Comicbox) -> None:
+    """Assert the fallback search landed — the online payload won the merge."""
+    md = cb.get_merged_metadata()["comicbox"]
+    assert md["series"]["name"] == "Online Series"
+    assert md["publisher"]["name"] == "Online Publisher"
+    assert md["identifiers"]["metron"]["key"] == "101"
+
+
+# --- search() failures ------------------------------------------------------
+
+
+def test_search_generic_exception_degrades(warnings: list[str]) -> None:
+    """A flaky upstream costs this source's contribution, not the run."""
+
+    def build(creds, settings):
+        return _FlakyMetron(creds, settings, search_exc=RuntimeError("upstream 500"))
+
+    cb = _build_cb()
+    with pytest.MonkeyPatch.context() as mp:
+        instances = _patch_factory(mp, build)
+        assert cb.run_online_lookup() is False
+        assert any("search failed: upstream 500" in m for m in warnings)
+        assert instances[0].get_calls == []
+        _assert_untouched(cb)
+
+
+def test_search_generic_exception_records_no_outcome_bucket() -> None:
+    """
+    A source-side error is not a resolution outcome.
+
+    `_run_search` returns before the matcher runs, so nothing lands in
+    auto-write / skip / no-match / prompt. The end-of-run summary stays
+    silent rather than reporting a fake "no-match".
+    """
+
+    def build(creds, settings):
+        return _FlakyMetron(creds, settings, search_exc=RuntimeError("boom"))
+
+    cb = _build_cb()
+    with pytest.MonkeyPatch.context() as mp:
+        _patch_factory(mp, build)
+        cb.run_online_lookup()
+    assert outcome_stats.has_any_activity() is False
+    assert outcome_stats.summary_lines() == []
+
+
+def test_search_not_implemented_error_degrades(warnings: list[str]) -> None:
+    """`NotImplementedError` has no special meaning on the search path."""
+
+    def build(creds, settings):
+        return _FlakyMetron(
+            creds, settings, search_exc=NotImplementedError("no search")
+        )
+
+    cb = _build_cb()
+    with pytest.MonkeyPatch.context() as mp:
+        _patch_factory(mp, build)
+        assert cb.run_online_lookup() is False
+    assert any("search failed" in m for m in warnings)
+    assert outcome_stats.has_any_activity() is False
+
+
+def test_search_abort_propagates(warnings: list[str]) -> None:
+    """Abort is about the run; it must not be degraded into a skip."""
+
+    def build(creds, settings):
+        return _FlakyMetron(
+            creds, settings, search_exc=OnlineLookupAbortedError("cancelled")
+        )
+
+    cb = _build_cb()
+    with pytest.MonkeyPatch.context() as mp:
+        _patch_factory(mp, build)
+        with pytest.raises(OnlineLookupAbortedError):
+            cb.run_online_lookup()
+    assert not any("search failed" in m for m in warnings)
+    assert outcome_stats.has_any_activity() is False
+
+
+# --- lookup_issue() failures at the box guard -------------------------------
+
+
+def test_series_cache_lookup_exception_falls_back_to_search(
+    warnings: list[str],
+) -> None:
+    """A warm-path failure is recoverable: the cold search still runs."""
+
+    def build(creds, settings):
+        return _FlakyMetron(creds, settings, lookup_exc=RuntimeError("volume 503"))
+
+    cb = _build_cb()
+    cb.set_series_cache(_warm_cache())
+    with pytest.MonkeyPatch.context() as mp:
+        instances = _patch_factory(mp, build)
+        assert cb.run_online_lookup() is True
+    src = instances[0]
+    assert src.lookup_calls == [(VOLUME_ID, "5")]
+    assert src.search_calls == 1
+    assert any(
+        "series-cache lookup_issue" in m and "falling back to search" in m
+        for m in warnings
+    )
+    # The recovered run still books its real outcome.
+    assert "1 auto-written" in "\n".join(outcome_stats.summary_lines())
+    _assert_applied(cb)
+
+
+def test_series_cache_lookup_and_search_both_fail(warnings: list[str]) -> None:
+    """Both legs down → no metadata, no crash, no outcome bucket."""
+
+    def build(creds, settings):
+        return _FlakyMetron(
+            creds,
+            settings,
+            lookup_exc=RuntimeError("volume 503"),
+            search_exc=RuntimeError("search 503"),
+        )
+
+    cb = _build_cb()
+    cb.set_series_cache(_warm_cache())
+    with pytest.MonkeyPatch.context() as mp:
+        _patch_factory(mp, build)
+        assert cb.run_online_lookup() is False
+    assert any("series-cache lookup_issue" in m for m in warnings)
+    assert any("search failed: search 503" in m for m in warnings)
+    assert outcome_stats.has_any_activity() is False
+    _assert_untouched(cb)
+
+
+def test_series_cache_lookup_abort_propagates() -> None:
+    """The warm path must not swallow an abort into a search fallback."""
+
+    def build(creds, settings):
+        return _FlakyMetron(
+            creds, settings, lookup_exc=OnlineLookupAbortedError("cancelled")
+        )
+
+    cb = _build_cb()
+    cb.set_series_cache(_warm_cache())
+    with pytest.MonkeyPatch.context() as mp:
+        instances = _patch_factory(mp, build)
+        with pytest.raises(OnlineLookupAbortedError):
+            cb.run_online_lookup()
+    assert instances[0].search_calls == 0
+    assert outcome_stats.has_any_activity() is False
+
+
+def test_series_cache_lookup_not_implemented_falls_back_quietly(
+    warnings: list[str],
+) -> None:
+    """A source without the fast path is normal, so it isn't a warning."""
+
+    def build(creds, settings):
+        return _FlakyMetron(creds, settings, lookup_exc=NotImplementedError())
+
+    cb = _build_cb()
+    cb.set_series_cache(_warm_cache())
+    with pytest.MonkeyPatch.context() as mp:
+        instances = _patch_factory(mp, build)
+        assert cb.run_online_lookup() is True
+    assert instances[0].search_calls == 1
+    assert not any("lookup_issue" in m for m in warnings)
+
+
+# --- the OnlineSource.lookup_issue wrapper ----------------------------------
+
+
+def _wrapper_source(**kwargs) -> _WrapperMetron:
+    cfg = get_config(Namespace(comicbox=Namespace()))
+    creds = OnlineSourceCredentials(user="u", password="p")
+    return _WrapperMetron(creds, cfg.online, **kwargs)
+
+
+def test_wrapper_degrades_source_errors_to_none(warnings: list[str]) -> None:
+    """Base-class contract: source-side errors log and fall back to search."""
+    src = _wrapper_source(lookup_exc=RuntimeError("gateway timeout"))
+    assert src.lookup_issue(VOLUME_ID, "5") is None
+    assert any(
+        f"lookup_issue(volume_id={VOLUME_ID}, number='5') failed: gateway timeout" in m
+        for m in warnings
+    )
+
+
+def test_wrapper_propagates_abort() -> None:
+    src = _wrapper_source(lookup_exc=OnlineLookupAbortedError("cancelled"))
+    with pytest.raises(OnlineLookupAbortedError):
+        src.lookup_issue(VOLUME_ID, "5")
+
+
+def test_wrapper_propagates_not_implemented() -> None:
+    """Callers detect "no fast path" by catching NotImplementedError."""
+    src = _wrapper_source(lookup_exc=NotImplementedError())
+    with pytest.raises(NotImplementedError):
+        src.lookup_issue(VOLUME_ID, "5")
+
+
+def test_wrapper_default_implementation_is_not_implemented() -> None:
+    """A source that never overrides `_lookup_issue_in_volume` opts out."""
+    src = _wrapper_source(implement_fast_path=False)
+    with pytest.raises(NotImplementedError):
+        src.lookup_issue(VOLUME_ID, "5")
+
+
+def test_wrapper_passes_a_hit_through() -> None:
+    src = _wrapper_source()
+    candidate = src.lookup_issue(VOLUME_ID, "5")
+    assert candidate is not None
+    assert candidate.issue_id == 101
+
+
+def test_wrapper_failure_degrades_through_the_box(warnings: list[str]) -> None:
+    """
+    End-to-end: the base wrapper's `None` is a cache miss to the box.
+
+    The box logs its "returned no match" info line rather than its own
+    warning, because the wrapper already absorbed the exception.
+    """
+
+    def build(creds, settings):
+        return _WrapperMetron(creds, settings, lookup_exc=RuntimeError("gateway"))
+
+    cb = _build_cb()
+    cb.set_series_cache(_warm_cache())
+    with pytest.MonkeyPatch.context() as mp:
+        instances = _patch_factory(mp, build)
+        assert cb.run_online_lookup() is True
+    assert instances[0].search_calls == 1
+    assert any("lookup_issue(volume_id=42" in m for m in warnings)
+    assert not any("series-cache lookup_issue" in m for m in warnings)
+    _assert_applied(cb)
+
+
+def test_wrapper_abort_propagates_through_the_box() -> None:
+    """An abort raised inside `_lookup_issue_in_volume` ends the run."""
+
+    def build(creds, settings):
+        return _WrapperMetron(
+            creds, settings, lookup_exc=OnlineLookupAbortedError("cancelled")
+        )
+
+    cb = _build_cb()
+    cb.set_series_cache(_warm_cache())
+    with pytest.MonkeyPatch.context() as mp:
+        instances = _patch_factory(mp, build)
+        with pytest.raises(OnlineLookupAbortedError):
+            cb.run_online_lookup()
+    assert instances[0].search_calls == 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_online_prompt.py
+++ b/tests/unit/test_online_prompt.py
@@ -1,0 +1,746 @@
+"""
+Default CLI selector tests — `comicbox.formats.base.online.prompt`.
+
+`prompt.cli_selector` is what every interactive run gets when no
+programmatic selector was registered (`box/online_lookup.py`,
+`_resolve_selector`), so its formatting, its reply grammar, and its
+submenu loops are user-facing surface. Most of the module is pure and
+needs no mocks; the loops are driven by monkeypatching `_prompt_line`
+and `_read_input` with scripted reply sequences.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from comicbox.formats.base.online import prompt
+from comicbox.formats.base.online.profile import (
+    Candidate,
+    CandidateSummary,
+    ComicProfile,
+)
+from comicbox.formats.base.online.selector import SelectorContext
+
+if TYPE_CHECKING:
+    from comicbox.config.settings import ComicboxSettings
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _summary(
+    *,
+    series: str = "Foo Comics",
+    issue: str = "5",
+    year: int | None = 2020,
+    publisher: str | None = "Quality Comics",
+    page_count: int | None = 24,
+) -> CandidateSummary:
+    return CandidateSummary(
+        series=series,
+        issue=issue,
+        year=year,
+        publisher=publisher,
+        page_count=page_count,
+        cover_url=None,
+        variant_label=None,
+    )
+
+
+def _candidate(
+    issue_id: int = 101,
+    *,
+    url: str = "",
+    score: float = 0.91,
+    cover_score: float | None = None,
+    **summary_kwargs,
+) -> Candidate:
+    return Candidate(
+        source="metron",
+        issue_id=issue_id,
+        summary=_summary(**summary_kwargs),
+        score=score,
+        cover_score=cover_score,
+        url=url,
+    )
+
+
+class _ScriptedPrompt:
+    """Stand-in for `_prompt_line` replaying a fixed reply sequence."""
+
+    def __init__(self, *replies: str | None) -> None:
+        self.replies: list[str | None] = list(replies)
+        self.messages: list[str] = []
+
+    def __call__(self, message: str) -> str | None:
+        self.messages.append(message)
+        if not self.replies:
+            reason = f"prompt asked past the end of the script: {message!r}"
+            raise AssertionError(reason)
+        return self.replies.pop(0)
+
+
+class _QuietSettings:
+    """Minimal settings stand-in carrying the `quiet` attr terse mode reads."""
+
+    def __init__(self, quiet: int = 0) -> None:
+        self.quiet = quiet
+
+
+def _ctx(
+    *,
+    file_path: object = None,
+    source: str = "metron",
+    settings: object = None,
+) -> SelectorContext:
+    return SelectorContext(
+        file_path=cast("None", file_path),
+        source=source,
+        settings=cast("ComicboxSettings", settings or _QuietSettings()),
+        triggered_hashing=False,
+    )
+
+
+# --- _format_candidate_line -------------------------------------------------
+
+
+def test_format_candidate_line_full() -> None:
+    line = prompt._format_candidate_line(1, _candidate())
+    assert line == "1. Foo Comics #5 (2020)   score=0.91 [metron:101]"
+
+
+def test_format_candidate_line_without_year() -> None:
+    """No year → the parenthetical is dropped, not rendered as `(None)`."""
+    line = prompt._format_candidate_line(3, _candidate(year=None))
+    assert "(None)" not in line
+    assert line == "3. Foo Comics #5   score=0.91 [metron:101]"
+
+
+def test_format_candidate_line_shows_cover_score() -> None:
+    """A hashed candidate carries its cover score beside the total."""
+    line = prompt._format_candidate_line(2, _candidate(cover_score=0.75))
+    assert "score=0.91 (cov=0.75)" in line
+
+
+def test_format_candidate_line_shows_zero_cover_score() -> None:
+    """cover_score=0.0 is a measurement, not an absence — it must render."""
+    line = prompt._format_candidate_line(1, _candidate(cover_score=0.0))
+    assert "(cov=0.00)" in line
+
+
+# --- _format_aux_lines ------------------------------------------------------
+
+
+def test_format_aux_lines_details_and_url() -> None:
+    aux = prompt._format_aux_lines(_candidate(url="https://example.test/1"))
+    assert aux == [
+        "   publisher='Quality Comics', pages=24, year=2020",
+        "   https://example.test/1",
+    ]
+
+
+def test_format_aux_lines_empty_when_nothing_to_show() -> None:
+    bare = _candidate(publisher=None, page_count=None, year=None, url="")
+    assert prompt._format_aux_lines(bare) == []
+
+
+def test_format_aux_lines_url_only() -> None:
+    bare = _candidate(publisher=None, page_count=None, year=None, url="u")
+    assert prompt._format_aux_lines(bare) == ["   u"]
+
+
+def test_format_aux_lines_zero_page_count_renders() -> None:
+    """`pages=0` is a real value; `is not None` must win over truthiness."""
+    aux = prompt._format_aux_lines(_candidate(publisher=None, page_count=0, year=None))
+    assert aux == ["   pages=0"]
+
+
+# --- _build_lines -----------------------------------------------------------
+
+
+def test_build_lines_header_names_the_file() -> None:
+    lines = prompt._build_lines(
+        ComicProfile(series="Foo"), [_candidate()], "/comics/foo.cbz", terse=False
+    )
+    assert lines[1] == "Ambiguous match for /comics/foo.cbz"
+
+
+def test_build_lines_header_without_a_path() -> None:
+    lines = prompt._build_lines(
+        ComicProfile(series="Foo"), [_candidate()], None, terse=False
+    )
+    assert lines[1] == "Ambiguous match"
+
+
+def test_build_lines_existing_row_summarizes_the_profile() -> None:
+    profile = ComicProfile(series="Foo", issue="5", year=2020, publisher="Quality")
+    lines = prompt._build_lines(profile, [_candidate()], None, terse=False)
+    assert lines[2] == (
+        "  Existing: series='Foo' issue=#5 year=2020 publisher='Quality'"
+    )
+
+
+def test_build_lines_omits_existing_row_for_an_empty_profile() -> None:
+    """Nothing known about the comic → no misleading all-None summary line."""
+    lines = prompt._build_lines(ComicProfile(), [_candidate()], None, terse=False)
+    assert not any("Existing:" in line for line in lines)
+
+
+def test_build_lines_includes_the_action_menu() -> None:
+    lines = prompt._build_lines(ComicProfile(), [_candidate()], None, terse=False)
+    assert lines[-4:] == [
+        "  s. Skip this file",
+        "  m. Enter ID manually",
+        "  o. Session options ...",
+        "  q. Abort entire run",
+    ]
+
+
+def test_build_lines_terse_drops_aux_lines() -> None:
+    candidates = [_candidate(url="https://example.test/1")]
+    verbose = prompt._build_lines(ComicProfile(), candidates, None, terse=False)
+    terse = prompt._build_lines(ComicProfile(), candidates, None, terse=True)
+    assert any("publisher=" in line for line in verbose)
+    assert not any("publisher=" in line for line in terse)
+    assert not any("example.test" in line for line in terse)
+    assert any("1. Foo Comics" in line for line in terse)
+
+
+def test_build_lines_caps_the_candidate_list_at_nine() -> None:
+    """`_MAX_DISPLAYED` is the display contract `_interpret` also enforces."""
+    candidates = [_candidate(issue_id=100 + i) for i in range(12)]
+    lines = prompt._build_lines(ComicProfile(), candidates, None, terse=True)
+    numbered = [line for line in lines if line.strip()[:2].rstrip(".").isdigit()]
+    assert len(numbered) == prompt._MAX_DISPLAYED
+    assert numbered[-1].strip().startswith("9.")
+    assert not any("[metron:110]" in line for line in lines)
+
+
+# --- _interpret -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("s", ("skip", None)),
+        ("skip", ("skip", None)),
+        ("q", ("abort", None)),
+        ("quit", ("abort", None)),
+        ("abort", ("abort", None)),
+        ("m", ("manual", "")),
+        ("manual", ("manual", "")),
+    ],
+)
+def test_interpret_word_aliases(raw: str, expected: tuple) -> None:
+    assert prompt._interpret(raw, 3) == expected
+
+
+@pytest.mark.parametrize("raw", ["o", "options", "  OPTIONS  "])
+def test_interpret_options_sentinel(raw: str) -> None:
+    assert prompt._interpret(raw, 3) == prompt._OPTIONS_SENTINEL
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("S", ("skip", None)), (" s ", ("skip", None)), ("\tQ\n", ("abort", None))],
+)
+def test_interpret_strips_and_lowercases(raw: str, expected: tuple) -> None:
+    assert prompt._interpret(raw, 3) == expected
+
+
+@pytest.mark.parametrize(("raw", "index"), [("1", 0), ("2", 1), ("3", 2)])
+def test_interpret_digits_in_range(raw: str, index: int) -> None:
+    assert prompt._interpret(raw, 3) == ("choose", index)
+
+
+@pytest.mark.parametrize("raw", ["0", "4", "10", "99"])
+def test_interpret_digits_out_of_range(raw: str) -> None:
+    """An out-of-range index is a typo, not a from-the-end lookup."""
+    assert prompt._interpret(raw, 3) is None
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\t\n"])
+def test_interpret_empty_input(raw: str) -> None:
+    assert prompt._interpret(raw, 3) is None
+
+
+@pytest.mark.parametrize("raw", ["x", "yes", "-1", "1.5", "1a", "sq"])
+def test_interpret_unrecognized_input(raw: str) -> None:
+    assert prompt._interpret(raw, 3) is None
+
+
+# --- _read_input / _ask_manual_id -------------------------------------------
+
+
+def test_read_input_returns_the_line(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("builtins.input", lambda _message: "  typed  ")
+    assert prompt._read_input("> ") == "  typed  "
+
+
+def test_read_input_treats_eof_as_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A closed stdin must not blow up a batch run."""
+
+    def _raise(_message: str) -> str:
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise)
+    assert prompt._read_input("> ") == ""
+
+
+def test_ask_manual_id_qualifies_a_bare_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: " 4242 ")
+    assert prompt._ask_manual_id("metron") == "metron:4242"
+
+
+def test_ask_manual_id_keeps_an_explicit_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: "comicvine:9")
+    assert prompt._ask_manual_id("metron") == "comicvine:9"
+
+
+def test_ask_manual_id_empty_backs_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: "   ")
+    assert prompt._ask_manual_id("metron") is None
+
+
+# --- _resolve_policy_input --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("1", "ask"), ("2", "careful"), ("3", "auto"), ("4", "eager")],
+)
+def test_resolve_policy_input_by_key(raw: str, expected: str) -> None:
+    key_to_name = dict(prompt._POLICY_CHOICES)
+    assert prompt._resolve_policy_input(raw, key_to_name=key_to_name) == expected
+
+
+@pytest.mark.parametrize("name", ["ask", "careful", "auto", "eager"])
+def test_resolve_policy_input_by_name(name: str) -> None:
+    key_to_name = dict(prompt._POLICY_CHOICES)
+    assert prompt._resolve_policy_input(name, key_to_name=key_to_name) == name
+
+
+@pytest.mark.parametrize("raw", ["", "5", "0", "nonsense", "Ask"])
+def test_resolve_policy_input_unrecognized(raw: str) -> None:
+    """Inputs arrive pre-lowercased; anything else is unrecognized."""
+    key_to_name = dict(prompt._POLICY_CHOICES)
+    assert prompt._resolve_policy_input(raw, key_to_name=key_to_name) is None
+
+
+def test_policy_menu_lists_every_choice_and_back() -> None:
+    lines = prompt._build_policy_lines()
+    for key, name in prompt._POLICY_CHOICES:
+        assert f"    {key}. {name}" in lines
+    assert lines[-1] == "    b. Back"
+
+
+def test_options_menu_lists_unattended_policy_and_back() -> None:
+    text = "\n".join(prompt._build_options_lines())
+    assert "u. Unattended" in text
+    assert "p. Change match policy" in text
+    assert "b. Back" in text
+
+
+# --- _handle_manual_result --------------------------------------------------
+
+
+def test_handle_manual_result_passes_other_actions_through() -> None:
+    assert prompt._handle_manual_result(("skip", None), "metron") == ("skip", None)
+
+
+def test_handle_manual_result_passes_a_filled_manual_through() -> None:
+    result = ("manual", "metron:5")
+    assert prompt._handle_manual_result(result, "metron") == result
+
+
+def test_handle_manual_result_prompts_for_an_empty_manual(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: "7")
+    assert prompt._handle_manual_result(("manual", ""), "metron") == (
+        "manual",
+        "metron:7",
+    )
+
+
+def test_handle_manual_result_none_when_the_user_backs_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty id means "never mind" — the caller re-prompts, not skips."""
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: "")
+    assert prompt._handle_manual_result(("manual", ""), "metron") is None
+
+
+# --- _prompt_line -----------------------------------------------------------
+
+
+class _FakeQuestionary:
+    """Minimal `questionary` stand-in: `.text(msg).ask()`."""
+
+    def __init__(
+        self, result: str | None = None, exc: BaseException | None = None
+    ) -> None:
+        self.result = result
+        self.exc = exc
+        self.messages: list[str] = []
+
+    def text(self, message: str) -> _FakeQuestionary:
+        self.messages.append(message)
+        return self
+
+    def ask(self) -> str | None:
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
+def _use_tty(monkeypatch: pytest.MonkeyPatch, fake: object) -> None:
+    monkeypatch.setattr(prompt, "_is_tty", lambda: True)
+    monkeypatch.setitem(sys.modules, "questionary", fake)
+
+
+def test_prompt_line_falls_back_to_input_off_tty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(prompt, "_is_tty", lambda: False)
+    monkeypatch.setattr(
+        prompt, "_read_input", lambda message: seen.append(message) or "s"
+    )
+    assert prompt._prompt_line("Choose:") == "s"
+    assert seen == ["Choose: "]
+
+
+def test_prompt_line_uses_questionary_on_a_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeQuestionary(result="2")
+    _use_tty(monkeypatch, fake)
+    assert prompt._prompt_line("Choose:") == "2"
+    assert fake.messages == ["Choose:"]
+
+
+def test_prompt_line_missing_questionary_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`None` in sys.modules makes `import questionary` raise ImportError."""
+    _use_tty(monkeypatch, None)
+    assert prompt._prompt_line("Choose:") is None
+
+
+def test_prompt_line_ctrl_c_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    _use_tty(monkeypatch, _FakeQuestionary(exc=KeyboardInterrupt()))
+    assert prompt._prompt_line("Choose:") is None
+
+
+def test_prompt_line_questionary_ask_returning_none_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Questionary returns None on its own Ctrl-C handling; that's an abort."""
+    _use_tty(monkeypatch, _FakeQuestionary(result=None))
+    assert prompt._prompt_line("Choose:") is None
+
+
+def test_prompt_line_other_questionary_errors_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Documents the current (narrow) except clause.
+
+    `_prompt_line` catches only ImportError and KeyboardInterrupt. Any
+    other questionary failure — a terminal that can't be put into raw
+    mode, for instance — escapes the selector and, because nothing
+    between here and `Runner._run_one` catches it, ends the run with a
+    traceback instead of degrading to the plain `input()` fallback.
+    """
+    _use_tty(monkeypatch, _FakeQuestionary(exc=RuntimeError("no tty control")))
+    with pytest.raises(RuntimeError):
+        prompt._prompt_line("Choose:")
+
+
+def test_is_tty_reflects_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Stdin:
+        def __init__(self, tty: bool) -> None:
+            self._tty = tty
+
+        def isatty(self) -> bool:
+            return self._tty
+
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=True))
+    assert prompt._is_tty() is True
+    monkeypatch.setattr(sys, "stdin", _Stdin(tty=False))
+    assert prompt._is_tty() is False
+    monkeypatch.setattr(sys, "stdin", None)
+    assert prompt._is_tty() is False
+
+
+# --- _ask_policy_choice -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("reply", "policy"),
+    [("1", "ask"), ("2", "careful"), ("3", "auto"), ("4", "eager"), ("eager", "eager")],
+)
+def test_ask_policy_choice_returns_set_policy(
+    monkeypatch: pytest.MonkeyPatch, reply: str, policy: str
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(reply))
+    assert prompt._ask_policy_choice() == ("set_policy", policy)
+
+
+@pytest.mark.parametrize("reply", ["b", "back", "", "  "])
+def test_ask_policy_choice_back_returns_none(
+    monkeypatch: pytest.MonkeyPatch, reply: str
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(reply))
+    assert prompt._ask_policy_choice() is None
+
+
+def test_ask_policy_choice_reprompts_on_garbage(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Unrecognized input loops instead of escaping the submenu."""
+    scripted = _ScriptedPrompt("9", "zzz", "2")
+    monkeypatch.setattr(prompt, "_prompt_line", scripted)
+    assert prompt._ask_policy_choice() == ("set_policy", "careful")
+    assert len(scripted.messages) == 3
+    out = capsys.readouterr().out
+    assert out.count("unrecognized") == 2
+
+
+def test_ask_policy_choice_none_reply_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(None))
+    assert prompt._ask_policy_choice() == ("abort", None)
+
+
+# --- _ask_session_options ---------------------------------------------------
+
+
+@pytest.mark.parametrize("reply", ["u", "unattended", "U"])
+def test_ask_session_options_unattended(
+    monkeypatch: pytest.MonkeyPatch, reply: str
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(reply))
+    assert prompt._ask_session_options() == ("set_unattended", None)
+
+
+@pytest.mark.parametrize("reply", ["p", "policy"])
+def test_ask_session_options_descends_into_policy(
+    monkeypatch: pytest.MonkeyPatch, reply: str
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(reply, "4"))
+    assert prompt._ask_session_options() == ("set_policy", "eager")
+
+
+def test_ask_session_options_policy_back_unwinds_one_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`b` in the policy submenu returns to session options, not the top."""
+    scripted = _ScriptedPrompt("p", "b", "u")
+    monkeypatch.setattr(prompt, "_prompt_line", scripted)
+    assert prompt._ask_session_options() == ("set_unattended", None)
+    assert scripted.messages == ["Option:", "Policy:", "Option:"]
+
+
+@pytest.mark.parametrize("reply", ["b", "back", ""])
+def test_ask_session_options_back_returns_none(
+    monkeypatch: pytest.MonkeyPatch, reply: str
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(reply))
+    assert prompt._ask_session_options() is None
+
+
+def test_ask_session_options_reprompts_on_garbage(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    scripted = _ScriptedPrompt("nope", "u")
+    monkeypatch.setattr(prompt, "_prompt_line", scripted)
+    assert prompt._ask_session_options() == ("set_unattended", None)
+    assert len(scripted.messages) == 2
+    assert "unrecognized: 'nope'" in capsys.readouterr().out
+
+
+def test_ask_session_options_none_reply_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(None))
+    assert prompt._ask_session_options() == ("abort", None)
+
+
+def test_ask_session_options_abort_propagates_out_of_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A None reply inside the policy submenu aborts the whole run."""
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("p", None))
+    assert prompt._ask_session_options() == ("abort", None)
+
+
+# --- _resolve_cli_selector_input --------------------------------------------
+
+
+def test_resolve_cli_selector_input_choose() -> None:
+    candidates = [_candidate(101), _candidate(102)]
+    assert prompt._resolve_cli_selector_input("2", candidates, "metron") == (
+        "choose",
+        1,
+    )
+
+
+def test_resolve_cli_selector_input_caps_index_at_the_display_limit() -> None:
+    """A 12-candidate list still only accepts 1-9 — what was printed."""
+    candidates = [_candidate(100 + i) for i in range(12)]
+    assert prompt._resolve_cli_selector_input("9", candidates, "metron") == (
+        "choose",
+        8,
+    )
+    assert prompt._resolve_cli_selector_input("10", candidates, "metron") is None
+
+
+def test_resolve_cli_selector_input_unrecognized_reports_and_reprompts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert prompt._resolve_cli_selector_input("zzz", [_candidate()], "metron") is None
+    assert "unrecognized: 'zzz'" in capsys.readouterr().out
+
+
+def test_resolve_cli_selector_input_options_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("u"))
+    result = prompt._resolve_cli_selector_input("o", [_candidate()], "metron")
+    assert result == ("set_unattended", None)
+
+
+def test_resolve_cli_selector_input_options_back_reprompts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backing out of the submenu returns None so the top level re-prompts."""
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("b"))
+    assert prompt._resolve_cli_selector_input("o", [_candidate()], "metron") is None
+
+
+def test_resolve_cli_selector_input_manual(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: "88")
+    result = prompt._resolve_cli_selector_input("m", [_candidate()], "metron")
+    assert result == ("manual", "metron:88")
+
+
+# --- cli_selector -----------------------------------------------------------
+
+
+def test_cli_selector_choose(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("2"))
+    candidates = [_candidate(101), _candidate(102)]
+    result = prompt.cli_selector(ComicProfile(series="Foo"), candidates, _ctx())
+    assert result == ("choose", 1)
+
+
+@pytest.mark.parametrize(
+    ("reply", "expected"),
+    [("s", ("skip", None)), ("q", ("abort", None))],
+)
+def test_cli_selector_terminal_replies(
+    monkeypatch: pytest.MonkeyPatch, reply: str, expected: tuple
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(reply))
+    result = prompt.cli_selector(ComicProfile(), [_candidate()], _ctx())
+    assert result == expected
+
+
+def test_cli_selector_none_reply_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """EOF / Ctrl-C at the top-level prompt aborts the run, never skips."""
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt(None))
+    result = prompt.cli_selector(ComicProfile(), [_candidate()], _ctx())
+    assert result == ("abort", None)
+
+
+def test_cli_selector_reprompts_instead_of_escaping(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Garbage never falls out of the loop as an accidental skip."""
+    scripted = _ScriptedPrompt("zzz", "", "0", "1")
+    monkeypatch.setattr(prompt, "_prompt_line", scripted)
+    result = prompt.cli_selector(ComicProfile(), [_candidate()], _ctx())
+    assert result == ("choose", 0)
+    assert len(scripted.messages) == 4
+    out = capsys.readouterr().out
+    # The menu is redrawn for every re-prompt.
+    assert out.count("q. Abort entire run") == 4
+
+
+def test_cli_selector_manual_backout_reprompts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty manual id returns to the menu rather than skipping the file."""
+    scripted = _ScriptedPrompt("m", "s")
+    monkeypatch.setattr(prompt, "_prompt_line", scripted)
+    monkeypatch.setattr(prompt, "_read_input", lambda _message: "")
+    result = prompt.cli_selector(ComicProfile(), [_candidate()], _ctx())
+    assert result == ("skip", None)
+    assert len(scripted.messages) == 2
+
+
+def test_cli_selector_options_back_reprompts(monkeypatch: pytest.MonkeyPatch) -> None:
+    scripted = _ScriptedPrompt("o", "b", "s")
+    monkeypatch.setattr(prompt, "_prompt_line", scripted)
+    result = prompt.cli_selector(ComicProfile(), [_candidate()], _ctx())
+    assert result == ("skip", None)
+    assert scripted.messages == ["Choose:", "Option:", "Choose:"]
+
+
+def test_cli_selector_options_sets_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("o", "p", "2"))
+    result = prompt.cli_selector(ComicProfile(), [_candidate()], _ctx())
+    assert result == ("set_policy", "careful")
+
+
+def test_cli_selector_renders_the_file_path_and_candidates(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("s"))
+    profile = ComicProfile(series="Foo Comics", issue="5", year=2020)
+    candidates = [_candidate(101, url="https://example.test/1"), _candidate(102)]
+    prompt.cli_selector(profile, candidates, _ctx(file_path="/comics/foo.cbz"))
+    out = capsys.readouterr().out
+    assert "Ambiguous match for /comics/foo.cbz" in out
+    assert "Existing: series='Foo Comics'" in out
+    assert "1. Foo Comics #5 (2020)" in out
+    assert "https://example.test/1" in out
+
+
+def test_cli_selector_terse_trims_aux_lines(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Terse rendering engages when the settings object carries `quiet`."""
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("s"))
+    ctx = _ctx(settings=_QuietSettings(quiet=1))
+    prompt.cli_selector(ComicProfile(), [_candidate(url="https://example.test/1")], ctx)
+    out = capsys.readouterr().out
+    assert "1. Foo Comics #5" in out
+    assert "publisher=" not in out
+    assert "example.test" not in out
+
+
+def test_real_settings_carry_no_quiet_attribute() -> None:
+    """
+    `cli_selector`'s terse mode is unreachable from the real config.
+
+    `terse = bool(getattr(settings, "quiet", 0))` reads an attribute
+    `ComicboxSettings` doesn't define — `-Q/--quiet` is folded into
+    `general.loglevel` by `comicbox/cli/__init__.py`, and the settings
+    dataclass is `slots=True` so nothing can attach `quiet` later. The
+    module docstring's "Honors --terse / -Q quiet" is therefore not
+    true of any CLI run today.
+    """
+    from argparse import Namespace
+
+    from comicbox.config import get_config
+
+    settings = get_config(Namespace(comicbox=Namespace()))
+    assert not hasattr(settings, "quiet")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_refresh_cache.py
+++ b/tests/unit/test_refresh_cache.py
@@ -1,0 +1,121 @@
+"""
+`--refresh-cache` unlink-once tests.
+
+`refresh_cache_unlink_once` exists because REFRESH means "discard stale
+state at run start", not "disable caching". Clients are rebuilt during a
+run and sources are rebuilt per file, so an unguarded unlink wiped the
+response cache *between* calls of the same file — defeating the
++1-API-call-per-unique-volume amortization `get()` relies on. These
+tests pin the exact regression that docstring records.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox.formats.base.online.sources import base as sources_base
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
+    """Isolate the unlink-once registry, which is a module global."""
+    saved = set(sources_base._refreshed_cache_paths)
+    sources_base._refreshed_cache_paths.clear()
+    try:
+        yield
+    finally:
+        sources_base._refreshed_cache_paths.clear()
+        sources_base._refreshed_cache_paths.update(saved)
+
+
+def test_second_caller_in_the_same_process_does_not_unlink(tmp_path: Path) -> None:
+    """The regression: a per-file source rebuild must not re-wipe the cache."""
+    cache = tmp_path / "responses.sqlite"
+    cache.write_text("stale from a previous run")
+
+    sources_base.refresh_cache_unlink_once(cache)
+    assert not cache.exists()
+
+    # The run re-warms the cache; the next source's REFRESH is a no-op.
+    cache.write_text("warmed by this run")
+    sources_base.refresh_cache_unlink_once(cache)
+    assert cache.read_text() == "warmed by this run"
+
+
+def test_repeated_calls_stay_no_ops(tmp_path: Path) -> None:
+    """Every later call in the process is a no-op, not just the second."""
+    cache = tmp_path / "responses.sqlite"
+    cache.write_text("stale")
+    sources_base.refresh_cache_unlink_once(cache)
+    cache.write_text("warm")
+    for _ in range(5):
+        sources_base.refresh_cache_unlink_once(cache)
+    assert cache.read_text() == "warm"
+
+
+def test_paths_are_tracked_independently(tmp_path: Path) -> None:
+    """One source's unlink must not consume another source's one shot."""
+    metron = tmp_path / "metron.sqlite"
+    comicvine = tmp_path / "comicvine.sqlite"
+    metron.write_text("stale")
+    comicvine.write_text("stale")
+
+    sources_base.refresh_cache_unlink_once(metron)
+    assert not metron.exists()
+    assert comicvine.exists()
+
+    sources_base.refresh_cache_unlink_once(comicvine)
+    assert not comicvine.exists()
+
+
+def test_missing_file_still_burns_the_one_shot(tmp_path: Path) -> None:
+    """A cold cache has nothing to unlink — and is still marked refreshed."""
+    cache = tmp_path / "absent.sqlite"
+    sources_base.refresh_cache_unlink_once(cache)
+    assert not cache.exists()
+
+    cache.write_text("warmed by this run")
+    sources_base.refresh_cache_unlink_once(cache)
+    assert cache.exists()
+
+
+def test_registry_records_the_path(tmp_path: Path) -> None:
+    """The guard keys on the string path, which is what the lock protects."""
+    cache = tmp_path / "responses.sqlite"
+    sources_base.refresh_cache_unlink_once(cache)
+    assert str(cache) in sources_base._refreshed_cache_paths
+
+
+def test_concurrent_callers_unlink_at_most_once(tmp_path: Path) -> None:
+    """`-j N` workers racing on one cache path still get a single unlink."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    cache = tmp_path / "responses.sqlite"
+    cache.write_text("stale")
+    unlinked: list[int] = []
+
+    real_unlink = type(cache).unlink
+
+    def counting_unlink(self, *args, **kwargs):
+        unlinked.append(1)
+        return real_unlink(self, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(type(cache), "unlink", counting_unlink)
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            for future in [
+                ex.submit(sources_base.refresh_cache_unlink_once, cache)
+                for _ in range(16)
+            ]:
+                future.result()
+    assert len(unlinked) == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_run_parallel.py
+++ b/tests/unit/test_run_parallel.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import shutil
 import threading
 from argparse import Namespace
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
+
+import pytest
+from loguru import logger as loguru_logger
 
 from comicbox.config import get_config
 from comicbox.config.settings import (
@@ -15,13 +21,13 @@ from comicbox.config.settings import (
     OnlineAuthSettings,
     OnlineSourceCredentials,
 )
+from comicbox.exceptions import UnsupportedArchiveTypeError
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
 from comicbox.run import Runner
+from tests.const import CIX_CBZ_SOURCE_PATH
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
-    import pytest
+    from collections.abc import Generator
 
 
 def _make_paths(tmp_path: Path, count: int) -> list[str]:
@@ -197,8 +203,6 @@ def test_run_parallel_caps_jobs_at_metron_burst_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """-j above the burst limit is clamped, and the clamp is explained."""
-    from loguru import logger as loguru_logger
-
     captured = _capture_max_workers(monkeypatch)
     messages: list[str] = []
     handler_id = loguru_logger.add(messages.append, level="INFO", format="{message}")
@@ -224,3 +228,149 @@ def test_run_parallel_keeps_jobs_at_or_below_limit(
     captured = _capture_max_workers(monkeypatch)
     Runner(_metron_settings())._run_parallel([], 4)
     assert captured == [4]
+
+
+# --------------------------------------------- real work through the pool
+
+
+def _real_batch(tmp_path: Path) -> tuple[list[Path], Path]:
+    """
+    Three readable comics and one corrupt file, in a fixed sort order.
+
+    `get_config` sorts `paths`, so the names are chosen to put the
+    corrupt file second: the serial path then has exactly one successful
+    file behind it, which is what makes the two error semantics below
+    distinguishable.
+    """
+    source = Path(CIX_CBZ_SOURCE_PATH)
+    good = []
+    for name in ("a_good.cbz", "c_good.cbz", "d_good.cbz"):
+        dest = tmp_path / name
+        shutil.copy(source, dest)
+        good.append(dest)
+    corrupt = tmp_path / "b_corrupt.cbz"
+    corrupt.write_bytes(b"this is not a zip archive")
+    return good, corrupt
+
+
+def _runner_for(paths: list[Path], jobs: int) -> Runner:
+    return Runner(
+        Namespace(
+            comicbox=Namespace(
+                paths=[str(p) for p in paths],
+                general=Namespace(jobs=jobs),
+            )
+        )
+    )
+
+
+@contextmanager
+def _captured_records() -> Generator[list[Any]]:
+    """
+    Collect loguru records. Must be entered *after* `Runner(...)`.
+
+    `Runner.__init__` calls `init_logging`, which removes existing
+    handlers — a handler added earlier would be gone before `run()`.
+    """
+    records: list[Any] = []
+    handler_id = loguru_logger.add(lambda m: records.append(m.record), level="TRACE")
+    try:
+        yield records
+    finally:
+        loguru_logger.remove(handler_id)
+
+
+def _messages(records: list[Any], text: str) -> list[Any]:
+    return [r for r in records if text in r["message"]]
+
+
+def _errors(records: list[Any]) -> list[Any]:
+    return [r for r in records if r["level"].name == "ERROR"]
+
+
+def test_parallel_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
+    """
+    Unpatched `_run_one` over real archives: one bad file can't stop the pool.
+
+    With no action flags set, each successfully opened comic logs
+    "No action performed" exactly once, which is the per-file receipt
+    this asserts on.
+    """
+    good, corrupt = _real_batch(tmp_path)
+    runner = _runner_for([*good, corrupt], jobs=2)
+    with _captured_records() as records:
+        runner.run()  # completes; no exception escapes the pool
+
+    assert len(_messages(records, "No action performed")) == len(good)
+    errors = _errors(records)
+    assert len(errors) == 1
+    assert errors[0]["message"] == str(corrupt)
+    assert isinstance(errors[0]["exception"].value, UnsupportedArchiveTypeError)
+
+
+def test_parallel_batch_logs_each_failure_once(tmp_path: Path) -> None:
+    """
+    `_run_one` logs, then returns normally, so `future.result()` re-raises nothing.
+
+    Both the worker's `except` and `_run_parallel`'s own `except` can log
+    the same path; only one of them does.
+    """
+    good, corrupt = _real_batch(tmp_path)
+    second_corrupt = tmp_path / "e_corrupt.cbz"
+    second_corrupt.write_bytes(b"also not a zip")
+    runner = _runner_for([*good, corrupt, second_corrupt], jobs=3)
+    with _captured_records() as records:
+        runner.run()
+
+    errors = _errors(records)
+    assert sorted(r["message"] for r in errors) == sorted(
+        [str(corrupt), str(second_corrupt)]
+    )
+    assert len(_messages(records, "No action performed")) == len(good)
+
+
+def test_serial_batch_aborts_on_a_corrupt_file(tmp_path: Path) -> None:
+    """
+    Documents a real asymmetry between the two dispatch paths.
+
+    `_run_inner`'s serial branch calls `run_on_file` directly, and
+    neither has an `except Exception` guard, so the first unreadable file
+    ends the batch with a traceback. The parallel branch routes through
+    `_run_one` — whose docstring is explicitly "swallowing exceptions for
+    batch resilience" — and logs-and-continues instead.
+
+    The guard arrived with `_run_one` in the parallel dispatch (v4.0.0);
+    the pre-existing serial loop never had one, and only `recurse()` did.
+    So this looks like an oversight rather than a decision: the same
+    corrupt file is a logged error under `-j 2` and a fatal traceback
+    under `-j 1`.
+    """
+    good, corrupt = _real_batch(tmp_path)
+    runner = _runner_for([*good, corrupt], jobs=1)
+    with _captured_records() as records, pytest.raises(UnsupportedArchiveTypeError):
+        runner.run()
+
+    # Only the file sorting before the corrupt one was processed; the two
+    # after it never ran.
+    assert len(_messages(records, "No action performed")) == 1
+    assert _errors(records) == []
+
+
+def test_recurse_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
+    """`recurse()` has the guard the serial explicit-path loop lacks."""
+    good, corrupt = _real_batch(tmp_path)
+    runner = Runner(
+        Namespace(
+            comicbox=Namespace(
+                paths=[str(tmp_path)],
+                general=Namespace(jobs=1, recurse=True),
+            )
+        )
+    )
+    with _captured_records() as records:
+        runner.run()
+
+    assert len(_messages(records, "No action performed")) == len(good)
+    errors = _errors(records)
+    assert len(errors) == 1
+    assert errors[0]["message"] == str(corrupt)

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,0 +1,160 @@
+"""
+`ComicboxValidate.validate` tests — the `--validate` action.
+
+`validate()` is one of the four `_CONFIG_ACTIONS` `Comicbox.run()`
+dispatches, and it's the only one that ends the process: a failing
+source exits 1 so `comicbox --validate` is usable as a CI gate. These
+tests cover the gate, the per-source loop, and both terminal outcomes.
+
+`tests/test_validate_testfiles.py` exercises `validate_source` against
+the real fixture corpus; this module covers the box method around it.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+import pytest
+from loguru import logger
+
+from comicbox.box import Comicbox
+from comicbox.box.validate import validate_source
+from comicbox.exceptions import MetadataError
+from comicbox.formats import MetadataFormats
+from comicbox.formats.sources import MetadataSources
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+VALID_CIX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    "<ComicInfo><Series>Captain Science</Series><Number>1</Number></ComicInfo>"
+)
+INVALID_CIX = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    "<ComicInfo><NotAComicInfoField>x</NotAComicInfoField></ComicInfo>"
+)
+
+
+@pytest.fixture
+def records() -> Iterator[list[tuple[str, str]]]:
+    """Capture (level, message) for every log record."""
+    captured: list[tuple[str, str]] = []
+    handler_id = logger.add(
+        lambda m: captured.append((m.record["level"].name, m.record["message"])),
+        level="TRACE",
+    )
+    try:
+        yield captured
+    finally:
+        logger.remove(handler_id)
+
+
+def _build_cb(
+    metadata: str | None = None,
+    fmt: MetadataFormats | None = None,
+    *,
+    validate: bool = True,
+) -> Comicbox:
+    args = Namespace(comicbox=Namespace(print=Namespace(validate=validate)))
+    cb = Comicbox(config=args)
+    if metadata is not None:
+        cb.add_source(MetadataSources.API, metadata, fmt=fmt)
+    return cb
+
+
+def _levels(records: list[tuple[str, str]], level: str) -> list[str]:
+    return [message for name, message in records if name == level]
+
+
+# --- the --validate gate ----------------------------------------------------
+
+
+def test_validate_is_a_noop_when_not_requested(
+    records: list[tuple[str, str]],
+) -> None:
+    """Without `--validate`, the action neither validates nor announces."""
+    _build_cb(INVALID_CIX, MetadataFormats.COMIC_INFO, validate=False).validate()
+    assert records == []
+
+
+# --- success ----------------------------------------------------------------
+
+
+def test_valid_source_succeeds(records: list[tuple[str, str]]) -> None:
+    _build_cb(VALID_CIX, MetadataFormats.COMIC_INFO).validate()
+    assert "ComicInfo: data validated" in _levels(records, "INFO")
+    assert _levels(records, "SUCCESS") == ["Metadata validation succeeded"]
+
+
+def test_no_sources_succeeds(records: list[tuple[str, str]]) -> None:
+    """Nothing to validate is a pass, not a failure."""
+    _build_cb().validate()
+    assert _levels(records, "SUCCESS") == ["Metadata validation succeeded"]
+
+
+def test_format_without_a_validator_passes(records: list[tuple[str, str]]) -> None:
+    """PDF/online formats register `validator=None` and are waved through."""
+    _build_cb('{"format": "MuPDF"}', MetadataFormats.PDF).validate()
+    assert any("no validator available" in m for m in _levels(records, "WARNING"))
+    assert _levels(records, "SUCCESS") == ["Metadata validation succeeded"]
+
+
+# --- failure ----------------------------------------------------------------
+
+
+def test_invalid_source_exits_one(records: list[tuple[str, str]]) -> None:
+    """The CI-gate contract: a schema violation exits 1."""
+    cb = _build_cb(INVALID_CIX, MetadataFormats.COMIC_INFO)
+    with pytest.raises(SystemExit) as exc_info:
+        cb.validate()
+    assert exc_info.value.code == 1
+    warnings = _levels(records, "WARNING")
+    assert any("ComicInfo: failed validation" in m for m in warnings)
+    assert _levels(records, "ERROR") == ["Metadata validation failed"]
+    assert _levels(records, "SUCCESS") == []
+
+
+def test_one_bad_source_among_good_ones_still_exits(
+    records: list[tuple[str, str]],
+) -> None:
+    """`validated &=` accumulates: a later pass can't clear an earlier fail."""
+    cb = _build_cb(INVALID_CIX, MetadataFormats.COMIC_INFO)
+    cb.add_source(MetadataSources.API, VALID_CIX, fmt=MetadataFormats.COMIC_INFO)
+    with pytest.raises(SystemExit) as exc_info:
+        cb.validate()
+    assert exc_info.value.code == 1
+    # Both sources were visited, not just the failing one.
+    assert "ComicInfo: data validated" in _levels(records, "INFO")
+
+
+def test_validate_runs_through_the_run_action_dispatch() -> None:
+    """`--validate` reaches `validate()` via `Comicbox.run()`'s action map."""
+    cb = _build_cb(INVALID_CIX, MetadataFormats.COMIC_INFO)
+    with pytest.raises(SystemExit) as exc_info:
+        cb.run()
+    assert exc_info.value.code == 1
+
+
+# --- validate_source edges --------------------------------------------------
+
+
+def test_validate_source_without_a_format_raises() -> None:
+    """An unguessable source is an error, not a silent pass."""
+    with pytest.raises(MetadataError):
+        validate_source(VALID_CIX)
+
+
+def test_validate_source_guesses_the_format_from_a_path() -> None:
+    from tests.const import TEST_METADATA_DIR
+
+    assert validate_source(TEST_METADATA_DIR / "comicinfo-write.xml") is True
+
+
+def test_validate_source_reports_a_bad_document() -> None:
+    assert validate_source(INVALID_CIX, fmt=MetadataFormats.COMIC_INFO) is False
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
150 new tests over four surfaces the suite never reached. **Tests only** — no production code changed.

| module | before | after |
|---|---|---|
| `formats/base/online/prompt.py` | 11% | 99% |
| `box/validate/__init__.py` | 47% | 93% |
| `formats/base/online/sources/base.py` | 70% | 93% |
| `box/online_lookup.py` | 83% | 85% |

Suite 1657 → 1807 tests; overall line coverage 92.2% → 93.8%.

## 1. `tests/unit/test_online_prompt.py` (new, 115 tests)

`prompt.cli_selector` is what every interactive run gets when no programmatic selector is registered, and no test file referenced it.

Pure functions are tested directly — `_format_candidate_line`, `_format_aux_lines`, `_build_lines` (header with/without a path, the `Existing:` row, terse trimming, the 9-candidate display cap), `_interpret` (digits in and out of range, the `s`/`q`/`m`/`o` aliases, empty, whitespace, unrecognized), `_resolve_policy_input`, `_handle_manual_result`.

The loops — `_ask_policy_choice`, `_ask_session_options`, `_resolve_cli_selector_input`, `cli_selector` — are driven by scripted `_prompt_line` / `_read_input` reply sequences, asserting the returned `SelectorResult`, that `b` unwinds exactly one level, that unrecognized input re-prompts rather than escaping as an accidental skip, and that a `None` reply always yields `("abort", None)`.

## 2. `tests/unit/test_online_degradation.py` (new, 15 tests)

Sources whose `search()` and `lookup_issue()` raise a generic `Exception`, `OnlineLookupAbortedError`, and `NotImplementedError`. Each asserts the warning, the `outcome_stats` bucket, that abort propagates rather than degrading, and that the merged metadata is untouched (verified against a success run, where the online payload does win the merge).

Includes a real `OnlineSource` subclass so the base-class `lookup_issue` wrapper actually runs — `tests/unit/test_series_cache.py` overrides `lookup_issue` wholesale and bypasses it.

## 3. `tests/unit/test_refresh_cache.py` (new, 6 tests)

`refresh_cache_unlink_once`, including the exact regression its docstring records: the second caller in the same process must not unlink the freshly-warmed cache. Plus per-path independence and a concurrent-callers race.

## 4. `tests/unit/test_validate.py` (new, 10 tests)

`ComicboxValidate.validate`: the `--validate` gate, both terminal outcomes including `SystemExit(1)`, `validated &=` accumulation, the no-validator format path, and dispatch through `Comicbox.run()`'s action map.

## 5. `tests/unit/test_run_parallel.py` (+4 tests)

Real work through the pool: three real archives plus a corrupt file with an **unpatched** `_run_one`, asserting the pool completes, each failure is logged exactly once (not twice — `_run_one` logs and returns, so `future.result()` re-raises nothing), and the other files still process. Plus the `recurse()` and serial counterparts.

## Two findings, documented not fixed

**`cli_selector`'s terse mode is dead code.** `terse = bool(getattr(settings, \"quiet\", 0))` reads an attribute `ComicboxSettings` does not define — `-Q/--quiet` is folded into `general.loglevel` by `comicbox/cli/__init__.py`, and the dataclass is `frozen=True, slots=True` so nothing can attach `quiet` later. The getattr always returns `0`, so `prompt.py`'s \"Honors \`--terse\` / \`-Q\` quiet by trimming auxiliary lines\" is true of no CLI run today. Pinned by `test_real_settings_carry_no_quiet_attribute`.

**Serial and parallel dispatch have different error semantics.** A corrupt file is a logged error under `-j 2` and a fatal traceback that ends the batch under `-j 1`. The parallel path routes through `_run_one`, whose docstring is explicitly \"swallowing exceptions for batch resilience\"; `_run_inner`'s serial loop calls `run_on_file` directly and neither has a guard. `_run_one` arrived with the parallel dispatch in v4.0.0 — the pre-existing serial loop never had a guard, and only `recurse()` did — so this reads as an oversight rather than a decision. Pinned by `test_serial_batch_aborts_on_a_corrupt_file`.

Also noted: `_prompt_line` catches only `ImportError` and `KeyboardInterrupt` around `questionary.text().ask()`. Any other questionary failure (a terminal that can't be put into raw mode, say) escapes the selector, and nothing between there and `Runner._run_one` catches it on the serial path. Pinned as current behavior by `test_prompt_line_other_questionary_errors_propagate`.

## Verification

`make fix`, `make lint`, `make ty` clean. Full suite: **1806 passed, 1 skipped**. `tests/conftest.py`'s collection-time `COMICBOX_*` scrub is untouched; the new module-global fixtures (`outcome_stats`, `_refreshed_cache_paths`) save and restore their state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)