### PR TITLE
perf(startup): defer schema compilation, the CLI epilog, and the default config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -181,6 +181,17 @@
       rendering "which source is being consulted right now" went blind on the
       explicit-id, stored-id and series-cache fast paths.
 
+- Performance
+    - Comicbox starts about a third faster. Importing it no longer compiles the
+      XSD and JSON Schema documents for every metadata format, and the CLI no
+      longer assembles its help tables on every run. Both are built the first
+      time something asks for them, so `--validate` and `--help` are unchanged.
+    - Building a `Comicbox` is about forty times cheaper. Each one re-read the
+      config files and rescanned the environment; the settings are now built
+      once and reused until the environment changes. As with `OnlineSession`,
+      editing a config file mid-run no longer changes settings for the rest of
+      the run.
+
 ## v4.8.6
 
 - Features

--- a/comicbox/box/validate/__init__.py
+++ b/comicbox/box/validate/__init__.py
@@ -4,15 +4,7 @@ import sys
 from pathlib import Path
 from types import MappingProxyType
 
-from jsonschema.exceptions import (
-    FormatError,
-    SchemaError,
-    UndefinedTypeCheck,
-    UnknownType,
-    ValidationError,
-)
 from loguru import logger
-from xmlschema.exceptions import XMLSchemaException
 
 from comicbox.box.dump_files import ComicboxDumpToFiles
 from comicbox.box.init import SourceData
@@ -20,15 +12,18 @@ from comicbox.box.validate.guess_format import guess_format
 from comicbox.exceptions import MetadataError
 from comicbox.formats import FORMAT_REGISTRATIONS, MetadataFormats
 from comicbox.formats.sources import MetadataSources
+from comicbox.validate.spec import build_validator, validation_failure_exceptions
 
-#: Derived from per-format `REGISTRATION.validator`. Formats whose
-#: registration has `validator=None` (PDF, PDF_XML, Filename, online APIs)
-#: are absent here and trigger the "no validator available" path below.
-FMT_VALIDATOR_MAP = MappingProxyType(
+#: Derived from per-format `REGISTRATION.validator_spec`. Formats whose
+#: registration has `validator_spec=None` (PDF, PDF_XML, Filename, online
+#: APIs) are absent here and trigger the "no validator available" path
+#: below. The specs stay unbuilt: `build_validator()` compiles a schema
+#: the first time this opt-in path actually validates against it.
+FMT_VALIDATOR_SPEC_MAP = MappingProxyType(
     {
-        fmt: registration.validator
+        fmt: registration.validator_spec
         for fmt, registration in FORMAT_REGISTRATIONS.items()
-        if registration.validator is not None
+        if registration.validator_spec is not None
     }
 )
 
@@ -51,24 +46,17 @@ def validate_source(
         reason = "Cannot determine format for source. Can't validate."
         raise MetadataError(reason)
 
-    validator = FMT_VALIDATOR_MAP.get(fmt)
-    if not validator:
+    spec = FMT_VALIDATOR_SPEC_MAP.get(fmt)
+    if not spec:
         # Just pass formats without validators
         logger.warning(f"{fmt.value.label}: no validator available")
         return True
+    validator = build_validator(spec)
     try:
         validator.validate(data)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
         logger.info(f"{fmt.value.label}: data validated")
         result = True
-    except (
-        XMLSchemaException,
-        # JsonValidation Errors
-        ValidationError,
-        SchemaError,
-        UndefinedTypeCheck,
-        UnknownType,
-        FormatError,
-    ) as exc:
+    except validation_failure_exceptions() as exc:
         logger.warning(f"{fmt.value.label}: failed validation")
         logger.warning(exc)
         result = False

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -3,17 +3,38 @@
 import sys
 from argparse import Action, ArgumentParser, Namespace
 from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from rich_argparse import RichHelpFormatter
 from typing_extensions import override
 
 from comicbox._pdf import PAGE_FORMAT_VALUES, PDF_ENABLED
-from comicbox.cli.epilog import build_epilog
 from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD
+
+if TYPE_CHECKING:
+    from rich.console import Group
 
 # Tracks one-shot stderr warnings so we don't spam users on repeated flag use.
 _WARNED_FLAGS: set[str] = set()
+
+
+class LazyEpilog:
+    """
+    Stand-in for the rich epilog that builds it only when help renders.
+
+    argparse asks for the epilog in `format_help()` and nowhere else, but
+    `build_epilog()` was called eagerly in `build_parser()` — so every
+    `comicbox` invocation imported `comicbox.cli.epilog` (and through it
+    the whole format registry) and assembled seven rich Tables that
+    almost no run ever prints. Rich resolves any object exposing
+    `__rich__` at render time, so the parser can hold this instead.
+    """
+
+    def __rich__(self) -> "Group":
+        """Assemble the real epilog. Called by rich while rendering help."""
+        from comicbox.cli.epilog import build_epilog
+
+        return build_epilog()
 
 
 class CSVAction(Action):
@@ -600,7 +621,7 @@ def build_parser() -> ArgumentParser:
 
     parser = ArgumentParser(
         description=description,
-        epilog=build_epilog(),  # pyright: ignore[reportArgumentType] # ty: ignore[invalid-argument-type]
+        epilog=LazyEpilog(),  # pyright: ignore[reportArgumentType] # ty: ignore[invalid-argument-type]
         formatter_class=RichHelpFormatter,
         add_help=False,
     )

--- a/comicbox/config/__init__.py
+++ b/comicbox/config/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -45,6 +46,12 @@ from comicbox.version import PACKAGE_NAME
 
 if TYPE_CHECKING:
     from argparse import Namespace
+
+# Every env var the config layer reads is COMICBOX-prefixed: confuse's
+# ``set_env`` auto-loading (``COMICBOX_*``), its user-config-dir lookup
+# (``COMICBOXDIR``), and the direct reads in ``online.env`` and
+# ``online.credentials``.
+_ENV_PREFIX = PACKAGE_NAME.upper()
 
 # Any non-Mapping container type — set/frozenset/tuple/list all pass.
 _NON_MAPPING_TYPES = (set, frozenset, tuple, list)
@@ -313,6 +320,58 @@ def _build_settings(
     )
 
 
+def _read_settings(args: Namespace | Mapping | None, modname: str) -> ComicboxSettings:
+    """Layer every config source and reduce the result to settings."""
+    config = Configuration(PACKAGE_NAME, modname=modname, read=False)
+    read_config_sources(config, args)
+
+    config_program = config[PACKAGE_NAME]
+    compute_config(config_program)
+
+    ad = config.get(_TEMPLATE)
+    return _build_settings(ad, args=args)
+
+
+# (environment snapshot, settings built from it). See _get_default_settings.
+_DefaultSettingsMemo = tuple[tuple[tuple[str, str], ...], ComicboxSettings]
+_default_settings_memo: _DefaultSettingsMemo | None = None
+
+
+def _environ_key() -> tuple[tuple[str, str], ...]:
+    """Snapshot the env vars a no-args config build depends on."""
+    return tuple(
+        sorted(item for item in os.environ.items() if item[0].startswith(_ENV_PREFIX))
+    )
+
+
+def _get_default_settings() -> ComicboxSettings:
+    """
+    Build the unparameterized settings once per environment.
+
+    Every ``Comicbox(path)`` constructed without an explicit config lands
+    here, and each one re-parsed ``config_default.yaml`` and the user's
+    ``config.yaml``, re-scanned the environment, and re-ran confuse's
+    template validation — several milliseconds apiece, per comic.
+    ``OnlineSession`` hoisted this same call to once per session for
+    exactly that reason; memoizing it here gives every library caller the
+    same win without each one having to know to hoist.
+
+    Keyed on the environment, so a host that exports ``COMICBOX_*`` (or
+    repoints ``COMICBOXDIR`` at a different user config) still gets a
+    fresh build. Like ``OnlineSession``, an edit to a config file at an
+    unchanged path is not re-read mid-process.
+    """
+    global _default_settings_memo  # noqa: PLW0603
+
+    key = _environ_key()
+    memo = _default_settings_memo
+    if memo is not None and memo[0] == key:
+        return memo[1]
+    settings = _read_settings(None, PACKAGE_NAME)
+    _default_settings_memo = (key, settings)
+    return settings
+
+
 def get_config(
     args: Namespace | Mapping | ComicboxSettings | None = None,
     *,
@@ -323,15 +382,10 @@ def get_config(
     """Get the config dict, layering env and args over defaults."""
     if isinstance(args, ComicboxSettings):
         return post_process_set_for_path(args, path, box=box)
-    if isinstance(args, Mapping):
-        args = dict(args)
-
-    config = Configuration(PACKAGE_NAME, modname=modname, read=False)
-    read_config_sources(config, args)
-
-    config_program = config[PACKAGE_NAME]
-    compute_config(config_program)
-
-    ad = config.get(_TEMPLATE)
-    settings = _build_settings(ad, args=args)
+    if args is None and modname == PACKAGE_NAME:
+        settings = _get_default_settings()
+    else:
+        if isinstance(args, Mapping):
+            args = dict(args)
+        settings = _read_settings(args, modname)
     return post_process_set_for_path(settings, path, box=box)

--- a/comicbox/formats/_base.py
+++ b/comicbox/formats/_base.py
@@ -5,7 +5,7 @@ from types import MappingProxyType
 
 from comicbox.formats.base.schemas.base import BaseSchema
 from comicbox.formats.base.transforms.base import BaseTransform
-from comicbox.validate.base import BaseValidator
+from comicbox.validate.spec import ValidatorSpec
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,7 +62,9 @@ class FormatRegistration:
 
     format: MetadataFormat
     sources: MappingProxyType[str, int]
-    validator: BaseValidator | None = None
+    #: Names the schema validator without building it. Only the opt-in
+    #: `--validate` path calls `build_validator()` on it.
+    validator_spec: ValidatorSpec | None = None
     has_tags_without_ids: bool = False
     is_online: bool = False
     cli_info: OnlineSourceCliInfo | None = None

--- a/comicbox/formats/comet/__init__.py
+++ b/comicbox/formats/comet/__init__.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 
 from comicbox.formats._base import FormatRegistration, MetadataFormat
 from comicbox.formats.comet.transform import CoMetTransform
-from comicbox.validate.xml_validator import XmlValidator
+from comicbox.validate.spec import ValidatorSpec, ValidatorType
 
 REGISTRATION = FormatRegistration(
     format=MetadataFormat(
@@ -26,5 +26,5 @@ REGISTRATION = FormatRegistration(
             "API": 6,
         }
     ),
-    validator=XmlValidator("CoMet-v1.1.xsd"),
+    validator_spec=ValidatorSpec(ValidatorType.XML, "CoMet-v1.1.xsd"),
 )

--- a/comicbox/formats/comic_book_info/__init__.py
+++ b/comicbox/formats/comic_book_info/__init__.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 
 from comicbox.formats._base import FormatRegistration, MetadataFormat
 from comicbox.formats.comic_book_info.transform import ComicBookInfoTransform
-from comicbox.validate.json_validator import JsonValidator
+from comicbox.validate.spec import ValidatorSpec, ValidatorType
 
 REGISTRATION = FormatRegistration(
     format=MetadataFormat(
@@ -23,6 +23,8 @@ REGISTRATION = FormatRegistration(
             "API": 5,
         }
     ),
-    validator=JsonValidator("comic-book-info-v1.0.schema.json"),
+    validator_spec=ValidatorSpec(
+        ValidatorType.JSON, "comic-book-info-v1.0.schema.json"
+    ),
     has_tags_without_ids=True,
 )

--- a/comicbox/formats/comic_info/__init__.py
+++ b/comicbox/formats/comic_info/__init__.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 
 from comicbox.formats._base import FormatRegistration, MetadataFormat
 from comicbox.formats.comic_info.transform import ComicInfoTransform
-from comicbox.validate.xml_validator import XmlValidator
+from comicbox.validate.spec import ValidatorSpec, ValidatorType
 
 REGISTRATION = FormatRegistration(
     format=MetadataFormat(
@@ -23,6 +23,6 @@ REGISTRATION = FormatRegistration(
             "API": 4,
         }
     ),
-    validator=XmlValidator("ComicInfo-v2.1-Draft.xsd"),
+    validator_spec=ValidatorSpec(ValidatorType.XML, "ComicInfo-v2.1-Draft.xsd"),
     has_tags_without_ids=True,
 )

--- a/comicbox/formats/comicbox/__init__.py
+++ b/comicbox/formats/comicbox/__init__.py
@@ -13,8 +13,7 @@ from comicbox.formats._base import FormatRegistration, MetadataFormat
 from comicbox.formats.comicbox.transform.cli import ComicboxCLITransform
 from comicbox.formats.comicbox.transform.json import ComicboxJsonTransform
 from comicbox.formats.comicbox.transform.yaml import ComicboxYamlTransform
-from comicbox.validate.json_validator import JsonValidator
-from comicbox.validate.yaml_validator import YamlValidator
+from comicbox.validate.spec import ValidatorSpec, ValidatorType
 
 _COMICBOX_SCHEMA_FILE = "v3.0/comicbox-v3.0.schema.json"
 
@@ -33,7 +32,7 @@ YAML_REGISTRATION = FormatRegistration(
             "API": 1,
         }
     ),
-    validator=YamlValidator(_COMICBOX_SCHEMA_FILE),
+    validator_spec=ValidatorSpec(ValidatorType.YAML, _COMICBOX_SCHEMA_FILE),
 )
 
 JSON_REGISTRATION = FormatRegistration(
@@ -51,7 +50,7 @@ JSON_REGISTRATION = FormatRegistration(
             "API": 2,
         }
     ),
-    validator=JsonValidator(_COMICBOX_SCHEMA_FILE),
+    validator_spec=ValidatorSpec(ValidatorType.JSON, _COMICBOX_SCHEMA_FILE),
 )
 
 CLI_YAML_REGISTRATION = FormatRegistration(
@@ -70,5 +69,5 @@ CLI_YAML_REGISTRATION = FormatRegistration(
             "API": 0,
         }
     ),
-    validator=YamlValidator(_COMICBOX_SCHEMA_FILE),
+    validator_spec=ValidatorSpec(ValidatorType.YAML, _COMICBOX_SCHEMA_FILE),
 )

--- a/comicbox/formats/metron_info/__init__.py
+++ b/comicbox/formats/metron_info/__init__.py
@@ -4,7 +4,7 @@ from types import MappingProxyType
 
 from comicbox.formats._base import FormatRegistration, MetadataFormat
 from comicbox.formats.metron_info.transform import MetronInfoTransform
-from comicbox.validate.xml_validator import XmlValidator
+from comicbox.validate.spec import ValidatorSpec, ValidatorType
 
 REGISTRATION = FormatRegistration(
     format=MetadataFormat(
@@ -23,5 +23,5 @@ REGISTRATION = FormatRegistration(
             "API": 3,
         }
     ),
-    validator=XmlValidator("MetronInfo-v1.1.xsd"),
+    validator_spec=ValidatorSpec(ValidatorType.XML, "MetronInfo-v1.1.xsd"),
 )

--- a/comicbox/validate/__init__.py
+++ b/comicbox/validate/__init__.py
@@ -3,7 +3,10 @@ Leaf schema validators.
 
 Lives outside `comicbox/box/` so importing a validator doesn't drag in the
 `Comicbox` mixin chain (which loops back through `comicbox.config` →
-`comicbox.formats.sources` → `comicbox.formats`). Format packages reference
-these classes from their `REGISTRATION`, so they must be importable while
-`comicbox.formats.__init__` is still loading.
+`comicbox.formats.sources` → `comicbox.formats`). Format packages name
+these classes with a `spec.ValidatorSpec` in their `REGISTRATION`, so
+`spec` must be importable while `comicbox.formats.__init__` is still
+loading — and, because the modules below pull in `xmlschema` /
+`jsonschema` and compile their schemas, nothing here may be imported
+until something actually validates.
 """

--- a/comicbox/validate/spec.py
+++ b/comicbox/validate/spec.py
@@ -1,0 +1,97 @@
+"""
+Deferred validator declarations.
+
+Format registrations name their schema validator with a ``ValidatorSpec``
+instead of constructing one. Construction is not cheap: it imports
+``xmlschema`` or ``jsonschema`` and then compiles an XSD 1.1 or JSON
+Schema document. Doing that eagerly put ~200ms of schema compilation into
+every ``import comicbox.formats`` — paid by every read, write, and CLI
+run — while the only consumer is the opt-in ``--validate`` path in
+``comicbox.box.validate``.
+
+Naming a validator here is pure data. Nothing heavier than ``comicbox``
+itself is imported until ``build_validator()`` is called.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from comicbox.validate.base import BaseValidator
+
+
+class ValidatorType(Enum):
+    """Schema languages comicbox validates metadata against."""
+
+    XML = "xml"
+    JSON = "json"
+    YAML = "yaml"
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatorSpec:
+    """
+    A schema language and the schema file to validate against.
+
+    Frozen and hashable so ``build_validator()`` can memoize on it: the
+    three comicbox-native registrations name the same schema file, and
+    without the memo every ``validate_source()`` call would recompile.
+    """
+
+    validator_type: ValidatorType
+    schema_path: str
+
+
+@cache
+def build_validator(spec: ValidatorSpec) -> "BaseValidator":
+    """Construct (and compile) the validator a spec names."""
+    # Lazy imports: reaching this function is what makes the xmlschema /
+    # jsonschema dependency chain worth loading. See the module docstring.
+    if spec.validator_type is ValidatorType.XML:
+        from comicbox.validate.xml_validator import XmlValidator
+
+        return XmlValidator(spec.schema_path)
+    if spec.validator_type is ValidatorType.JSON:
+        from comicbox.validate.json_validator import JsonValidator
+
+        return JsonValidator(spec.schema_path)
+    if spec.validator_type is ValidatorType.YAML:
+        from comicbox.validate.yaml_validator import YamlValidator
+
+        return YamlValidator(spec.schema_path)
+    # Spelled out rather than falling through to a default: a new
+    # ValidatorType silently building the wrong validator would look like
+    # a schema bug, not a missing branch.
+    reason = f"No validator for {spec.validator_type}"
+    raise NotImplementedError(reason)
+
+
+@cache
+def validation_failure_exceptions() -> tuple[type[Exception], ...]:
+    """
+    Get the exceptions a validator raises for invalid data.
+
+    Deferred for the same reason the validators are: importing these
+    names at module scope pulls in all of ``xmlschema`` and
+    ``jsonschema`` even when nothing validates.
+    """
+    from jsonschema.exceptions import (
+        FormatError,
+        SchemaError,
+        UndefinedTypeCheck,
+        UnknownType,
+        ValidationError,
+    )
+    from xmlschema.exceptions import XMLSchemaException
+
+    return (
+        XMLSchemaException,
+        # JsonValidation Errors
+        ValidationError,
+        SchemaError,
+        UndefinedTypeCheck,
+        UnknownType,
+        FormatError,
+    )

--- a/tests/unit/test_lazy_startup.py
+++ b/tests/unit/test_lazy_startup.py
@@ -1,0 +1,112 @@
+"""
+Import- and startup-cost contracts.
+
+Each of these guards a deferral that is invisible at runtime: when one
+regresses the code still works, it just gets slower again. A module-scope
+import added in the wrong place is exactly how they regress, so they are
+asserted here rather than left to a benchmark nobody runs.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from argparse import Namespace
+from typing import TYPE_CHECKING
+
+from comicbox.config import get_config
+from comicbox.formats import FORMAT_REGISTRATIONS
+from comicbox.validate.base import BaseValidator
+from comicbox.validate.spec import build_validator
+
+if TYPE_CHECKING:
+    import pytest
+
+# Importing any of these compiles schemas or drags in a dependency tree
+# that only the opt-in --validate path needs.
+_VALIDATION_ONLY_PACKAGES = frozenset(
+    {
+        "elementpath",
+        "jsonschema",
+        "jsonschema_specifications",
+        "referencing",
+        "xmlschema",
+    }
+)
+
+
+def _modules_loaded_by(code: str) -> set[str]:
+    """Run ``code`` in a fresh interpreter and return the modules it left behind."""
+    script = code + "\nimport sys\nprint(' '.join(sys.modules))"
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], capture_output=True, check=True, text=True
+    )
+    modules = set(proc.stdout.split())
+    assert "comicbox" in modules  # the probe really did import comicbox
+    return modules
+
+
+def test_reading_a_comic_does_not_load_schema_validators() -> None:
+    """Importing the box chain must not compile any XSD or JSON Schema."""
+    packages = {
+        name.split(".")[0] for name in _modules_loaded_by("import comicbox.box")
+    }
+    assert not packages & _VALIDATION_ONLY_PACKAGES
+
+
+def test_building_the_cli_parser_does_not_build_the_epilog() -> None:
+    """The epilog's seven rich Tables are only ever printed by ``--help``."""
+    modules = _modules_loaded_by(
+        "from comicbox.cli.parser import build_parser\nbuild_parser()"
+    )
+    assert "comicbox.cli.epilog" not in modules
+
+
+def test_help_still_renders_the_epilog() -> None:
+    """Deferring the epilog must not drop it from ``--help``."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "comicbox.cli", "--help"],
+        capture_output=True,
+        check=True,
+        text=True,
+        env={**os.environ, "COLUMNS": "100"},
+    )
+    assert "--print PHASES" in proc.stdout
+    assert "Online sources" in proc.stdout
+    assert "Format keys" in proc.stdout
+
+
+def test_every_registered_validator_spec_builds() -> None:
+    """A spec naming a validator comicbox can't build breaks ``--validate``."""
+    specs = [
+        registration.validator_spec
+        for registration in FORMAT_REGISTRATIONS.values()
+        if registration.validator_spec is not None
+    ]
+    assert specs
+    for spec in specs:
+        assert isinstance(build_validator(spec), BaseValidator)
+
+
+def test_default_config_is_reused() -> None:
+    """The no-args build is memoized, so a per-comic Comicbox stays cheap."""
+    assert get_config() is get_config()
+
+
+def test_default_config_rebuilds_when_the_environment_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A memo outliving its environment would silently ignore env vars."""
+    before = get_config()
+    monkeypatch.setenv("COMICBOX_ONLINE_FIRST_WINS", "false")
+    after = get_config()
+    assert after is not before
+    assert after.online.lookup.first_wins is False
+    monkeypatch.delenv("COMICBOX_ONLINE_FIRST_WINS")
+    assert get_config().online.lookup.first_wins is True
+
+
+def test_args_never_come_from_the_memo() -> None:
+    """Only the unparameterized build is shared."""
+    assert get_config(Namespace(comicbox=Namespace())) is not get_config()


### PR DESCRIPTION
Three costs were paid on every run by code paths that almost never needed them.

## 1. Validators are named, not built

`FormatRegistration.validator` held a constructed `XmlValidator` /
`JsonValidator` / `YamlValidator`, so importing a format package imported
`xmlschema` or `jsonschema` and compiled its schema. Five registrations did
this, putting ~200ms of XSD 1.1 and JSON Schema compilation into every
`import comicbox.formats` — paid by every read, write, and CLI run — while the
sole consumer is the opt-in `--validate` path in
[comicbox/box/validate/\_\_init\_\_.py](comicbox/box/validate/__init__.py).

A registration now names its validator with a `ValidatorSpec` (pure data), and
[comicbox/validate/spec.py](comicbox/validate/spec.py) builds it — memoized —
the first time something validates. The exception tuple `validate_source()`
catches is deferred the same way, so neither library enters the import graph
until validation actually runs.

## 2. The CLI epilog builds when help renders

`build_parser()` called `build_epilog()` eagerly, assembling seven rich Tables
and importing `FORMAT_REGISTRATIONS` for help text only `--help` prints. The
parser now holds a `LazyEpilog`, which rich resolves at render time.
`--help` output is byte-identical.

## 3. The default config is built once

`get_config()` re-parsed `config_default.yaml` and the user's `config.yaml`,
rescanned the environment, and re-ran confuse's template validation for every
`Comicbox(path)` built without an explicit config — 3.4ms per comic, ~84% of it
YAML parsing. `OnlineSession` hoisted this same call to once per session for
exactly that reason; the no-args build is now memoized so every library caller
gets it without knowing to hoist.

The memo is keyed on the `COMICBOX*` environment, so an exported `COMICBOX_*`
var or a repointed `COMICBOXDIR` still rebuilds. Only the unparameterized call
is shared; anything passing args builds fresh, and a build that raises caches
nothing.

## Measurements

`python -X importtime` and best-of-9 process timings, in two matched worktrees
each with its own `uv sync`ed venv:

| | before | after | |
|---|---:|---:|---:|
| `import comicbox.formats` | 392.4 ms | 201.1 ms | −49% |
| `import comicbox.box` | 522.9 ms | 328.1 ms | −37% |
| `import comicbox.cli` | 524.3 ms | 327.2 ms | −38% |
| `comicbox --version` (wall) | 686.0 ms | 443.8 ms | −35% |
| `comicbox --help` (wall) | 678.0 ms | 429.0 ms | −37% |
| `get_config()` | 3.431 ms | 0.029 ms | −99% |
| `Comicbox(path)` | 3.508 ms | 0.090 ms | −97% |
| 500 × `Comicbox(path)` | 1810.8 ms | 45.6 ms | −97% |

`import comicbox` on its own is 0.1 ms before and after — the top-level
`__init__` was already trivial, so the meaningful entry points are measured
instead.

The `-X importtime` self-times that moved:

```
comicbox.formats.comet          70.1 ms  (CoMet XSD compile)   -> gone
comicbox.formats.comic_info     14.3 ms  (ComicInfo XSD)       -> gone
comicbox.formats.metron_info    14.4 ms  (MetronInfo XSD)      -> gone
xmlschema                       58.3 ms                        -> gone
jsonschema                      40.4 ms                        -> gone
```

## Behavior

Unchanged, with one documented exception: a config file edited **at an unchanged
path** mid-process is no longer re-read, matching the decision `OnlineSession`
already made. Pointing `COMICBOXDIR` at a different config, or changing any
`COMICBOX_*` var, still rebuilds.

## Verification

- `make fix`, `make lint`, `make ty`, `make typecheck` all clean.
- Full suite: **1663 passed, 1 skipped** (1656 before + 7 new).
- `comicbox --help` output diffed byte-for-byte against `develop`.
- All three validator languages exercised through the lazy path, accepting valid
  data and rejecting invalid data (XSD, JSON Schema, and YAML).
- No import-cycle regression: `comicbox.box` and `comicbox.cli` import cleanly
  when entered first from `comicbox.config`, `comicbox.formats`,
  `comicbox.formats.sources`, `comicbox.box`, `comicbox.cli.parser`,
  `comicbox.box.validate`, or `comicbox.validate.spec` — without
  `tests/conftest.py`'s pre-priming.

New regression tests in
[tests/unit/test_lazy_startup.py](tests/unit/test_lazy_startup.py) guard the
deferrals, which are otherwise invisible: when one regresses the code still
works, it just gets slow again. Both import guards were confirmed to fail
against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
