### PR TITLE
feat(config)!: rename write.mode to write.merge_mode, surface it in config + CLI, drop --replace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,12 @@
       `urn:metron:series:178012` when the type isn't the implied one. Older urns
       still read.
     - Tags like `marvel-comics` and `2019-2021` no longer become database ids.
+    - Removed `--replace` and the `write.replace` config key. Despite the name
+      it performed the `update` merge, never the `replace` merge. Use
+      `--merge-mode update`.
+    - The write API takes `merge_mode` instead of `mode`, and defaults to the
+      config's `write.merge_mode` instead of forcing `additive`. The `WriteMode`
+      enum is now `MergeMode`.
 
 - Fixes
     - Writing MetronInfo no longer invents extra credits. Only `Painter` still
@@ -154,6 +160,10 @@
       ones no source declares, like the online formats.
 
 - Features
+    - New `--merge-mode` option and `write.merge_mode` config key choose how
+      supplied metadata merges into a comic's existing tags: `additive` (the
+      default), `replace` or `update`. Only the write API could set this before.
+      `--help` shows what each mode does.
     - Web urls in the Notes field are read into `urls`.
     - New `SourceStarted` online event, emitted once per source that actually
       runs, immediately before that source is consulted and after the first-wins

--- a/comicbox/box/merge.py
+++ b/comicbox/box/merge.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from comicbox.box.online_lookup import ComicboxOnlineLookup
-from comicbox.config.settings import WriteMode
+from comicbox.config.settings import MergeMode
 from comicbox.formats.comicbox.schema import ComicboxSchemaMixin
 from comicbox.formats.sources import MetadataSources
 from comicbox.merge import AdditiveMerger, Merger, ReplaceMerger, UpdateMerger
@@ -12,21 +12,21 @@ from comicbox.merge import AdditiveMerger, Merger, ReplaceMerger, UpdateMerger
 if TYPE_CHECKING:
     from comicbox.formats import MetadataFormats
 
-# Map the public WriteMode enum onto the existing merger classes. The
-# three modes correspond 1:1; see WriteMode docstring for semantics.
-_MERGER_BY_MODE: dict[WriteMode, type[Merger]] = {
-    WriteMode.ADDITIVE: AdditiveMerger,
-    WriteMode.UPDATE: UpdateMerger,
-    WriteMode.REPLACE: ReplaceMerger,
+# Map the public MergeMode enum onto the existing merger classes. The
+# three modes correspond 1:1; see MergeMode docstring for semantics.
+_MERGER_BY_MODE: dict[MergeMode, type[Merger]] = {
+    MergeMode.ADDITIVE: AdditiveMerger,
+    MergeMode.UPDATE: UpdateMerger,
+    MergeMode.REPLACE: ReplaceMerger,
 }
 
 # Sources whose metadata the caller supplied to *this* run: the write
 # API's patch, `-m` on the command line, `--import` files, and the
-# config's own metadata block. `write.mode` describes how that supplied
-# metadata overlays the comic's existing tags, so it applies to exactly
-# these. Everything else — the archive's own files, its comment, its
-# filename, an online lookup's answer — is metadata comicbox discovered,
-# and discovery is always accumulated additively.
+# config's own metadata block. `write.merge_mode` describes how that
+# supplied metadata overlays the comic's existing tags, so it applies to
+# exactly these. Everything else — the archive's own files, its comment,
+# its filename, an online lookup's answer — is metadata comicbox
+# discovered, and discovery is always accumulated additively.
 _PATCH_SOURCES = frozenset(
     {
         MetadataSources.CONFIG,
@@ -75,34 +75,19 @@ class ComicboxMerge(ComicboxOnlineLookup):
             if sub_md := normalized_md.get(ComicboxSchemaMixin.ROOT_TAG):
                 merger.merge(merged_sub_md, sub_md)
 
-    def _resolve_patch_merger(self) -> type[Merger]:
-        """
-        Pick the merger class for caller-supplied metadata.
-
-        ``write.mode`` is the authoritative knob; the legacy ``write.replace``
-        bool is honored as a back-compat alias for ``mode=update`` when the
-        caller didn't set mode explicitly.
-        """
-        write = self._config.write
-        mode = write.mode
-        if mode is WriteMode.ADDITIVE and write.replace:
-            # Caller used the legacy bool; preserve its historical
-            # UpdateMerger semantics.
-            mode = WriteMode.UPDATE
-        return _MERGER_BY_MODE[mode]
-
     def _merger_for_source(self, source: MetadataSources) -> type[Merger]:
         """
-        Cross-source reads are additive; only a patch honors ``write.mode``.
+        Cross-source reads are additive; only a patch honors ``merge_mode``.
 
-        Selecting every source's merger from ``write.mode`` made a plain
-        read depend on write settings — `to_dict()` returned different
-        metadata under `--replace` — and under `update` it was lossy:
-        `dict.update` at the root meant the last source carrying a key
-        dropped every earlier source's contribution to it wholesale.
+        Selecting every source's merger from ``write.merge_mode`` made a
+        plain read depend on write settings — `to_dict()` returned
+        different metadata under a non-default mode — and under `update`
+        it was lossy: `dict.update` at the root meant the last source
+        carrying a key dropped every earlier source's contribution to it
+        wholesale.
         """
         if source in _PATCH_SOURCES:
-            return self._resolve_patch_merger()
+            return _MERGER_BY_MODE[self._config.write.merge_mode]
         return AdditiveMerger
 
     def _set_merged_metadata(self) -> None:

--- a/comicbox/cli/epilog.py
+++ b/comicbox/cli/epilog.py
@@ -80,6 +80,32 @@ _PDF_PAGE_FORMAT_DESC = MappingProxyType(
     }
 )
 
+# (mode, dict-typed fields, list-typed fields, top level keys)
+_MERGE_MODE_ROWS = (
+    ("additive (default)", "recurse", "concatenate", "kept"),
+    ("replace", "recurse", "overwrite", "kept"),
+    (
+        "update",
+        "replaced wholesale",
+        "replaced wholesale",
+        "replaced, siblings dropped",
+    ),
+)
+_MERGE_MODE_INTRO = Styled(
+    """
+[bold]Merging supplied metadata[/bold]
+
+[cyan]--merge-mode <mode>[/cyan] controls how metadata you supply — [cyan]-m[/cyan],
+[cyan]--import[/cyan], and the config metadata block — overlays the tags already in
+the comic. Metadata comicbox discovers on its own is always additive.
+
+[green]additive[/green] and [green]replace[/green] differ only on the five list typed fields:
+[green]remainders[/green], [green]reprints[/green], [green]series_groups[/green], [green]urls[/green] and [green]series.alternative_names[/green].
+Everywhere else the schema nests dicts, where the two behave identically.
+""",
+    style="argparse.text",
+)
+
 # (mode, behavior on unambiguous top, on solo viable, on close call near top)
 _MATCH_MODE_ROWS = (
     ("ask", "prompt", "prompt", "prompt"),
@@ -136,6 +162,20 @@ def _get_pdf_page_format_phases_table() -> Table:
     # argparse accepts.
     for value in PAGE_FORMAT_VALUES:
         table.add_row(value, _PDF_PAGE_FORMAT_DESC.get(value, ""))
+    return table
+
+
+def _get_merge_mode_table() -> Table:
+    table = Table(
+        title="[dark_cyan]--merge-mode[/dark_cyan] values",
+        **_TABLE_ARGS,  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+    )
+    table.add_column("--merge-mode", style="green")
+    table.add_column("dict fields")
+    table.add_column("list fields")
+    table.add_column("top level keys")
+    for row in _MERGE_MODE_ROWS:
+        table.add_row(*row)
     return table
 
 
@@ -201,6 +241,8 @@ def build_epilog() -> Group:
         _get_help_print_phases_table(),
         _METADATA_EXAMPLES,
         _DELETE_KEYS_EXAMPLES,
+        _MERGE_MODE_INTRO,
+        _get_merge_mode_table(),
         _get_online_sources_table(),
         _MATCH_MODE_INTRO,
         _get_match_mode_table(),

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from comicbox._pdf import PAGE_FORMAT_VALUES, PDF_ENABLED
 from comicbox.cli.epilog import build_epilog
-from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD
+from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD, MergeMode
 
 # Tracks one-shot stderr warnings so we don't spam users on repeated flag use.
 _WARNED_FLAGS: set[str] = set()
@@ -242,11 +242,19 @@ def _add_write_group(parser: ArgumentParser) -> None:
         ),
     )
     group.add_argument(
-        "--replace",
-        action="store_true",
+        "--merge-mode",
+        action="store",
         default=None,
-        dest="write_replace",
-        help="Replace metadata keys instead of merging them.",
+        choices=tuple(mode.value for mode in MergeMode),
+        metavar="MODE",
+        dest="write_merge_mode",
+        help=(
+            "How supplied metadata merges into a comic's existing tags: "
+            "[green]additive[/green] (default; dicts recurse, lists concatenate), "
+            "[green]replace[/green] (dicts recurse, lists overwrite), "
+            "[green]update[/green] (top level keys replaced wholesale, "
+            "siblings of a patched key are dropped). Table below."
+        ),
     )
     group.add_argument(
         "--stamp",

--- a/comicbox/config/__init__.py
+++ b/comicbox/config/__init__.py
@@ -36,9 +36,11 @@ from comicbox.config.settings import (
     ComputeSettings,
     ConvertSettings,
     GeneralSettings,
+    MergeMode,
     PrintSettings,
     ReadSettings,
     WriteSettings,
+    parse_enum,
 )
 from comicbox.formats.sources import MetadataSources
 from comicbox.version import PACKAGE_NAME
@@ -150,7 +152,10 @@ _TEMPLATE = MappingTemplate(
                 "write": MappingTemplate(
                     {
                         "formats": Optional(_NON_MAPPING_CONTAINER),
-                        "replace": bool,
+                        # Validated in _build_write_settings rather than
+                        # by a Choice template, so a bad value fails with
+                        # an error that names the key and the valid modes.
+                        "merge_mode": String(),
                         "stamp": bool,
                         "stamp_notes": bool,
                         "delete_all_tags": bool,
@@ -254,7 +259,9 @@ def _build_read_settings(read_block: Any) -> ReadSettings:
 def _build_write_settings(write_block: Any) -> WriteSettings:
     return WriteSettings(
         formats=frozenset(write_block.formats or ()),
-        replace=bool(write_block.replace),
+        merge_mode=parse_enum(
+            MergeMode, "write.merge_mode", str(write_block.merge_mode), noun="value"
+        ),
         stamp=bool(write_block.stamp),
         stamp_notes=bool(write_block.stamp_notes),
         delete_all_tags=bool(write_block.delete_all_tags),

--- a/comicbox/config/online.py
+++ b/comicbox/config/online.py
@@ -22,10 +22,9 @@ from argparse import Namespace
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
-from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any
 
 from loguru import logger
 
@@ -42,6 +41,7 @@ from comicbox.config.settings import (
     OnlineSourceTuning,
     OnlineTuningSettings,
     Prompts,
+    parse_enum,
 )
 from comicbox.formats.base.online import SOURCE_NAMES
 from comicbox.formats.base.online.cli_overrides import CliOverrides
@@ -61,8 +61,6 @@ _TTL_UNIT_SECONDS: Mapping[str, int] = {
     "w": 604800,
 }
 
-_EnumT = TypeVar("_EnumT", bound=Enum)
-
 
 def _coalesce(*values: Any) -> Any:
     """Return the first non-None value (order = priority)."""
@@ -70,18 +68,6 @@ def _coalesce(*values: Any) -> Any:
         if v is not None:
             return v
     return None
-
-
-def _parse_enum(
-    enum_cls: type[_EnumT], flag: str, raw: str, *, noun: str = "name"
-) -> _EnumT:
-    """Parse a lowercased string into an enum member, raising a flag-tagged error."""
-    try:
-        return enum_cls(raw.strip().lower())
-    except ValueError as exc:
-        valid = ", ".join(member.value for member in enum_cls)
-        reason = f"{flag}: unknown {noun} {raw!r}; valid: {valid}"
-        raise ValueError(reason) from exc
 
 
 def _parse_ttl(raw: str | None) -> timedelta:
@@ -207,7 +193,7 @@ def _build_per_source_tuning(
         effort_raw = block.get("effort")
         out[str(name).lower()] = OnlineSourceTuning(
             auto_threshold=block.get("auto_threshold"),
-            effort=_parse_enum(Effort, "--effort", str(effort_raw))
+            effort=parse_enum(Effort, "--effort", str(effort_raw))
             if effort_raw
             else None,
             min_confidence=block.get("min_confidence"),
@@ -259,12 +245,12 @@ def _build_lookup(
     if not selected:
         selected = None
     match_mode = (
-        _parse_enum(MatchMode, "--match", str(match_raw))
+        parse_enum(MatchMode, "--match", str(match_raw))
         if match_raw
         else MatchMode.AUTO
     )
     prompts_value = (
-        _parse_enum(Prompts, "--prompts", str(prompts_raw), noun="value")
+        parse_enum(Prompts, "--prompts", str(prompts_raw), noun="value")
         if prompts_raw
         else Prompts.ASK
     )
@@ -324,7 +310,7 @@ def _build_cache(
     cache_mode = (
         cache_mode_raw
         if isinstance(cache_mode_raw, CacheMode)
-        else _parse_enum(CacheMode, "--cache", str(cache_mode_raw), noun="value")
+        else parse_enum(CacheMode, "--cache", str(cache_mode_raw), noun="value")
     )
     cache_dir_raw = _coalesce(
         cli("cache_dir"), online_env.get("cache_dir"), online_block.cache.dir
@@ -360,7 +346,7 @@ def _build_tuning(
         cli("effort"), online_env.get("effort"), online_block.tuning.effort
     )
     effort_value = (
-        _parse_enum(Effort, "--effort", str(effort_raw))
+        parse_enum(Effort, "--effort", str(effort_raw))
         if effort_raw
         else Effort.BALANCED
     )
@@ -483,7 +469,7 @@ def runtime_online_inputs(
     cli_overrides = CliOverrides.from_auth_list(getattr(cns, "auth", None) or ())
     cache_cli = getattr(cns, "cache", None)
     cache_mode_cli = (
-        _parse_enum(CacheMode, "--cache", str(cache_cli), noun="value")
+        parse_enum(CacheMode, "--cache", str(cache_cli), noun="value")
         if cache_cli
         else None
     )

--- a/comicbox/config/settings.py
+++ b/comicbox/config/settings.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from typing_extensions import override
 
@@ -29,6 +29,20 @@ if TYPE_CHECKING:
     from comicbox.formats import MetadataFormats
     from comicbox.formats.sources import MetadataSources
     from comicbox.print import PrintPhases
+
+_EnumT = TypeVar("_EnumT", bound=Enum)
+
+
+def parse_enum(
+    enum_cls: type[_EnumT], flag: str, raw: str, *, noun: str = "name"
+) -> _EnumT:
+    """Parse a lowercased string into an enum member, raising a flag-tagged error."""
+    try:
+        return enum_cls(raw.strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(member.value for member in enum_cls)
+        reason = f"{flag}: unknown {noun} {raw!r}; valid: {valid}"
+        raise ValueError(reason) from exc
 
 
 class MatchMode(str, Enum):
@@ -132,22 +146,31 @@ class ReadSettings:
     merge_order: "tuple[MetadataSources, ...] | None" = None
 
 
-class WriteMode(str, Enum):
+class MergeMode(str, Enum):
     """
-    How a write merges its patch against the comic's existing metadata.
+    How caller-supplied metadata merges into a comic's existing tags.
+
+    Applies to metadata the caller handed to this run — the write API's
+    patch, ``-m``, ``--import`` files and the config's metadata block.
+    Metadata comicbox discovered on its own is always accumulated
+    additively.
 
     - ``additive``: deep-merge via mergedeep ADDITIVE. Dicts recurse;
       lists / tuples / sets at conflicting paths *concatenate*; scalars
       and other leaves *replace*. Default.
-    - ``update``: ``dict.update()`` at ROOT_TAG. Replaces top-level keys
-      wholesale; siblings of a replaced key are dropped.
     - ``replace``: deep-merge via mergedeep REPLACE. Dicts recurse;
-      everything else (scalars, lists, tuples, sets) *replaces*. Codex's
-      "rename publisher from `Foo Comics` to `Foo`" use case wants this
-      when paired with list-typed fields whose patch is meant to be the
-      new complete value rather than an append. For dict-of-dict
-      structures (most of comicbox's schema) ``additive`` and ``replace``
-      are indistinguishable.
+      everything else (scalars, lists, tuples, sets) *replaces*. Use it
+      when a list-typed patch value is meant to be the new complete
+      value rather than an append.
+    - ``update``: ``dict.update()`` at ROOT_TAG. Replaces top-level keys
+      wholesale; siblings of a replaced key are dropped. A patch of
+      ``{"credits": {"Jane": {...}}}`` removes every other credit.
+
+    ``additive`` and ``replace`` differ only on the five list-typed
+    schema fields: ``remainders``, ``reprints``, ``series_groups``,
+    ``urls`` and ``series.alternative_names``. Everywhere else the
+    schema is dict-of-dict or scalar, where the two are
+    indistinguishable.
     """
 
     ADDITIVE = "additive"
@@ -160,11 +183,9 @@ class WriteSettings:
     """Which metadata formats to write back, and how."""
 
     formats: "frozenset[MetadataFormats]" = field(default_factory=frozenset)
-    # Default merge behavior on write. The legacy ``replace`` bool is
-    # kept as a deprecated alias: ``replace=True`` maps to
-    # ``mode=WriteMode.UPDATE`` (its historical meaning — UpdateMerger).
-    mode: WriteMode = WriteMode.ADDITIVE
-    replace: bool = False  # DEPRECATED: alias for ``mode=update``.
+    # How supplied metadata overlays existing tags. Settable with the
+    # ``write.merge_mode`` config key and ``--merge-mode``.
+    merge_mode: MergeMode = MergeMode.ADDITIVE
     stamp: bool = False
     stamp_notes: bool = True
     delete_all_tags: bool = False

--- a/comicbox/config_default.yaml
+++ b/comicbox/config_default.yaml
@@ -35,7 +35,10 @@ comicbox:
 
   write:
     formats: []
-    replace: False
+    # How supplied metadata (-m, --import, the write API's patch, the
+    # config metadata block) merges into a comic's existing tags.
+    # One of: additive, update, replace.
+    merge_mode: additive
     stamp: False
     stamp_notes: True
     delete_all_tags: False

--- a/comicbox/write.py
+++ b/comicbox/write.py
@@ -4,9 +4,12 @@ Public write API: single-file ``write_metadata`` and batch ``bulk_write``.
 Wraps the existing ``Comicbox(...).dump()`` plumbing with a documented,
 Codex-facing surface:
 
-- ``mode``: ``"additive"`` / ``"update"`` / ``"replace"`` — picks the
-  merge strategy applied to the patch dict against the comic's
-  existing metadata. See :class:`comicbox.config.settings.WriteMode`.
+- ``merge_mode``: ``"additive"`` / ``"update"`` / ``"replace"`` — picks
+  the merge strategy applied to the patch dict against the comic's
+  existing metadata. ``None`` (the default) defers to the config's
+  ``write.merge_mode``, itself ``additive`` unless a config file or
+  ``--merge-mode`` says otherwise. See
+  :class:`comicbox.config.settings.MergeMode`.
 - ``formats``: which on-archive formats to write back (ComicInfo.xml,
   comicbox.yaml, …). Names match the ``MetadataFormats`` enum value.
 - ``delete_keys``: glom key paths removed from the final metadata
@@ -33,7 +36,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from comicbox.box import Comicbox
 from comicbox.config import get_config
-from comicbox.config.settings import WriteMode
+from comicbox.config.settings import MergeMode
 from comicbox.events import (
     BatchFinished,
     BatchStarted,
@@ -94,7 +97,8 @@ class BulkWriteItem:
 
     path: Path
     patch: Mapping[str, Any]
-    mode: Mode = "additive"
+    # None defers to the base config's write.merge_mode (default: additive).
+    merge_mode: Mode | None = None
     formats: frozenset[FormatName] | None = None
     delete_keys: frozenset[str] | None = None
 
@@ -103,7 +107,7 @@ def write_metadata(
     path: Path,
     patch: Mapping[str, Any],
     *,
-    mode: Mode = "additive",
+    merge_mode: Mode | None = None,
     formats: Iterable[FormatName] | None = None,
     delete_keys: Iterable[str] | None = None,
     dry_run: bool = False,
@@ -116,6 +120,14 @@ def write_metadata(
     ``"comicbox"`` root tag, or the root-wrapped form ``Comicbox.to_dict``
     returns (``{"comicbox": {...}}``); the wrapper is detected and
     unwrapped so the natural round-trip works.
+
+    ``merge_mode`` selects how the patch overlays the comic's existing
+    tags: ``"additive"`` (dicts recurse, lists concatenate),
+    ``"replace"`` (dicts recurse, lists overwrite) or ``"update"``
+    (top level keys replaced wholesale, siblings of a patched key
+    dropped). ``None`` defers to the config's ``write.merge_mode``; an
+    explicit value always wins. See
+    :class:`comicbox.config.settings.MergeMode`.
 
     ``delete_keys`` are glom key paths (relative to the root tag, e.g.
     ``"summary"`` or ``"series.name"``) removed from the final merged
@@ -137,7 +149,7 @@ def write_metadata(
             " unless delete_keys is non-empty"
         )
         raise WriteValidationError(msg)
-    mode_enum = _validate_mode(mode)
+    mode_enum = _validate_merge_mode(merge_mode) if merge_mode is not None else None
     fmt_set = _resolve_formats(formats)
     settings = _build_write_settings(
         mode_enum, fmt_set, delete_keys=delete_key_set, base_config=base_config
@@ -413,18 +425,19 @@ def _write_one(
         return write_metadata(
             item.path,
             item.patch,
-            mode=item.mode,
+            merge_mode=item.merge_mode,
             formats=item.formats,
             delete_keys=item.delete_keys,
             base_config=base_config,
         )
 
 
-def _validate_mode(mode: Mode) -> WriteMode:
+def _validate_merge_mode(merge_mode: Mode) -> MergeMode:
     try:
-        return WriteMode(mode)
+        return MergeMode(merge_mode)
     except ValueError as exc:
-        msg = f"Unknown mode {mode!r}; expected one of {[m.value for m in WriteMode]}"
+        valid = [mode.value for mode in MergeMode]
+        msg = f"Unknown merge mode {merge_mode!r}; expected one of {valid}"
         raise WriteValidationError(msg) from exc
 
 
@@ -458,18 +471,27 @@ def _normalize_delete_keys(delete_keys: Iterable[str] | None) -> frozenset[str]:
 
 
 def _build_write_settings(
-    mode: WriteMode,
+    merge_mode: MergeMode | None,
     formats: frozenset[MetadataFormats],
     *,
     delete_keys: frozenset[str],
     base_config: ComicboxSettings | None,
 ) -> ComicboxSettings:
-    """Layer write.mode / write.formats / general.delete_keys over a base config."""
+    """Layer write.merge_mode / write.formats / general.delete_keys over a base."""
     base = base_config or get_config()
     # replace() carries every other WriteSettings field forward; the old
     # field-by-field copy silently reset any newly added field to its
     # default for every caller passing base_config.
-    new_write = replace(base.write, formats=formats, mode=mode)
+    #
+    # An unset merge_mode must leave the base config's value alone.
+    # Passing a resolved default here instead would overwrite whatever a
+    # config file or --merge-mode had established, making those surfaces
+    # dead for every API caller.
+    new_write = (
+        replace(base.write, formats=formats)
+        if merge_mode is None
+        else replace(base.write, formats=formats, merge_mode=merge_mode)
+    )
     if not delete_keys:
         return replace(base, write=new_write)
     new_general = replace(

--- a/tests/cli/test_cli_write.py
+++ b/tests/cli/test_cli_write.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from pathlib import Path
 from types import MappingProxyType
 
+import pytest
+
 from comicbox import cli
 from comicbox.box import Comicbox
 from comicbox.config import get_config
@@ -93,7 +95,7 @@ TMP_MULTI_PATH = TMP_DIR / CBZ_MULTI_SOURCE_PATH.name
 
 TEST_EXPORT_PATH = TMP_DIR / MetadataFormats.COMICBOX_CLI_YAML.value.filename
 CLI_PATH = TEST_METADATA_DIR / MetadataFormats.COMICBOX_CLI_YAML.value.filename
-METADATA_REPLACE = MappingProxyType(
+METADATA_UPDATE = MappingProxyType(
     {
         ComicboxCLISchema.ROOT_TAG: {
             **METADATA[ComicboxCLISchema.ROOT_TAG],
@@ -191,7 +193,7 @@ def test_cli_action_write() -> None:
     _cleanup()
 
 
-def test_cli_action_write_replace() -> None:
+def test_cli_action_write_merge_mode_update() -> None:
     """Test cli metadata write to file."""
     _setup()
     with Comicbox(TMP_PATH) as car:
@@ -206,7 +208,8 @@ def test_cli_action_write_replace() -> None:
         "tags: {d: {},e: {},f: {}}",
         "-m",
         "{ title: bozo_title }",
-        "--replace",
+        "--merge-mode",
+        "update",
         str(TMP_PATH),
         "--print",
         "nmcp",
@@ -218,7 +221,42 @@ def test_cli_action_write_replace() -> None:
     md[ComicboxCLISchema.ROOT_TAG].pop("notes", None)
     md[ComicboxCLISchema.ROOT_TAG].pop("updated_at", None)
     md = MappingProxyType(md)
-    assert_diff(METADATA_REPLACE, md)
+    assert_diff(METADATA_UPDATE, md)
+    _cleanup()
+
+
+@pytest.mark.parametrize(
+    ("merge_mode", "expect_groups"),
+    [("additive", {"G1", "G2", "G3"}), ("replace", {"G3"})],
+)
+def test_cli_action_write_merge_mode_list_field(
+    merge_mode: str, expect_groups: set[str]
+) -> None:
+    """
+    ``--merge-mode replace`` is reachable from the CLI, and it differs.
+
+    The deprecated ``--replace`` selected *update*, so replace mode had
+    no command line surface at all. A list typed field is the only place
+    additive and replace disagree, so nothing else could pin this.
+    """
+    _setup()
+    seed = ("comicbox", "-m", "series_groups: [G1, G2]", "-w", "cb", str(TMP_PATH))
+    cli.main(seed)
+    args = (
+        "comicbox",
+        "-m",
+        "series_groups: [G3]",
+        "--merge-mode",
+        merge_mode,
+        "-w",
+        "cb",
+        str(TMP_PATH),
+    )
+    cli.main(args)
+
+    with Comicbox(TMP_PATH) as car:
+        md = car.get_internal_metadata()
+    assert set(md[ComicboxCLISchema.ROOT_TAG]["series_groups"]) == expect_groups
     _cleanup()
 
 

--- a/tests/unit/test_config_defaults_drift.py
+++ b/tests/unit/test_config_defaults_drift.py
@@ -93,7 +93,6 @@ _KNOWN_DIVERGENCES = {
 
 # Dataclass fields with no YAML key, and why they don't need one.
 _NO_YAML_KEY = {
-    "write.mode": "Derived from the deprecated `replace` bool at build time.",
     "online.lookup.enabled": "Runtime-only: set by --online, never persisted.",
     "online.lookup.ids": "Runtime-only: set by --id.",
     "online.lookup.series_ids": "Runtime-only: set by --series-id.",

--- a/tests/unit/test_merge_mode_config.py
+++ b/tests/unit/test_merge_mode_config.py
@@ -1,0 +1,100 @@
+"""
+The ``write.merge_mode`` surface: config file and CLI flag.
+
+The mode was reachable only through the Python write API for two
+releases. The confuse template and ``_build_write_settings`` never read
+it, so a value in a config file was silently ignored, and the sole
+user-facing knob was the deprecated ``--replace`` bool — which selected
+``update``, not ``replace``, and left ``replace`` unreachable outside
+Python entirely.
+
+These pin the three entry points against resulting settings rather than
+key paths, so they stay honest if the args reshaping moves.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox.cli import get_args
+from comicbox.config import get_config
+from comicbox.config.settings import MergeMode
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ALT_CONFIG = """
+comicbox:
+  write:
+    merge_mode: update
+"""
+
+
+@pytest.fixture
+def alt_config(tmp_path: Path) -> Path:
+    """Write a config file selecting a non-default merge mode."""
+    path = tmp_path / "merge-mode.yaml"
+    path.write_text(_ALT_CONFIG)
+    return path
+
+
+def test_default_merge_mode_is_additive() -> None:
+    """The contrast case: nothing supplied means additive."""
+    assert get_config().write.merge_mode is MergeMode.ADDITIVE
+
+
+def test_config_file_merge_mode_is_honored(alt_config: Path) -> None:
+    """A ``-c`` file's merge_mode reaches the settings dataclass."""
+    cns = get_args(("comicbox", "-c", str(alt_config), "x.cbz"))
+    settings = get_config(Namespace(comicbox=cns))
+    assert settings.write.merge_mode is MergeMode.UPDATE
+
+
+def test_mapping_config_merge_mode_is_honored() -> None:
+    """The Mapping args shape honors the same key."""
+    settings = get_config({"comicbox": {"write": {"merge_mode": "replace"}}})
+    assert settings.write.merge_mode is MergeMode.REPLACE
+
+
+def test_cli_merge_mode_beats_the_config_file(alt_config: Path) -> None:
+    """An explicit ``--merge-mode`` sits above the ``-c`` file."""
+    cns = get_args(
+        ("comicbox", "-c", str(alt_config), "--merge-mode", "replace", "x.cbz")
+    )
+    settings = get_config(Namespace(comicbox=cns))
+    assert settings.write.merge_mode is MergeMode.REPLACE
+
+
+def test_cli_merge_mode_lands_on_the_write_block() -> None:
+    """``--merge-mode`` drains into the nested write namespace."""
+    cns = get_args(("comicbox", "--merge-mode", "update", "x.cbz"))
+    assert cns.write.merge_mode == "update"
+
+
+def test_cli_merge_mode_rejects_unknown_choice() -> None:
+    """Argparse guards the CLI surface before confuse ever sees it."""
+    with pytest.raises(SystemExit):
+        get_args(("comicbox", "--merge-mode", "bogus", "x.cbz"))
+
+
+def test_replace_flag_is_gone() -> None:
+    """``--replace`` was removed; it must not silently parse again."""
+    with pytest.raises(SystemExit):
+        get_args(("comicbox", "--replace", "x.cbz"))
+
+
+def test_bad_config_merge_mode_raises_naming_the_valid_values() -> None:
+    """
+    An unparseable config value fails loudly instead of defaulting.
+
+    Silently ignoring a bad config value is the defect class the config
+    audit removed elsewhere; the message names the key and the choices.
+    """
+    with pytest.raises(ValueError, match=r"write\.merge_mode") as exc_info:
+        get_config({"comicbox": {"write": {"merge_mode": "bogus"}}})
+    message = str(exc_info.value)
+    for mode in MergeMode:
+        assert mode.value in message

--- a/tests/unit/test_merge_precedence.py
+++ b/tests/unit/test_merge_precedence.py
@@ -26,7 +26,7 @@ from comicbox.box import Comicbox
 from comicbox.box.init import LoadedMetadata
 from comicbox.box.merge import ComicboxMerge
 from comicbox.config import get_config
-from comicbox.config.settings import ComicboxSettings, WriteMode
+from comicbox.config.settings import ComicboxSettings, MergeMode
 from comicbox.formats import MetadataFormats
 from comicbox.formats.sources import MetadataSources
 
@@ -78,10 +78,10 @@ def _merge_order(*names: str) -> ComicboxSettings:
     return get_config({"comicbox": {"read": {"merge_order": list(names)}}})
 
 
-def _write_mode(mode: WriteMode) -> ComicboxSettings:
-    """Set write.mode the way the public write API does."""
+def _merge_mode(mode: MergeMode) -> ComicboxSettings:
+    """Set write.merge_mode the way the public write API does."""
     config = get_config()
-    return replace(config, write=replace(config.write, mode=mode))
+    return replace(config, write=replace(config.write, merge_mode=mode))
 
 
 ###########################
@@ -166,8 +166,8 @@ def test_add_metadata_with_an_online_format_merges(cbz: Path) -> None:
 #################################
 
 
-@pytest.mark.parametrize("mode", list(WriteMode))
-def test_reads_are_identical_under_every_write_mode(cbz: Path, mode: WriteMode) -> None:
+@pytest.mark.parametrize("mode", list(MergeMode))
+def test_reads_are_identical_under_every_merge_mode(cbz: Path, mode: MergeMode) -> None:
     """
     `to_dict()` must not depend on how a hypothetical write would merge.
 
@@ -175,27 +175,21 @@ def test_reads_are_identical_under_every_write_mode(cbz: Path, mode: WriteMode) 
     so comicbox.json's `credits` replaced ComicInfo's wholesale and Joe
     vanished from a plain read.
     """
-    md = _read(cbz, _write_mode(mode))
+    md = _read(cbz, _merge_mode(mode))
     assert md == _read(cbz)
     assert set(md["credits"]) == {"Joe", "Wally"}
-
-
-def test_legacy_replace_bool_does_not_change_a_read(cbz: Path) -> None:
-    """The deprecated `write.replace` alias is a write knob too."""
-    config = get_config({"comicbox": {"write": {"replace": True}}})
-    assert _read(cbz, config) == _read(cbz)
 
 
 @pytest.mark.parametrize(
     ("mode", "expect_sibling"),
     [
-        (WriteMode.ADDITIVE, True),
-        (WriteMode.REPLACE, True),
-        (WriteMode.UPDATE, False),
+        (MergeMode.ADDITIVE, True),
+        (MergeMode.REPLACE, True),
+        (MergeMode.UPDATE, False),
     ],
 )
-def test_write_mode_still_governs_the_supplied_patch(
-    cbz: Path, mode: WriteMode, *, expect_sibling: bool
+def test_merge_mode_still_governs_the_supplied_patch(
+    cbz: Path, mode: MergeMode, *, expect_sibling: bool
 ) -> None:
     """
     The patch keeps its documented per-mode semantics against the archive.
@@ -204,7 +198,7 @@ def test_write_mode_still_governs_the_supplied_patch(
     the archive comment supplied — while the deep modes keep it.
     """
     patch = {"comicbox": {"series": {"name": "D"}}}
-    with Comicbox(cbz, config=_write_mode(mode), metadata=patch) as cb:
+    with Comicbox(cbz, config=_merge_mode(mode), metadata=patch) as cb:
         series = cb.to_dict()["comicbox"]["series"]
     assert series["name"] == "D"
     assert ("volume_count" in series) is expect_sibling

--- a/tests/unit/test_write_api.py
+++ b/tests/unit/test_write_api.py
@@ -52,13 +52,15 @@ def test_write_metadata_replaces_scalar_preserving_siblings(tmp_cbz: Path) -> No
             "identifiers": {"metron": {"key": "42"}},
         }
     }
-    write_metadata(tmp_cbz, patch=initial, mode="replace", formats=["comicbox_json"])
+    write_metadata(
+        tmp_cbz, patch=initial, merge_mode="replace", formats=["comicbox_json"]
+    )
 
     # Patch only the name
     result = write_metadata(
         tmp_cbz,
         patch={"publisher": {"name": "Foo"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comicbox_json"],
     )
     assert result.written is True
@@ -85,11 +87,13 @@ def test_write_metadata_additive_recurses_into_publisher_dict(tmp_cbz: Path) -> 
             "identifiers": {"metron": {"key": "42"}},
         }
     }
-    write_metadata(tmp_cbz, patch=initial, mode="replace", formats=["comicbox_json"])
+    write_metadata(
+        tmp_cbz, patch=initial, merge_mode="replace", formats=["comicbox_json"]
+    )
     write_metadata(
         tmp_cbz,
         patch={"publisher": {"name": "Foo"}},
-        mode="additive",
+        merge_mode="additive",
         formats=["comicbox_json"],
     )
     pub = _read_publisher(tmp_cbz)
@@ -110,13 +114,13 @@ def test_write_metadata_update_replaces_top_level_key(tmp_cbz: Path) -> None:
                 "identifiers": {"metron": {"key": "42"}},
             }
         },
-        mode="replace",
+        merge_mode="replace",
         formats=["comicbox_json"],
     )
     write_metadata(
         tmp_cbz,
         patch={"publisher": {"name": "Foo"}},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
     )
     pub = _read_publisher(tmp_cbz)
@@ -124,12 +128,56 @@ def test_write_metadata_update_replaces_top_level_key(tmp_cbz: Path) -> None:
     assert "identifiers" not in pub
 
 
+@pytest.mark.parametrize(
+    ("merge_mode", "expect_urls", "expect_groups"),
+    [
+        (
+            "additive",
+            ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
+            {"G1", "G2", "G3"},
+        ),
+        ("replace", ["https://example.com/c"], {"G3"}),
+    ],
+)
+def test_write_metadata_list_fields_concatenate_or_overwrite(
+    tmp_cbz: Path,
+    merge_mode: str,
+    expect_urls: list[str],
+    expect_groups: set[str],
+) -> None:
+    """
+    List typed fields are the only axis where additive and replace differ.
+
+    Everywhere else the schema nests dicts or holds scalars, where both
+    modes recurse and replace leaves identically. `urls` (a list) and
+    `series_groups` (a set) are two of the five fields that can tell the
+    two modes apart.
+    """
+    seed = {
+        "urls": ["https://example.com/a", "https://example.com/b"],
+        "series_groups": ["G1", "G2"],
+    }
+    write_metadata(tmp_cbz, patch=seed, merge_mode="replace", formats=["comicbox_json"])
+    write_metadata(
+        tmp_cbz,
+        patch={"urls": ["https://example.com/c"], "series_groups": ["G3"]},
+        merge_mode=merge_mode,  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+        formats=["comicbox_json"],
+    )
+
+    md = _read_sub_md(tmp_cbz)
+    # The archive's own identifiers compute a comicvine url; only the
+    # supplied ones say anything about the merge.
+    assert [url for url in md["urls"] if "example.com" in url] == expect_urls
+    assert set(md["series_groups"]) == expect_groups
+
+
 def test_write_metadata_dry_run_returns_payload(tmp_cbz: Path) -> None:
     """dry_run=True returns the serialised would-be-written content."""
     result = write_metadata(
         tmp_cbz,
         patch={"publisher": {"name": "Foo"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comic_info"],
         dry_run=True,
     )
@@ -150,7 +198,7 @@ def test_write_metadata_unwraps_root_wrapped_patch(tmp_cbz: Path) -> None:
     """The root-wrapped shape to_dict() returns round-trips instead of no-opping."""
     wrapped = {"comicbox": {"publisher": {"name": "Wrapped"}}}
     result = write_metadata(
-        tmp_cbz, patch=wrapped, mode="replace", formats=["comicbox_json"]
+        tmp_cbz, patch=wrapped, merge_mode="replace", formats=["comicbox_json"]
     )
     assert result.written is True
     assert _read_publisher(tmp_cbz)["name"] == "Wrapped"
@@ -161,13 +209,13 @@ def test_write_metadata_round_trips_to_dict(tmp_cbz: Path) -> None:
     write_metadata(
         tmp_cbz,
         patch={"publisher": {"name": "RoundTrip"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comicbox_json"],
     )
     with Comicbox(tmp_cbz) as cb:
         full = cb.to_dict()
     result = write_metadata(
-        tmp_cbz, patch=full, mode="replace", formats=["comicbox_json"]
+        tmp_cbz, patch=full, merge_mode="replace", formats=["comicbox_json"]
     )
     assert result.written is True
     assert _read_publisher(tmp_cbz)["name"] == "RoundTrip"
@@ -188,13 +236,13 @@ def test_write_metadata_delete_keys_clears_field(tmp_cbz: Path) -> None:
     write_metadata(
         tmp_cbz,
         patch={"summary": "old summary", "age_rating": "Everyone"},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
     )
     result = write_metadata(
         tmp_cbz,
         patch={"age_rating": "Teen"},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
         delete_keys=["summary"],
     )
@@ -209,13 +257,13 @@ def test_write_metadata_delete_keys_allows_empty_patch(tmp_cbz: Path) -> None:
     write_metadata(
         tmp_cbz,
         patch={"summary": "doomed"},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
     )
     result = write_metadata(
         tmp_cbz,
         patch={},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
         delete_keys=["summary"],
     )
@@ -228,13 +276,13 @@ def test_write_metadata_delete_keys_strips_root_prefix(tmp_cbz: Path) -> None:
     write_metadata(
         tmp_cbz,
         patch={"summary": "doomed"},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
     )
     write_metadata(
         tmp_cbz,
         patch={},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
         delete_keys=["comicbox.summary"],
     )
@@ -251,13 +299,13 @@ def test_bulk_write_item_delete_keys_passes_through(tmp_cbz: Path) -> None:
     write_metadata(
         tmp_cbz,
         patch={"summary": "doomed", "age_rating": "Everyone"},
-        mode="update",
+        merge_mode="update",
         formats=["comicbox_json"],
     )
     item = BulkWriteItem(
         path=tmp_cbz,
         patch={},
-        mode="update",
+        merge_mode="update",
         formats=frozenset({"COMICBOX_JSON"}),
         delete_keys=frozenset({"summary"}),
     )
@@ -269,12 +317,79 @@ def test_bulk_write_item_delete_keys_passes_through(tmp_cbz: Path) -> None:
     assert md["age_rating"] == "Everyone"
 
 
-def test_write_metadata_rejects_unknown_mode(tmp_cbz: Path) -> None:
-    with pytest.raises(WriteValidationError, match="Unknown mode"):
+def _seed_publisher_with_sibling(path: Path) -> None:
+    """Seed publisher.name plus a nested sibling update mode would drop."""
+    write_metadata(
+        path,
+        patch={
+            "publisher": {
+                "name": "Original",
+                "identifiers": {"metron": {"key": "42"}},
+            }
+        },
+        merge_mode="replace",
+        formats=["comicbox_json"],
+    )
+
+
+def test_write_metadata_unset_merge_mode_defers_to_the_config(tmp_cbz: Path) -> None:
+    """
+    An omitted merge_mode honors the config instead of forcing additive.
+
+    The API used to pass its own default down unconditionally, which
+    overwrote whatever `write.merge_mode` a config file or --merge-mode
+    had established for every caller supplying a base_config.
+    """
+    config = get_config({"comicbox": {"write": {"merge_mode": "update"}}})
+    _seed_publisher_with_sibling(tmp_cbz)
+    write_metadata(
+        tmp_cbz,
+        patch={"publisher": {"name": "Foo"}},
+        formats=["comicbox_json"],
+        base_config=config,
+    )
+    pub = _read_publisher(tmp_cbz)
+    assert pub["name"] == "Foo"
+    assert "identifiers" not in pub
+
+
+def test_write_metadata_explicit_merge_mode_beats_the_config(tmp_cbz: Path) -> None:
+    """An explicit merge_mode wins over the config's."""
+    config = get_config({"comicbox": {"write": {"merge_mode": "update"}}})
+    _seed_publisher_with_sibling(tmp_cbz)
+    write_metadata(
+        tmp_cbz,
+        patch={"publisher": {"name": "Foo"}},
+        merge_mode="additive",
+        formats=["comicbox_json"],
+        base_config=config,
+    )
+    pub = _read_publisher(tmp_cbz)
+    assert pub["name"] == "Foo"
+    assert pub["identifiers"]["metron"]["key"] == "42"
+
+
+def test_bulk_write_item_unset_merge_mode_defers_to_the_config(tmp_cbz: Path) -> None:
+    """BulkWriteItem's unset merge_mode reaches the config the same way."""
+    config = get_config({"comicbox": {"write": {"merge_mode": "update"}}})
+    _seed_publisher_with_sibling(tmp_cbz)
+    item = BulkWriteItem(
+        path=tmp_cbz,
+        patch={"publisher": {"name": "Foo"}},
+        formats=frozenset({"COMICBOX_JSON"}),
+    )
+    results = list(bulk_write([item], base_config=config))
+    assert len(results) == 1
+    assert results[0].written is True
+    assert "identifiers" not in _read_publisher(tmp_cbz)
+
+
+def test_write_metadata_rejects_unknown_merge_mode(tmp_cbz: Path) -> None:
+    with pytest.raises(WriteValidationError, match="Unknown merge mode"):
         write_metadata(
             tmp_cbz,
             patch={"publisher": {"name": "x"}},
-            mode="bogus",  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+            merge_mode="bogus",  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
             formats=["comic_info"],
         )
 
@@ -304,7 +419,7 @@ def test_bulk_write_yields_per_file_results(tmp_path: Path) -> None:
             BulkWriteItem(
                 path=target,
                 patch={"publisher": {"name": f"Pub{i}"}},
-                mode="replace",
+                merge_mode="replace",
                 formats=frozenset({"COMICBOX_JSON"}),
             )
         )
@@ -323,7 +438,7 @@ def test_bulk_write_emits_events(tmp_cbz: Path) -> None:
         BulkWriteItem(
             path=tmp_cbz,
             patch={"publisher": {"name": "X"}},
-            mode="replace",
+            merge_mode="replace",
             formats=frozenset({"COMICBOX_JSON"}),
         )
     ]
@@ -348,7 +463,7 @@ def test_bulk_write_respects_cancel_token(tmp_path: Path) -> None:
             BulkWriteItem(
                 path=target,
                 patch={"publisher": {"name": "Changed"}},
-                mode="replace",
+                merge_mode="replace",
                 formats=frozenset({"COMICBOX_JSON"}),
             )
         )
@@ -370,7 +485,7 @@ def test_bulk_write_stop_on_error_cancels_queued_writes(tmp_path: Path) -> None:
         BulkWriteItem(
             path=bad,
             patch={"publisher": {"name": "x"}},
-            mode="replace",
+            merge_mode="replace",
             formats=frozenset({"COMICBOX_JSON"}),
         )
     ]
@@ -383,7 +498,7 @@ def test_bulk_write_stop_on_error_cancels_queued_writes(tmp_path: Path) -> None:
             BulkWriteItem(
                 path=target,
                 patch={"publisher": {"name": "Changed"}},
-                mode="replace",
+                merge_mode="replace",
                 formats=frozenset({"COMICBOX_JSON"}),
             )
         )
@@ -409,7 +524,7 @@ def test_bulk_write_cancel_mid_batch_stops_queued_writes(tmp_path: Path) -> None
             BulkWriteItem(
                 path=target,
                 patch={"publisher": {"name": "Changed"}},
-                mode="replace",
+                merge_mode="replace",
                 formats=frozenset({"COMICBOX_JSON"}),
             )
         )
@@ -431,7 +546,7 @@ def test_bulk_write_emits_batch_started_eagerly(tmp_cbz: Path) -> None:
         BulkWriteItem(
             path=tmp_cbz,
             patch={"publisher": {"name": "X"}},
-            mode="replace",
+            merge_mode="replace",
             formats=frozenset({"COMICBOX_JSON"}),
         )
     ]
@@ -451,7 +566,7 @@ def test_bulk_write_abandonment_skips_queued_writes(tmp_path: Path) -> None:
             BulkWriteItem(
                 path=target,
                 patch={"publisher": {"name": "Changed"}},
-                mode="replace",
+                merge_mode="replace",
                 formats=frozenset({"COMICBOX_JSON"}),
             )
         )
@@ -475,13 +590,13 @@ def test_bulk_write_reports_per_file_errors(tmp_path: Path) -> None:
         BulkWriteItem(
             path=bad,
             patch={"publisher": {"name": "x"}},
-            mode="replace",
+            merge_mode="replace",
             formats=frozenset({"COMICBOX_JSON"}),
         ),
         BulkWriteItem(
             path=good,
             patch={"publisher": {"name": "y"}},
-            mode="replace",
+            merge_mode="replace",
             formats=frozenset({"COMICBOX_JSON"}),
         ),
     ]
@@ -508,7 +623,7 @@ def test_write_metadata_final_path_unchanged_for_cbz(tmp_cbz: Path) -> None:
     result = write_metadata(
         tmp_cbz,
         patch={"publisher": {"name": "Foo"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comicbox_json"],
     )
     assert result.written is True
@@ -520,7 +635,7 @@ def test_write_metadata_converts_cbr_and_reports_final_path(tmp_cbr: Path) -> No
     result = write_metadata(
         tmp_cbr,
         patch={"publisher": {"name": "Foo"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comic_info"],
     )
     assert result.written is True
@@ -540,7 +655,7 @@ def test_write_metadata_convert_delete_orig_removes_original(tmp_cbr: Path) -> N
     result = write_metadata(
         tmp_cbr,
         patch={"publisher": {"name": "Foo"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comic_info"],
         base_config=cfg,
     )
@@ -556,7 +671,7 @@ def test_write_metadata_dry_run_reports_no_final_path(tmp_cbr: Path) -> None:
     result = write_metadata(
         tmp_cbr,
         patch={"publisher": {"name": "Foo"}},
-        mode="replace",
+        merge_mode="replace",
         formats=["comic_info"],
         dry_run=True,
     )
@@ -574,7 +689,7 @@ def test_bulk_write_propagates_final_path_on_conversion(tmp_cbr: Path) -> None:
         BulkWriteItem(
             path=tmp_cbr,
             patch={"publisher": {"name": "Foo"}},
-            mode="replace",
+            merge_mode="replace",
             formats=frozenset({"COMIC_INFO"}),
         )
     ]


### PR DESCRIPTION
## Context

`write.mode` selected the merger for caller-supplied metadata but had **no config-file or CLI surface**. The confuse template and `_build_write_settings` never read it, so a value in a config file was silently ignored. The only user-facing knob was `--replace`, which is marked deprecated, maps to `update` rather than `replace` despite its name, and left `replace` mode unreachable outside Python entirely.

The drift test allowlisted the gap with a rationale — *"Derived from the deprecated `replace` bool at build time"* — that describes no code that exists. The `replace` → `update` mapping happened at merge time, not build time. The guard that exists to catch exactly this kind of gap was handed a false rationale, which is why the missing surface went unnoticed.

## Changes

**Rename.** `WriteMode` → `MergeMode`, `WriteSettings.mode` → `merge_mode`. The name said "write" but it runs during the read/merge phase; post-#180 what it actually governs is how *supplied* metadata merges. The field name now matches the YAML key, so the drift test needs no alias entry.

**New surfaces.** Adds the `write.merge_mode` config key and a `--merge-mode` option, with an epilog table naming the five list-typed fields where `additive` and `replace` differ (`remainders`, `reprints`, `series_groups`, `urls`, `series.alternative_names`). A bad config value raises naming the key and the valid modes rather than being silently ignored — the defect class #179 fixed elsewhere.

**Removals.** `write.replace` and `--replace` are gone. That deletes the legacy alias branch in the merger resolution, which could not distinguish "defaulted to additive" from "explicitly chose additive" and silently upgraded the latter to `update`.

**The load-bearing fix.** `write_metadata` / `BulkWriteItem` take `merge_mode`, defaulting to `None`. `_build_write_settings` previously passed a resolved mode down *unconditionally*, overwriting whatever a `base_config` carried — which would have made the entire new config surface dead code for every API caller. A test pins this and fails against the old behavior.

**Housekeeping.** `parse_enum` moves from `config/online.py` to `config/settings.py` now that it has a consumer outside the online block.

## Default stays `additive`

Codex uses only `update`, but passes it explicitly on every call, so comicbox's default is invisible to it. The default governs only the human surfaces (`-m`, `--import`, config metadata block, API callers omitting the kwarg), which supply *partial* metadata — where `update` silently deletes sibling data. `update` itself is legitimate, long-standing CLI behavior; the fix for the expectation mismatch is the honest flag name and help text, not a behavior change.

## Codex impact

Codex passes an explicit `"update"` on every live path and has zero references to `write.replace` / `--replace`, so only two keyword renames affect it at pin-bump time:

- `librarian/scribe/tagwrite_rename.py` — import `MergeMode`, `replace(..., merge_mode=MergeMode(mode))`
- `librarian/scribe/tag_writer.py` — `BulkWriteItem(..., merge_mode=mode, ...)`

The `Mode` TypeAlias keeps its name and shape. Codex-internal names (its HTTP `mode` field, `BulkTagWriteTask.mode`, frontend payload) are unaffected.

## Tests

- **List-typed additive-vs-replace** — the only axis where the two modes differ had *zero* coverage; now covered for both the write API and the CLI.
- Config-file and CLI surfaces, including CLI-beats-config precedence.
- Both validation surfaces (argparse `choices`, `parse_enum`) plus the API's `WriteValidationError`.
- The `None` sentinel deferring to config, and explicit values overriding it.
- `--replace` is gone and must not silently parse again.

Deleted `test_legacy_replace_bool_does_not_change_a_read` (would pass vacuously once the template key is gone); renamed `test_cli_action_write_replace` → `..._merge_mode_update` with its expectation preserved exactly, since `--replace` always meant UPDATE.

## Verification

`make fix`, `make lint`, `make ty`, `make typecheck` all clean. Full suite: **1649 passed, 1 skipped**. `--help` renders the new flag and epilog table correctly.

## Noted separately, not fixed here

ComicInfo.xml **writes** `<SeriesGroup>` correctly but never **reads** it back — series-group data is silently lost on every read of a ComicInfo file. Suspected cause: `SeriesGroup` is mapped through `name_obj_to_cb` alongside Characters/Genre/Tags, but `series_groups` is a `StringSetField`, not a name-object dict. Pre-existing and unrelated to this change; it's why the CLI list-field test uses `comicbox_json` rather than ComicInfo. Tracked in its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
