### PR TITLE
fix(run): one guard for every batch dispatch; make the prompt's terse mode real

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,17 @@
       enum is now `MergeMode`.
 
 - Fixes
+    - A comic that can't be read no longer ends the batch. Every dispatch path —
+      serial, `--recurse` and `-j N` — now logs the file and keeps going.
+      Previously `comicbox a.cbz b.cbz c.cbz` stopped at the first unreadable
+      file and left the rest untouched, while the same batch under `-j 2`
+      processed all of them.
+    - `comicbox` exits non-zero when any file failed, instead of only when the
+      failure happened to end the run. A batch where every file failed used to
+      exit 0 under `-j N`.
+    - The ambiguous-match prompt trims its per-candidate detail lines on a
+      quieted run (`-QQ` and up, or a `loglevel` above `INFO` in the config). It
+      always claimed to and never did.
     - Writing MetronInfo no longer invents extra credits. Only `Painter` still
       writes Penciller, Inker and Colorist.
     - `breakdowns`, `finishes`, `plotter` and `scripter` keep their own role

--- a/comicbox/cli/__init__.py
+++ b/comicbox/cli/__init__.py
@@ -141,3 +141,10 @@ def main(params: Sequence[str] | None = None) -> None:
     except _HANDLED_EXCEPTIONS as exc:
         rich_print(f"[yellow]{exc}[/yellow]")
         sys.exit(1)
+    if runner.failure_count:
+        # Batch dispatch logs each failure and keeps going, so without
+        # this a run where every file failed still exited 0. Serial runs
+        # used to report it by letting the first failure escape, which
+        # also abandoned every file behind it.
+        rich_print(f"[yellow]{runner.failure_count} file(s) failed.[/yellow]")
+        sys.exit(1)

--- a/comicbox/formats/base/online/prompt.py
+++ b/comicbox/formats/base/online/prompt.py
@@ -23,7 +23,9 @@ Layout matches the Phase 4 spec:
 Display rules:
 - Top 9 candidates max.
 - `cover_score` shown in parens after `score` when hashing was invoked.
-- Honors `--terse` / `-Q` quiet by trimming auxiliary lines.
+- Trims the auxiliary lines when the run asked for less output.
+  `-Q` has no setting of its own — the CLI folds it into
+  `general.loglevel` — so that resolved level is what's read.
 
 Session options (nested under `o`) let the user switch the rest of
 this run to unattended mode or change the match policy
@@ -37,14 +39,21 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from comicbox.config.settings import ComicboxSettings
     from comicbox.formats.base.online.profile import Candidate, ComicProfile
     from comicbox.formats.base.online.selector import SelectorContext, SelectorResult
 
 
 _MAX_DISPLAYED = 9
+
+#: Trim the per-candidate detail lines at this loglevel and above.
+#: `-QQ` resolves to SUCCESS, so two Qs is where trimming starts.
+_TERSE_MIN_LEVEL = "SUCCESS"
 
 _POLICY_CHOICES: tuple[tuple[str, str], ...] = (
     ("1", "ask"),
@@ -188,6 +197,30 @@ def _build_policy_lines() -> list[str]:
     return lines
 
 
+def _resolve_terse(settings: ComicboxSettings) -> bool:
+    """
+    Trim the per-candidate detail lines when the run asked for less output.
+
+    `-Q/--quiet` has no setting of its own: `comicbox.cli` folds it into
+    `general.loglevel`, so that resolved level is the only record of it.
+    Anything above the INFO default trims — `-QQ` and up, or a
+    `loglevel` above INFO in the config file. A single `-Q` maps to
+    INFO, which is already the default, so it changes nothing here
+    either.
+
+    This used to read `settings.quiet`, which `ComicboxSettings` has
+    never defined and — being `slots=True` — nothing could attach. The
+    `getattr` default won every time, so trimming never once happened.
+    """
+    loglevel = settings.general.loglevel
+    if isinstance(loglevel, str):
+        try:
+            loglevel = logger.level(loglevel.upper()).no
+        except ValueError:
+            return False
+    return loglevel >= logger.level(_TERSE_MIN_LEVEL).no
+
+
 def _prompt_line(message: str) -> str | None:
     """Prompt the user once; return None if the user aborts."""
     if _is_tty():
@@ -285,8 +318,7 @@ def cli_selector(
     options submenu) until the user enters a valid id, skips, or
     aborts.
     """
-    settings = ctx.settings
-    terse = bool(getattr(settings, "quiet", 0))
+    terse = _resolve_terse(ctx.settings)
 
     while True:
         for line in _build_lines(profile, candidates, ctx.file_path, terse=terse):

--- a/comicbox/run.py
+++ b/comicbox/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import replace
 from pathlib import Path
@@ -12,7 +13,7 @@ from loguru import logger
 from comicbox.box import Comicbox
 from comicbox.config import get_config
 from comicbox.enums.comicbox import FileTypeEnum
-from comicbox.exceptions import OnlineLookupAbortedError
+from comicbox.exceptions import OnlineLookupAbortedError, UnsupportedArchiveTypeError
 from comicbox.formats.base.online import outcome_stats
 from comicbox.formats.base.online.auto_engage import resolve_auto_engaged_budget
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
@@ -23,6 +24,11 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
 
     from comicbox.config.settings import ComicboxSettings
+
+#: Expected per-file failures: the path simply isn't an archive we can
+#: open. A traceback tells the user nothing the message doesn't, so these
+#: log one line. Anything else is a bug and earns the stack.
+_EXPECTED_FILE_ERRORS = (UnsupportedArchiveTypeError,)
 
 
 class Runner:
@@ -37,6 +43,11 @@ class Runner:
     def __init__(self, config: Namespace | Mapping | ComicboxSettings | None) -> None:
         """Initialize actions and config."""
         self._config: ComicboxSettings = get_config(config)
+        #: Files this run couldn't process. Batch dispatch logs a failure
+        #: and keeps going, so this is the only record that anything went
+        #: wrong; `comicbox.cli.main` exits non-zero when it's non-empty.
+        self.failure_count = 0
+        self._failure_lock = threading.Lock()
         init_logging(self._config.general.loglevel)
 
     def _iter_recurse(self, path: Path) -> Iterator[Path]:
@@ -66,9 +77,23 @@ class Runner:
             out.append(path)
         return out
 
-    def _run_one(self, path: Path) -> None:
+    def _record_failure(self) -> None:
+        """Count one failed file. Called from pool workers, so locked."""
+        with self._failure_lock:
+            self.failure_count += 1
+
+    def _run_one(self, path: Path | str | None) -> None:
         """
-        Process a single file, swallowing exceptions for batch resilience.
+        Process one batch element, swallowing exceptions for batch resilience.
+
+        The single guard every batch dispatch shares — serial, recursive
+        and threaded — so one unreadable comic costs its own file and
+        nothing more, whatever `-j` says. It used to wrap only the thread
+        pool, which made the same corrupt file a logged error under
+        `-j 2` and a fatal one under `-j 1`.
+
+        `run_on_file` stays unguarded on purpose: a caller asking about
+        one file wants to hear that it failed.
 
         Abort is the one exception that isn't about this file: the user
         answered "abort" at a prompt (or a caller cancelled a retry
@@ -76,12 +101,14 @@ class Runner:
         turned it into "skip one comic and keep prompting for the rest."
         """
         try:
-            with Comicbox(path, config=self._config) as car:
-                car.print_file_header()
-                car.run()
+            self.run_on_file(path)
         except OnlineLookupAbortedError:
             raise
+        except _EXPECTED_FILE_ERRORS as exc:
+            self._record_failure()
+            logger.error(exc)
         except Exception:
+            self._record_failure()
             logger.exception(path)
 
     def run_on_file(self, path: Path | str | None) -> None:
@@ -108,15 +135,11 @@ class Runner:
             logger.warning(f"Recurse option not set. Ignoring directory {path}")
             return
 
+        # `_run_one` guards each file and lets an abort through, which
+        # ends the walk: the remaining files are not ours to keep
+        # processing.
         for full_path in self._iter_recurse(path):
-            try:
-                self.run_on_file(full_path)
-            except OnlineLookupAbortedError:
-                # Abort ends the walk; the remaining files are not ours
-                # to keep processing.
-                raise
-            except Exception:
-                logger.exception(full_path)
+            self._run_one(full_path)
 
     def _metron_is_active(self) -> bool:
         """Best-effort check: could this run actually hit Metron via mokkari."""
@@ -180,6 +203,7 @@ class Runner:
     def run(self) -> None:
         """Run actions with config."""
         outcome_stats.reset()
+        self.failure_count = 0
         try:
             self._run_inner()
         finally:
@@ -221,7 +245,7 @@ class Runner:
             paths = self._expand_paths()
             self._maybe_auto_engage_api_budget(len(paths))
             for raw in self._config.paths or ():
-                self.run_on_file(raw)
+                self._run_one(raw)
             return
 
         # Parallel path: expand directories first so the thread pool sees

--- a/tests/cli/test_cli_exit_code.py
+++ b/tests/cli/test_cli_exit_code.py
@@ -1,0 +1,111 @@
+"""
+CLI exit-code tests for partially-failed batches.
+
+Batch dispatch logs a failed file and keeps going, so the exit code is
+the only thing a script can check. Before the guard was unified, a
+serial run reported failure by letting the first bad file escape — which
+also abandoned every file behind it — and a `-j 2` run over the same
+batch exited 0.
+
+That the surviving files are still processed is asserted precisely, off
+the log records, in `tests/unit/test_run_parallel.py`.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from io import StringIO
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox import cli, logger
+from tests.const import CIX_CBZ_SOURCE_PATH
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
+    """
+    Point loguru back at the real stdout when the test is done.
+
+    `cli.main` builds a `Runner`, which calls `init_logging` and binds a
+    loguru sink to whatever `sys.stdout` is at that moment — here, the
+    buffer below. `init_logging` then memoizes, so without this every
+    later test in the session logs into that dead buffer.
+    """
+    try:
+        yield
+    finally:
+        logger._initialized_key = None
+        logger.init_logging()
+
+
+def _batch(tmp_path: Path) -> tuple[list[Path], Path]:
+    good = []
+    for name in ("a_good.cbz", "c_good.cbz"):
+        dest = tmp_path / name
+        shutil.copy(CIX_CBZ_SOURCE_PATH, dest)
+        good.append(dest)
+    corrupt = tmp_path / "b_corrupt.cbz"
+    corrupt.write_bytes(b"not a zip")
+    return good, corrupt
+
+
+def _run_cli(*argv: str) -> tuple[int, str]:
+    """Run `cli.main`, returning its exit code (0 when it didn't exit) and stdout."""
+    old_stdout = sys.stdout
+    buf = StringIO()
+    code = 0
+    try:
+        sys.stdout = buf
+        cli.main(("comicbox", *argv))
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    finally:
+        sys.stdout = old_stdout
+    return code, buf.getvalue()
+
+
+@pytest.mark.parametrize("jobs", ["1", "2"])
+def test_partial_failure_exits_one(tmp_path: Path, jobs: str) -> None:
+    """Same batch, same exit code, whatever `-j` says."""
+    good, corrupt = _batch(tmp_path)
+    code, out = _run_cli("-j", jobs, *(str(p) for p in [*good, corrupt]))
+    assert code == 1
+    assert "1 file(s) failed." in out
+
+
+def test_clean_batch_exits_zero(tmp_path: Path) -> None:
+    good, _corrupt = _batch(tmp_path)
+    code, out = _run_cli(*(str(p) for p in good))
+    assert code == 0
+    assert "failed" not in out
+
+
+def test_single_corrupt_file_exits_one(tmp_path: Path) -> None:
+    """The common interactive case keeps its non-zero exit."""
+    _good, corrupt = _batch(tmp_path)
+    code, out = _run_cli(str(corrupt))
+    assert code == 1
+    assert "1 file(s) failed." in out
+
+
+def test_every_file_failing_exits_one(tmp_path: Path) -> None:
+    """A `-j N` batch where nothing succeeded used to exit 0."""
+    corrupt = []
+    for name in ("a.cbz", "b.cbz", "c.cbz"):
+        path = tmp_path / name
+        path.write_bytes(b"not a zip")
+        corrupt.append(path)
+    code, out = _run_cli("-j", "2", *(str(p) for p in corrupt))
+    assert code == 1
+    assert "3 file(s) failed." in out
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_online_prompt.py
+++ b/tests/unit/test_online_prompt.py
@@ -12,10 +12,12 @@ and `_read_input` with scripted reply sequences.
 from __future__ import annotations
 
 import sys
+from argparse import Namespace
 from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from comicbox.config import get_config
 from comicbox.formats.base.online import prompt
 from comicbox.formats.base.online.profile import (
     Candidate,
@@ -82,11 +84,11 @@ class _ScriptedPrompt:
         return self.replies.pop(0)
 
 
-class _QuietSettings:
-    """Minimal settings stand-in carrying the `quiet` attr terse mode reads."""
-
-    def __init__(self, quiet: int = 0) -> None:
-        self.quiet = quiet
+def _settings(loglevel: str | int = "INFO") -> ComicboxSettings:
+    """Real settings with only the loglevel pinned — terse's one input."""
+    return get_config(
+        Namespace(comicbox=Namespace(general=Namespace(loglevel=loglevel)))
+    )
 
 
 def _ctx(
@@ -98,7 +100,7 @@ def _ctx(
     return SelectorContext(
         file_path=cast("None", file_path),
         source=source,
-        settings=cast("ComicboxSettings", settings or _QuietSettings()),
+        settings=cast("ComicboxSettings", settings) if settings else _settings(),
         triggered_hashing=False,
     )
 
@@ -713,9 +715,9 @@ def test_cli_selector_renders_the_file_path_and_candidates(
 def test_cli_selector_terse_trims_aux_lines(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Terse rendering engages when the settings object carries `quiet`."""
+    """A quieted run keeps the numbered choices and drops the chrome."""
     monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("s"))
-    ctx = _ctx(settings=_QuietSettings(quiet=1))
+    ctx = _ctx(settings=_settings("WARNING"))
     prompt.cli_selector(ComicProfile(), [_candidate(url="https://example.test/1")], ctx)
     out = capsys.readouterr().out
     assert "1. Foo Comics #5" in out
@@ -723,23 +725,69 @@ def test_cli_selector_terse_trims_aux_lines(
     assert "example.test" not in out
 
 
-def test_real_settings_carry_no_quiet_attribute() -> None:
+def test_cli_selector_verbose_by_default(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(prompt, "_prompt_line", _ScriptedPrompt("s"))
+    prompt.cli_selector(
+        ComicProfile(), [_candidate(url="https://example.test/1")], _ctx()
+    )
+    out = capsys.readouterr().out
+    assert "publisher=" in out
+    assert "example.test" in out
+
+
+# --- _resolve_terse ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("loglevel", ["SUCCESS", "WARNING", "ERROR", "CRITICAL", 30])
+def test_resolve_terse_engages_above_info(loglevel: str | int) -> None:
+    assert prompt._resolve_terse(_settings(loglevel)) is True
+
+
+@pytest.mark.parametrize("loglevel", ["INFO", "DEBUG", "TRACE", "info", 10])
+def test_resolve_terse_stays_off_at_or_below_info(loglevel: str | int) -> None:
+    assert prompt._resolve_terse(_settings(loglevel)) is False
+
+
+def test_resolve_terse_ignores_an_unknown_level() -> None:
+    """A bad `--loglevel` is the logger's problem to report, not ours."""
+    assert prompt._resolve_terse(_settings("NONSENSE")) is False
+
+
+# --- terse against the real config ------------------------------------------
+
+
+def _settings_for(*argv: str) -> ComicboxSettings:
+    """Resolve settings the way the CLI does, `-Q` folding included."""
+    from comicbox.cli import get_args
+
+    return get_config(Namespace(comicbox=get_args(("comicbox", *argv))))
+
+
+def test_real_config_default_is_verbose() -> None:
+    assert prompt._resolve_terse(_settings_for("x.cbz")) is False
+
+
+def test_real_config_double_quiet_is_terse() -> None:
+    """`-QQ` resolves to SUCCESS, the first level that means "less"."""
+    assert prompt._resolve_terse(_settings_for("-QQ", "x.cbz")) is True
+
+
+def test_real_config_single_quiet_changes_nothing() -> None:
     """
-    `cli_selector`'s terse mode is unreachable from the real config.
+    Documents `-Q`'s no-op first level.
 
-    `terse = bool(getattr(settings, "quiet", 0))` reads an attribute
-    `ComicboxSettings` doesn't define — `-Q/--quiet` is folded into
-    `general.loglevel` by `comicbox/cli/__init__.py`, and the settings
-    dataclass is `slots=True` so nothing can attach `quiet` later. The
-    module docstring's "Honors --terse / -Q quiet" is therefore not
-    true of any CLI run today.
+    `comicbox.cli._QUIET_LOGLEVEL` maps one `-Q` to INFO, which is
+    already `config_default.yaml`'s level, so a single `-Q` neither
+    quiets the log nor trims the prompt. Two Qs is where it starts.
     """
-    from argparse import Namespace
+    assert prompt._resolve_terse(_settings_for("-Q", "x.cbz")) is False
 
-    from comicbox.config import get_config
 
-    settings = get_config(Namespace(comicbox=Namespace()))
-    assert not hasattr(settings, "quiet")
+def test_real_config_yaml_loglevel_is_terse() -> None:
+    """`loglevel` is a config-file key; `-Q` is just its CLI shorthand."""
+    assert prompt._resolve_terse(_settings("WARNING")) is True
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/unit/test_run_parallel.py
+++ b/tests/unit/test_run_parallel.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
-import pytest
 from loguru import logger as loguru_logger
 
 from comicbox.config import get_config
@@ -21,13 +20,14 @@ from comicbox.config.settings import (
     OnlineAuthSettings,
     OnlineSourceCredentials,
 )
-from comicbox.exceptions import UnsupportedArchiveTypeError
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
 from comicbox.run import Runner
 from tests.const import CIX_CBZ_SOURCE_PATH
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+    import pytest
 
 
 def _make_paths(tmp_path: Path, count: int) -> list[str]:
@@ -242,6 +242,7 @@ def _real_batch(tmp_path: Path) -> tuple[list[Path], Path]:
     file behind it, which is what makes the two error semantics below
     distinguishable.
     """
+    tmp_path.mkdir(parents=True, exist_ok=True)
     source = Path(CIX_CBZ_SOURCE_PATH)
     good = []
     for name in ("a_good.cbz", "c_good.cbz", "d_good.cbz"):
@@ -304,8 +305,8 @@ def test_parallel_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
     assert len(_messages(records, "No action performed")) == len(good)
     errors = _errors(records)
     assert len(errors) == 1
-    assert errors[0]["message"] == str(corrupt)
-    assert isinstance(errors[0]["exception"].value, UnsupportedArchiveTypeError)
+    assert str(corrupt) in errors[0]["message"]
+    assert runner.failure_count == 1
 
 
 def test_parallel_batch_logs_each_failure_once(tmp_path: Path) -> None:
@@ -323,37 +324,77 @@ def test_parallel_batch_logs_each_failure_once(tmp_path: Path) -> None:
         runner.run()
 
     errors = _errors(records)
-    assert sorted(r["message"] for r in errors) == sorted(
-        [str(corrupt), str(second_corrupt)]
-    )
+    assert len(errors) == 2
+    assert {str(corrupt), str(second_corrupt)} == {
+        r["message"].rsplit(": ", 1)[-1] for r in errors
+    }
     assert len(_messages(records, "No action performed")) == len(good)
+    assert runner.failure_count == 2
 
 
-def test_serial_batch_aborts_on_a_corrupt_file(tmp_path: Path) -> None:
+def test_serial_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
     """
-    Documents a real asymmetry between the two dispatch paths.
+    `-j 1` is as resilient as `-j 2` — the asymmetry this used to pin.
 
-    `_run_inner`'s serial branch calls `run_on_file` directly, and
-    neither has an `except Exception` guard, so the first unreadable file
-    ends the batch with a traceback. The parallel branch routes through
-    `_run_one` — whose docstring is explicitly "swallowing exceptions for
-    batch resilience" — and logs-and-continues instead.
-
-    The guard arrived with `_run_one` in the parallel dispatch (v4.0.0);
-    the pre-existing serial loop never had one, and only `recurse()` did.
-    So this looks like an oversight rather than a decision: the same
-    corrupt file is a logged error under `-j 2` and a fatal traceback
-    under `-j 1`.
+    The serial branch called `run_on_file` directly and neither had a
+    guard, so the first unreadable file ended the batch and every file
+    sorting after it went unprocessed. Both branches now route through
+    `_run_one`.
     """
     good, corrupt = _real_batch(tmp_path)
     runner = _runner_for([*good, corrupt], jobs=1)
-    with _captured_records() as records, pytest.raises(UnsupportedArchiveTypeError):
+    with _captured_records() as records:
         runner.run()
 
-    # Only the file sorting before the corrupt one was processed; the two
-    # after it never ran.
-    assert len(_messages(records, "No action performed")) == 1
-    assert _errors(records) == []
+    assert len(_messages(records, "No action performed")) == len(good)
+    assert len(_errors(records)) == 1
+    assert runner.failure_count == 1
+
+
+def test_serial_and_parallel_agree_on_a_corrupt_file(tmp_path: Path) -> None:
+    """The same batch, the same outcome, whatever `-j` says."""
+
+    def outcome(jobs: int, root: Path) -> tuple[int, int]:
+        good, _corrupt = _real_batch(root)
+        runner = _runner_for([*good, root / "b_corrupt.cbz"], jobs=jobs)
+        with _captured_records() as records:
+            runner.run()
+        return len(_messages(records, "No action performed")), runner.failure_count
+
+    serial = outcome(1, tmp_path / "serial")
+    parallel = outcome(2, tmp_path / "parallel")
+    assert serial == parallel == (3, 1)
+
+
+def test_expected_archive_errors_log_without_a_traceback(tmp_path: Path) -> None:
+    """
+    "Not a comic" is a message, not a bug — it doesn't earn a stack.
+
+    Unexpected failures still get `logger.exception`; this is the one
+    class of per-file error the user can act on directly.
+    """
+    good, corrupt = _real_batch(tmp_path)
+    runner = _runner_for([*good, corrupt], jobs=1)
+    with _captured_records() as records:
+        runner.run()
+
+    error = _errors(records)[0]
+    assert error["exception"] is None
+    assert "Unsupported archive type" in error["message"]
+
+
+def test_run_resets_the_failure_count(tmp_path: Path) -> None:
+    """A reused Runner reports this run's failures, not the last one's."""
+    good, corrupt = _real_batch(tmp_path)
+    runner = _runner_for([*good, corrupt], jobs=1)
+    with _captured_records():
+        runner.run()
+    assert runner.failure_count == 1
+
+    runner._config = replace(runner._config, paths=tuple(str(p) for p in good))
+    with _captured_records():
+        runner.run()
+    assert runner.failure_count == 0
 
 
 def test_recurse_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
@@ -373,4 +414,5 @@ def test_recurse_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
     assert len(_messages(records, "No action performed")) == len(good)
     errors = _errors(records)
     assert len(errors) == 1
-    assert errors[0]["message"] == str(corrupt)
+    assert str(corrupt) in errors[0]["message"]
+    assert runner.failure_count == 1


### PR DESCRIPTION
Fixes the two defects [#183](https://github.com/ajslater/comicbox/pull/183) documented in test docstrings, now that they're pinned. Branched off `develop` after #183 merged.

## A bad file no longer ends the batch

The same corrupt comic was a logged error under `-j 2` and fatal under `-j 1`:

| invocation | before | after |
|---|---|---|
| `comicbox a.cbz b.cbz c.cbz` | traceback, **batch dies** | logs it, keeps going |
| `comicbox --recurse dir/` | logs it, keeps going | unchanged |
| `comicbox -j 2 a.cbz b.cbz c.cbz` | logs it, keeps going | unchanged |

`_run_one` guarded the thread pool, `recurse()` guarded the walk, and `_run_inner`'s serial loop guarded nothing. The guard arrived *with* the parallel dispatch in v4.0.0; the pre-existing serial loop never got one. All three now route through `_run_one`, whose docstring already claimed to be the batch-resilience seam.

`run_on_file` stays unguarded on purpose — a caller asking about one file wants to hear that it failed. That's the seam between "public single-file API" and "batch element".

## Failures are now reported

This is the part I want a second look at, because it's the one thing that grew past the original ask.

Collapsing onto the guard would have **silently dropped the only failure signal a script had**: `main()` already catches `UnsupportedArchiveTypeError` and exits 1, which is how a serial run reported a bad file today (at the cost of abandoning everything behind it). Making the serial path resilient without replacing that signal would have turned `comicbox corrupt.cbz` from exit 1 into exit 0.

So `Runner` counts failed files and `main()` exits 1 when any did. That also fixes the converse, which was already broken: a `-j N` batch where *every* file failed used to exit 0.

The counter is lock-guarded — `_run_one` runs in pool workers.

Expected archive errors (`UnsupportedArchiveTypeError`) log one clean line instead of a traceback; anything else still earns `logger.exception`. That preserves the message quality the single-file case had via `main()`'s yellow handler, and improves batch output as a side effect.

## The prompt's terse mode does something

`cli_selector` read `settings.quiet`, which `ComicboxSettings` has never defined and — being `slots=True` — nothing could attach, so the `getattr` default won every time and the ~2 extra lines per candidate were never trimmed.

`-Q` has no setting of its own; `comicbox.cli` folds it into `general.loglevel`. `_resolve_terse` reads that instead, and takes a real `ComicboxSettings` rather than duck-typing it, which is what let this rot silently.

Trimming starts at `-QQ`. `_QUIET_LOGLEVEL` maps a single `-Q` to `INFO`, which is already `config_default.yaml`'s level, so one `-Q` still changes nothing — neither the log nor the prompt. That's pre-existing and left alone, but it's now pinned by `test_real_config_single_quiet_changes_nothing` so it's a decision rather than a surprise.

## Tests

+27 tests; the four in #183 that pinned the old behavior are rewritten.

- `test_serial_batch_aborts_on_a_corrupt_file` → `test_serial_batch_survives_a_corrupt_file`, plus `test_serial_and_parallel_agree_on_a_corrupt_file` asserting the two dispatch paths now produce identical outcomes.
- `test_expected_archive_errors_log_without_a_traceback` and `test_run_resets_the_failure_count`.
- New `tests/cli/test_cli_exit_code.py` covering the exit codes end-to-end through `cli.main`.
- `_resolve_terse` tested against real `get_config` output, including `-Q` / `-QQ` resolved the way the CLI resolves them.

One note on the CLI test: it swaps `sys.stdout` for a `StringIO` rather than using `capsys`, and restores loguru on teardown. `Runner.__init__` calls `init_logging`, which binds a sink to whatever `sys.stdout` is at that moment and then memoizes — with `capsys` that left every later test in the session logging into a closed capture buffer (172 "Logging error in Loguru Handler" messages). The teardown fixture leaves the session cleaner than it found it.

## Verification

`make fix`, `make lint`, `make ty` clean. Full suite **1855 passed, 1 skipped**, same 12 warnings as `develop` and zero loguru handler errors (verified against a clean `develop` worktree).

## Not done

Whether a *partially* failed batch should be distinguishable from a fully failed one (exit 1 vs. a count, or a `--fail-fast`) is left alone — this PR only preserves and generalizes the exit-1 that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)