### PR TITLE
fix(comic_info): read SeriesGroup back instead of dropping it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,10 @@
       case. An unrecognized name is no longer read as ComicVine.
     - An issue naming a suffix but no number, like `1234AU`, gets its number.
     - A notes timestamp nothing can parse leaves `updated_at` unset.
+    - ComicInfo's `SeriesGroup` is read back. The tag was written correctly and
+      then dropped on load: it was mapped like `Characters` and `Tags`, whose
+      comicbox fields hold a name and its ids, while `series_groups` holds plain
+      names.
 
 - Features
     - New `--merge-mode` option and `write.merge_mode` config key choose how

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -9,7 +9,7 @@ from rich_argparse import RichHelpFormatter
 from typing_extensions import override
 
 from comicbox._pdf import PAGE_FORMAT_VALUES, PDF_ENABLED
-from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD
+from comicbox.config.settings import DEFAULT_AUTO_THRESHOLD, MergeMode
 
 if TYPE_CHECKING:
     from rich.console import Group

--- a/comicbox/formats/comic_info/transform/__init__.py
+++ b/comicbox/formats/comic_info/transform/__init__.py
@@ -200,6 +200,9 @@ SIMPLE_KEY_MAP = frozenbidict(
         "Review": REVIEW_KEY,
         "ScanInformation": SCAN_INFO_KEY,
         "Series": SERIES_NAME_KEYPATH,
+        # A string set on both sides, not a name object map: comicbox
+        # series_groups is a StringSetField, so the set passes through.
+        "SeriesGroup": SERIES_GROUPS_KEY,
         "Summary": SUMMARY_KEY,
         "Title": TITLE_KEY,
         "Volume": VOLUME_NUMBER_KEYPATH,
@@ -211,7 +214,6 @@ NAME_OBJ_KEY_MAP = frozenbidict(
         "Characters": CHARACTERS_KEY,
         "Genre": GENRES_KEY,
         "Locations": LOCATIONS_KEY,
-        "SeriesGroup": SERIES_GROUPS_KEY,
         "Tags": TAGS_KEY,
         "Teams": TEAMS_KEY,
     }

--- a/tests/unit/test_comicinfo_series_groups.py
+++ b/tests/unit/test_comicinfo_series_groups.py
@@ -1,0 +1,114 @@
+"""
+ComicInfo's SeriesGroup wrote correctly but never read back.
+
+The tag sat in the transform's name object key map alongside Characters,
+Genre, Locations, Tags and Teams, so the read direction turned
+``SeriesGroup`` into ``{"G1": {}, "G2": {}}``. Every other member of that
+map targets a ``SimpleNamedDictField``, which accepts both a name object
+dict and a bare string set; comicbox's ``series_groups`` is a plain
+``StringSetField``, which deserializes a Mapping to nothing. The value was
+dropped without an error on load. The write direction hid the bug because
+the set serialized back to the comma string the tag expects.
+
+SeriesGroup is a string set on both sides, so it belongs in the plain key
+map, which passes the set straight through.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+from zipfile import ZipFile
+
+from comicbox import cli
+from comicbox.box import Comicbox
+from comicbox.formats import MetadataFormats
+from comicbox.formats.base.fields.comicbox import SimpleNamedDictField
+from comicbox.formats.comet.transform import NAME_OBJ_KEY_MAP as COMET_NAME_OBJ_MAP
+from comicbox.formats.comic_book_info.transform import (
+    NAME_OBJ_KEYPATHS as CBI_NAME_OBJ_MAP,
+)
+from comicbox.formats.comic_info.schema import ComicInfoSchema
+from comicbox.formats.comic_info.transform import (
+    NAME_OBJ_KEY_MAP as CIX_NAME_OBJ_MAP,
+)
+from comicbox.formats.comic_info.transform import ComicInfoTransform
+from comicbox.formats.comicbox.schema import ComicboxSchemaMixin, ComicboxSubSchemaMixin
+from comicbox.formats.pdf.transform import (
+    MUPDF_NAME_OBJ_KEY_MAP,
+    XMLPDF_NAME_OBJ_KEY_MAP,
+)
+from tests.const import EMPTY_CBZ_SOURCE_PATH
+from tests.util import get_tmp_dir, my_cleanup, my_setup
+
+_CIX = ComicInfoTransform(None)
+_TMP_DIR = get_tmp_dir(__file__)
+_TMP_PATH = _TMP_DIR / EMPTY_CBZ_SOURCE_PATH.name
+
+# Every name object key map in the codebase. Their targets must all accept a
+# name object dict, which is what `name_obj_to_cb` builds.
+_NAME_OBJ_MAPS = MappingProxyType(
+    {
+        "comic_book_info": CBI_NAME_OBJ_MAP,
+        "comet": COMET_NAME_OBJ_MAP,
+        "comic_info": CIX_NAME_OBJ_MAP,
+        "pdf_mupdf": MUPDF_NAME_OBJ_KEY_MAP,
+        "pdf_xml": XMLPDF_NAME_OBJ_KEY_MAP,
+    }
+)
+
+
+def _to_cb(native: dict[str, Any]) -> dict:
+    loaded: dict = ComicInfoSchema().load({"ComicInfo": native})  # pyright: ignore[reportAssignmentType]
+    return dict(_CIX.to_comicbox(loaded).get("comicbox", {}))
+
+
+def _from_cb(sub_md: dict[str, Any]) -> dict:
+    return dict(_CIX.from_comicbox({"comicbox": sub_md}).get("ComicInfo", {}))
+
+
+def test_series_group_reads() -> None:
+    """The tag's comma string becomes the comicbox string set."""
+    sub_md = _to_cb({"SeriesGroup": "G1,G2"})
+    assert sub_md["series_groups"] == {"G1", "G2"}
+
+
+def test_series_group_reads_as_a_string_set() -> None:
+    """The name object dict it used to build is the shape that got dropped."""
+    sub_md = _to_cb({"SeriesGroup": "G1"})
+    assert isinstance(sub_md["series_groups"], set)
+
+
+def test_series_group_writes() -> None:
+    """The set still serializes back to the comma string the tag expects."""
+    native = _from_cb({"series_groups": {"G2", "G1"}})
+    assert native["SeriesGroup"] == {"G1", "G2"}
+
+
+def test_series_group_round_trips_through_an_archive() -> None:
+    """End to end: write ComicInfo.xml into a cbz and read it back."""
+    my_setup(_TMP_DIR, EMPTY_CBZ_SOURCE_PATH)
+    try:
+        cli.main(
+            ("comicbox", "-m", "series_groups: [G1, G2]", "-w", "cr", str(_TMP_PATH))
+        )
+        with ZipFile(_TMP_PATH) as zf:
+            xml = zf.read(MetadataFormats.COMIC_INFO.value.filename).decode()
+        with Comicbox(_TMP_PATH) as car:
+            md = car.to_dict()
+    finally:
+        my_cleanup(_TMP_DIR)
+    assert "<SeriesGroup>G1,G2</SeriesGroup>" in xml
+    assert set(md[ComicboxSchemaMixin.ROOT_TAG]["series_groups"]) == {"G1", "G2"}
+
+
+def test_name_object_maps_only_target_name_object_fields() -> None:
+    """A string set field routed through a name object map drops its value."""
+    fields = ComicboxSubSchemaMixin().fields
+    for format_name, key_map in _NAME_OBJ_MAPS.items():
+        for tag, keypath in key_map.items():
+            field = fields.get(keypath)
+            assert isinstance(field, SimpleNamedDictField), (
+                f"{format_name} maps {tag} to {keypath},"
+                " which does not accept a name object dict."
+            )


### PR DESCRIPTION
## SeriesGroup

ComicInfo's `SeriesGroup` wrote correctly and was silently dropped on read.

The tag sat in the transform's `NAME_OBJ_KEY_MAP`, so the read direction
built `{"G1": {}, "G2": {}}` for it. Every other member of that map targets a
`SimpleNamedDictField`, which accepts a name-object dict *or* a bare string
set; comicbox's `series_groups` is a plain `StringSetField`, whose
`_deserialize` returns nothing for a Mapping (`marshmallow.utils.is_collection`
is False for dicts). The value vanished during the `ComicboxYamlSchema.load`
inside `to_comicbox`, with no error. The write direction hid the bug because
the set serialized back to the comma string the tag expects.

`SeriesGroup` is a string set on both sides — `XmlStringSetField(as_string=True)`
in the ComicInfo schema, `StringSetField` in comicbox — so it moves to the plain
key map and passes through untransformed in both directions.

Before:

```
<SeriesGroup>G1,G2</SeriesGroup>  ->  to_dict(): no series_groups key
```

After:

```
<SeriesGroup>G1,G2</SeriesGroup>  ->  {'series_groups': ['G1', 'G2']}
```

### Other formats

Checked every `name_obj_to_cb` map by round-tripping a comicbox dict through
each format's transform. CoMet (`character`, `genre`), ComicBookInfo (`genre`,
`tags`) and PDF (both the XMP and MuPDF maps: `tags`, `genres`) target only
`SimpleNamedDictField`s, so they round-trip. MetronInfo builds no name objects;
its `urls`, `reprints` and `series.alternative_names` all round-trip. Comicbox's
only other string-collection fields are `urls` (fine) and `remainders`
(filename-only).

### Tests

`tests/unit/test_comicinfo_series_groups.py` — transform-level read and write,
the reported CLI write/read round-trip through a cbz, and a drift guard that
asserts every name-object map target is a `SimpleNamedDictField`, so a set-typed
field can't be routed through that map again. Four of the five fail without the
fix.

## Second commit: the CLI is broken on develop

Unrelated to the above, found because `tests/unit/test_merge_mode_config.py`
fails on current `develop`: #185 deferred the CLI's imports and dropped
`MergeMode` from the runtime import in `comicbox/cli/parser.py`, while
`_add_write_group` still reads it for the `--merge-mode` choices. `build_parser`
raises `NameError`, so **every** CLI invocation dies — `comicbox --version`
included. Restored the import; it comes from `config.settings`, which the parser
already imports at runtime for `DEFAULT_AUTO_THRESHOLD`, so it costs no extra
startup work. Happy to split this out if you'd rather.

`make fix`, `make lint`, `make ty` clean; `make test`: 1832 passed, 1 skipped
(the pre-existing `test_online_matcher` skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)