### PR TITLE
perf(computed): stop deep-diffing every pair of reprints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -205,6 +205,13 @@
       once and reused until the environment changes. As with `OnlineSession`,
       editing a config file mid-run no longer changes settings for the rest of
       the run.
+    - Books with many reprints no longer dominate the computed pass. Reprints
+      were consolidated by deep-diffing every ordered pair of them, which grew
+      quadratically and was 93% of the pass on a forty-reprint book; they are
+      now compared on flattened, normalized fields. A reprint's name is also
+      parsed once per distinct name rather than once per reprint. Reading a
+      forty-reprint book is about seventeen times faster, and a
+      hundred-and-thirty-six-reprint book about fifty.
 
 ## v4.8.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,9 @@
     - The write API takes `merge_mode` instead of `mode`, and defaults to the
       config's `write.merge_mode` instead of forcing `additive`. The `WriteMode`
       enum is now `MergeMode`.
+    - `deepdiff` is no longer a dependency. Nothing in the library imports it
+      since reprint consolidation stopped diffing pairs of reprints. Anything
+      that got it transitively through comicbox has to depend on it directly.
 
 - Fixes
     - Writing MetronInfo no longer invents extra credits. Only `Painter` still

--- a/comicbox/box/computed/__init__.py
+++ b/comicbox/box/computed/__init__.py
@@ -23,15 +23,16 @@ a computed method was silently never called; ``getattr(self, name)`` dispatches
 through the instance like every other method call.
 """
 
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import lru_cache
 from types import MappingProxyType
 from typing import Any
 
 from comicfn2dict.parse import comicfn2dict
 from comicfn2dict.regex import ORIGINAL_FORMAT_RE
-from deepdiff import DeepDiff
 from glom import glom
 from loguru import logger
 
@@ -58,6 +59,74 @@ def _prune_empty(value: Any) -> Any:
             if not is_empty(pruned := _prune_empty(sub_value))
         }
     return value
+
+
+# One spec, built once. dict() on the specs ran per reprint name.
+_FILENAME_TO_REPRINT_SPECS = dict(FILENAME_TO_REPRINT_SPECS)
+
+
+@lru_cache(maxsize=1024)
+def _parse_reprint_name(name: str) -> Mapping[str, Any]:
+    """
+    Read a reprint's name with the filename grammar, once per distinct name.
+
+    Both the grammar and the glom spec are pure functions of the name, and
+    names repeat: a reprint-heavy book is mostly the same few editions said
+    twice, which is what the consolidation pass exists for.
+
+    The result is shared between callers and must be treated as read only.
+    Everything that reaches a reprint from here goes through
+    ``_prune_empty``, which builds a fresh container at every mapping level.
+    """
+    return glom(comicfn2dict(name), _FILENAME_TO_REPRINT_SPECS)
+
+
+def _comparable(value: Any) -> Hashable:
+    """
+    One reprint value in the form two reprints can be compared by.
+
+    Sources disagree about representation without disagreeing about
+    content: a volume number read out of a reprint's name is the string
+    ``"2"`` where the same number loaded through the schema is the int
+    ``2``, and capitalization is a source's habit rather than a fact about
+    the edition.
+    """
+    if isinstance(value, Mapping):
+        return frozenset(
+            (key, _comparable(sub_value)) for key, sub_value in value.items()
+        )
+    if isinstance(value, Sequence | AbstractSet) and not isinstance(value, str | bytes):
+        # Order is the serializer's choice, so compare as a multiset.
+        return tuple(sorted((_comparable(item) for item in value), key=repr))
+    return str(value).casefold()
+
+
+def _reprint_fields(reprint: Mapping, prefix: str = "") -> dict[str, Hashable]:
+    """Flatten a reprint to comparable leaf values, keyed by dotted path."""
+    fields: dict[str, Hashable] = {}
+    for key, value in reprint.items():
+        path = f"{prefix}{key}"
+        if isinstance(value, Mapping):
+            fields.update(_reprint_fields(value, f"{path}."))
+        else:
+            fields[path] = _comparable(value)
+    return fields
+
+
+def _reprints_agree(
+    left: Mapping[str, Hashable], right: Mapping[str, Hashable]
+) -> bool:
+    """
+    Whether two flattened reprints describe one edition rather than two.
+
+    They do when neither contradicts the other on a field they both carry.
+    Sharing no field at all is not agreement — that is two editions, not one
+    said twice — unless one of them makes no claim to contradict.
+    """
+    if not left or not right:
+        return True
+    shared = left.keys() & right.keys()
+    return bool(shared) and all(left[path] == right[path] for path in shared)
 
 
 @dataclass
@@ -130,8 +199,7 @@ class ComicboxComputed(ComicboxComputedStoriesTitle):
             new_reprint = dict(old_reprint)
             name = new_reprint.get(NAME_KEY)
             if name:
-                filename_dict = comicfn2dict(str(name))
-                parsed = glom(filename_dict, dict(FILENAME_TO_REPRINT_SPECS))
+                parsed = _parse_reprint_name(str(name))
                 for key, value in parsed.items():
                     # The filename grammar yields a slot for every field it
                     # knows, empty when the name didn't say.
@@ -153,22 +221,27 @@ class ComicboxComputed(ComicboxComputedStoriesTitle):
         old_reprints = sub_data.get(REPRINTS_KEY)
         if not old_reprints:
             return None
+        # Compare flattened, normalized fields rather than diffing every pair
+        # of nested reprints. The DeepDiff this replaces was ~93% of the whole
+        # computed pass on a reprint-heavy book, and its ignore_order pairing
+        # decided agreement by a similarity threshold, so whether two reprints
+        # consolidated depended on how many fields they *didn't* share.
+        fields = [_reprint_fields(reprint) for reprint in old_reprints]
         new_reprints = []
         merged_indexes = set()
         for index, old_reprint in enumerate(old_reprints):
             if index in merged_indexes:
                 continue
-            for sub_index, compare_old_reprint in enumerate(old_reprints[index:]):
-                diff = DeepDiff(
-                    old_reprint,
-                    compare_old_reprint,
-                    ignore_order=True,
-                    ignore_string_case=True,
-                    ignore_encoding_errors=True,
-                )
-                if "values_changed" not in diff:
-                    AdditiveMerger.merge(old_reprint, compare_old_reprint)
-                    merged_indexes.add(index + sub_index)
+            # A leader absorbs what agrees with it, so its fields grow as the
+            # scan runs and later candidates are compared against everything
+            # it has taken on. The scan starts past the leader itself: it used
+            # to begin at the leader, merging a dict into itself, which
+            # mergedeep skips outright.
+            for sub_index in range(index + 1, len(old_reprints)):
+                if _reprints_agree(fields[index], fields[sub_index]):
+                    AdditiveMerger.merge(old_reprint, old_reprints[sub_index])
+                    fields[index] = _reprint_fields(old_reprint)
+                    merged_indexes.add(sub_index)
             new_reprints.append(old_reprint)
 
         if len(old_reprints) != len(new_reprints):
@@ -260,10 +333,15 @@ class ComicboxComputed(ComicboxComputedStoriesTitle):
                 # and both are stamped into notes. Merge the delta into the
                 # snapshot so later actions see it. That accumulated snapshot
                 # *is* the computed metadata — ComicboxMetadata reads it back
-                # instead of replaying every delta onto a second copy. The
-                # copy keeps the stored delta from aliasing the snapshot a
-                # later action may change.
-                action.merger.merge(sub_data, deepcopy(sub_md))
+                # instead of replaying every delta onto a second copy.
+                #
+                # The delta is merged as-is. It used to be deep copied first,
+                # to keep the stored delta from aliasing a snapshot a later
+                # action may change, but mergedeep never lends the source's
+                # objects to the destination: every branch of it either
+                # recurses into the destination's own mapping or assigns a
+                # deepcopy. Copying here only did that same work twice.
+                action.merger.merge(sub_data, sub_md)
 
             md = {ComicboxSchemaMixin.ROOT_TAG: sub_md}
             computed_data = ComputedData(action.label, md, action.merger)

--- a/comicbox/box/dump.py
+++ b/comicbox/box/dump.py
@@ -95,7 +95,7 @@ class ComicboxDump(ComicboxPages):
         if not denormalized_metadata:
             return
         if fmt == MetadataFormats.PDF and not self._config.convert.cbz:
-            schema, denormalized_metadata = self._to_dict(MetadataFormats.PDF)
+            # fmt is PDF here, so the pair above is already the PDF pair.
             mupdf_md = schema.dump(denormalized_metadata) or {}
             if isinstance(mupdf_md, Mapping):
                 pdf_md.update(mupdf_md.get(schema.ROOT_TAG, {}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
   "case-converter~=1.2",
   "comicfn2dict>=0.3.2,<1.0.0",
   "confuse~=2.2.0",
-  "deepdiff~=9.0",
   "glom~=25.12",
   "httpx~=0.28",
   "imagehash>=4.3.2",
@@ -105,6 +104,7 @@ lint = [
 ]
 test = [
   "coverage[toml]~=7.0",
+  "deepdiff~=9.0",
   "pytest-asyncio~=1.0",
   "pytest-cov~=7.0",
   "pytest~=9.0",

--- a/tests/unit/test_computed_reprints.py
+++ b/tests/unit/test_computed_reprints.py
@@ -1,0 +1,223 @@
+"""
+Reprint consolidation, and the invariants the fast path has to keep.
+
+Consolidation used to ask DeepDiff whether two reprints conflicted, once for
+every ordered pair — the dominant cost of the whole computed pass on a book
+with many reprints, and quadratic in their number. It now compares flattened,
+normalized fields. These tests pin the agreement rule that replaced it, and
+the aliasing invariants that let the per-delta deep copy go away.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from comicbox.box import Comicbox
+from comicbox.box.computed import (
+    _comparable,
+    _parse_reprint_name,
+    _reprint_fields,
+    _reprints_agree,
+)
+from comicbox.formats import MetadataFormats
+from comicbox.merge import AdditiveMerger, ReplaceMerger
+
+
+def test_a_merger_never_lends_the_destination_its_source_objects() -> None:
+    """
+    What lets the computed pass merge a delta in without copying it first.
+
+    Every branch of the deep merge either recurses into the destination's own
+    mapping or assigns a deep copy, so a merged delta and the snapshot it went
+    into never come to share a mutable object.
+    """
+    for merger in (AdditiveMerger, ReplaceMerger):
+        source: dict[str, Any] = {
+            "shared": {"list": [1, 2]},
+            "top_list": [3],
+            "only_source": {"a": "b"},
+        }
+        dest: dict[str, Any] = {"shared": {"list": [9]}, "top_list": [8]}
+        merger.merge(dest, source)
+        assert dest["shared"] is not source["shared"], merger
+        assert dest["shared"]["list"] is not source["shared"]["list"], merger
+        assert dest["top_list"] is not source["top_list"], merger
+        assert dest["only_source"] is not source["only_source"], merger
+
+
+def _consolidate(reprints: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Run a book's reprints through the computed pass and read them back."""
+    metadata = json.dumps({"comicbox": {"issue": "1", "reprints": reprints}})
+    with Comicbox() as car:
+        car.add_metadata(metadata, MetadataFormats.COMICBOX_JSON)
+        return list(car.get_computed_merged_metadata()["comicbox"]["reprints"])
+
+
+def test_the_same_reprint_said_twice_becomes_one() -> None:
+    """The plain case consolidation exists for."""
+    reprint = {"series": {"name": "Strange Academy"}, "issue": "1"}
+    assert len(_consolidate([dict(reprint), dict(reprint)])) == 1
+
+
+def test_a_reprint_that_says_less_folds_into_one_that_says_more() -> None:
+    """Silence is not disagreement, so the fuller reprint absorbs the sparser."""
+    reprints = _consolidate(
+        [
+            {"series": {"name": "Strange Academy"}, "issue": "1"},
+            {"series": {"name": "Strange Academy"}},
+        ]
+    )
+    assert len(reprints) == 1
+    assert reprints[0]["issue"] == "1"
+
+
+def test_reprints_that_contradict_each_other_stay_apart() -> None:
+    """One field they both carry and disagree on is enough to keep them two."""
+    reprints = _consolidate(
+        [
+            {"series": {"name": "Strange Academy"}, "issue": "1"},
+            {"series": {"name": "Strange Academy"}, "issue": "2"},
+        ]
+    )
+    assert len(reprints) == 2
+
+
+def test_reprints_with_nothing_in_common_stay_apart() -> None:
+    """Two editions that share no field are two editions, not one said twice."""
+    left = {"series": {"name": "Strange Academy"}}
+    right = {"volume": {"number": 3}}
+    assert not _reprints_agree(_reprint_fields(left), _reprint_fields(right))
+
+
+def test_an_empty_reprint_contradicts_nothing() -> None:
+    """A reprint that makes no claim cannot conflict with one that does."""
+    assert _reprints_agree({}, _reprint_fields({"issue": "1"}))
+
+
+def test_case_is_a_sources_habit_not_a_disagreement() -> None:
+    """ignore_string_case was part of the old comparison and stays part of this one."""
+    left = {"series": {"name": "Strange Academy"}, "issue": "1"}
+    right = {"series": {"name": "STRANGE ACADEMY"}, "issue": "1"}
+    assert _reprints_agree(_reprint_fields(left), _reprint_fields(right))
+
+
+def test_representation_is_not_a_disagreement() -> None:
+    """
+    Both of these say volume 2.
+
+    A volume number read out of a reprint's name is a string; the same number
+    loaded through the schema is an int.
+    """
+    assert _comparable(2) == _comparable("2")
+    left = {"name": "Doctor Strange", "volume": {"number": 2}}
+    right = {"name": "Doctor Strange", "volume": {"number": "2"}}
+    assert _reprints_agree(_reprint_fields(left), _reprint_fields(right))
+
+
+def test_field_order_is_not_a_disagreement() -> None:
+    """The old comparison ignored order; a flattened one has no order to ignore."""
+    left = {"issue": "1", "series": {"name": "Strange Academy"}}
+    right = {"series": {"name": "Strange Academy"}, "issue": "1"}
+    assert _reprint_fields(left) == _reprint_fields(right)
+
+
+def test_nested_reprint_fields_flatten_to_dotted_paths() -> None:
+    """Nested mappings are compared field by field, not as whole subtrees."""
+    fields = _reprint_fields({"series": {"name": "A"}, "volume": {"number": 3}})
+    assert set(fields) == {"series.name", "volume.number"}
+
+
+def test_a_reprint_heavy_book_consolidates_its_duplicates() -> None:
+    """Thirty-two reprints, half of them repeats, end up as the distinct sixteen."""
+    distinct = [
+        {"name": f"Strange Academy v1 #{issue:03d} (2020) The Reprint"}
+        for issue in range(1, 17)
+    ]
+    reprints = _consolidate([*distinct, *(dict(reprint) for reprint in distinct)])
+    assert len(reprints) == len(distinct)
+
+
+def test_two_reprints_sharing_a_name_do_not_share_its_parsed_values() -> None:
+    """
+    The name parse is memoized, so its result is shared between callers.
+
+    Every value that reaches a reprint from it must still be that reprint's
+    own: consolidation merges into these mappings in place, and one book's
+    merge must not turn up in the next book that cites the same issue.
+    """
+    name = "Strange Academy v1 #001 (2020) The Reprint"
+    reprints = _consolidate(
+        [{"name": name, "issue": "1"}, {"name": name, "issue": "2"}]
+    )
+    assert len(reprints) == 2
+    first, second = (reprint["series"] for reprint in reprints)
+    assert first == second
+    assert first is not second
+
+
+def test_the_name_parse_is_memoized() -> None:
+    """Reprint names repeat; the grammar and the glom spec do not rerun for them."""
+    name = "Uncanny X-Men v3 #003 (1992) The Reprint"
+    _parse_reprint_name(name)
+    before = _parse_reprint_name.cache_info().hits
+    _parse_reprint_name(name)
+    assert _parse_reprint_name.cache_info().hits == before + 1
+
+
+def test_the_computed_pass_leaves_the_merged_metadata_alone() -> None:
+    """
+    Consolidation merges reprints in place, so the pass works on a copy.
+
+    Without it the box's cached merged metadata — what every source actually
+    said — would come back carrying the computed pass's own conclusions.
+    """
+    metadata = json.dumps(
+        {
+            "comicbox": {
+                "issue": "1",
+                "reprints": [
+                    {"series": {"name": "Strange Academy"}, "issue": "1"},
+                    {"series": {"name": "Strange Academy"}},
+                ],
+            }
+        }
+    )
+    with Comicbox() as car:
+        car.add_metadata(metadata, MetadataFormats.COMICBOX_JSON)
+        before = json.dumps(car.get_merged_metadata()["comicbox"]["reprints"], indent=1)
+        car.to_dict()
+        after = json.dumps(car.get_merged_metadata()["comicbox"]["reprints"], indent=1)
+    assert before == after
+
+
+def test_a_computed_delta_is_not_rewritten_by_a_later_action() -> None:
+    """
+    Each delta keeps saying what its own action produced.
+
+    The deltas are what --print shows for each phase, so a later action
+    rewriting an earlier one's would misreport where a value came from.
+    """
+    metadata = json.dumps(
+        {
+            "comicbox": {
+                "issue": "1",
+                "reprints": [
+                    {"name": "Strange Academy v1 #001 (2020)"},
+                    {"name": "Strange Academy v1 #001 (2020)"},
+                ],
+            }
+        }
+    )
+    with Comicbox() as car:
+        car.add_metadata(metadata, MetadataFormats.COMICBOX_JSON)
+        deltas = {
+            computed.label: json.dumps(computed.metadata, default=str, sort_keys=True)
+            for computed in car.get_computed_metadata()
+        }
+        # Everything after "from reprint names" ran before this is read back.
+        names_delta = deltas["from reprint names"]
+        reprints_delta = deltas["from reprints"]
+    assert json.loads(names_delta)["comicbox"]["reprints"] != []
+    assert len(json.loads(names_delta)["comicbox"]["reprints"]) == 2
+    assert len(json.loads(reprints_delta)["comicbox"]["reprints"]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,6 @@ dependencies = [
     { name = "case-converter" },
     { name = "comicfn2dict" },
     { name = "confuse" },
-    { name = "deepdiff" },
     { name = "glom" },
     { name = "httpx" },
     { name = "imagehash" },
@@ -958,6 +957,7 @@ lint = [
 ]
 test = [
     { name = "coverage", extra = ["toml"] },
+    { name = "deepdiff" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -970,7 +970,6 @@ requires-dist = [
     { name = "comicbox-pdffile", marker = "extra == 'pdf'", specifier = ">=0.6.3,<0.7" },
     { name = "comicfn2dict", specifier = ">=0.3.2,<1.0.0" },
     { name = "confuse", specifier = "~=2.2.0" },
-    { name = "deepdiff", specifier = "~=9.0" },
     { name = "glom", specifier = "~=25.12" },
     { name = "httpx", specifier = "~=0.28" },
     { name = "imagehash", specifier = ">=4.3.2" },
@@ -1039,6 +1038,7 @@ lint = [
 ]
 test = [
     { name = "coverage", extras = ["toml"], specifier = "~=7.0" },
+    { name = "deepdiff", specifier = "~=9.0" },
     { name = "pytest", specifier = "~=9.0" },
     { name = "pytest-asyncio", specifier = "~=1.0" },
     { name = "pytest-cov", specifier = "~=7.0" },


### PR DESCRIPTION
Reprint-heavy books spent almost all of the computed pass deciding which
reprints were duplicates. `_get_computed_from_reprints` compared every ordered
pair of reprints with `DeepDiff` — including each reprint against itself, since
the inner loop sliced `old_reprints[index:]` rather than `[index + 1:]`. On a
40-reprint book that is 784 diffs and **93% of `to_dict()`**, and it grows
quadratically.

## Timings

Fixture: a comicbox-JSON book whose reprints carry free-text names the filename
grammar can read, with a fifth of them repeats so consolidation has real work.
Best of 5×3 runs, Python 3.14.4, M-series macOS. The `reprints` column is the
list as given, before consolidation.

### Computed pass only

| reprints | before | after | speedup |
| -------: | -----: | ----: | ------: |
| 16 | 13.62 ms | 1.24 ms | 11.0× |
| 24 | 33.52 ms | 1.69 ms | 19.8× |
| 40 | 95.61 ms | 2.65 ms | 36.1× |
| 72 | 312.90 ms | 4.95 ms | 63.2× |
| 136 | 989.88 ms | 10.70 ms | 92.5× |

### `to_dict()`

| reprints | before | after | speedup |
| -------: | -----: | ----: | ------: |
| 16 | 14.55 ms | 2.20 ms | 6.6× |
| 24 | 35.17 ms | 3.52 ms | 10.0× |
| 40 | 98.77 ms | 5.78 ms | 17.1× |
| 72 | 319.19 ms | 11.17 ms | 28.6× |
| 136 | 999.79 ms | 19.56 ms | 51.1× |

### `to_string()` across five formats

| reprints | before | after | speedup |
| -------: | -----: | ----: | ------: |
| 16 | 71.99 ms | 9.81 ms | 7.3× |
| 24 | 172.11 ms | 13.85 ms | 12.4× |
| 40 | 490.96 ms | 21.13 ms | 23.2× |
| 72 | 1587.03 ms | 34.08 ms | 46.6× |
| 136 | 4990.72 ms | 59.41 ms | 84.0× |

The curve is roughly linear now instead of quadratic, so the win grows with the
reprint count.

`cProfile` on the 40-reprint fixture, before — `_get_computed_from_reprints` is
1.041 s of a 1.122 s `to_dict()`:

```
     3    0.008    0.003    1.041    0.347 box/computed/__init__.py:147(_get_computed_from_reprints)
  2352    0.034    0.000    1.031    0.000 deepdiff/diff.py:153(__init__)
```

After, it no longer appears in the top 18; the remaining time is marshmallow
serialization and the glom-based sort in `ListField`.

## What changed

### Reprint consolidation

Each reprint is flattened once into comparable leaf values keyed by dotted path
(`series.name`, `volume.number`, …). Two agree when neither contradicts the
other on a field they both carry. Values are normalized the way the old
comparison's flags asked for: case-insensitively (`ignore_string_case`), and
across the representations sources actually differ in — a volume number read
out of a reprint's name is the string `"2"` where the same number loaded
through the schema is the int `2`, which DeepDiff reported as `type_changes`
rather than `values_changed` and therefore also treated as agreement.

The scan is still pairwise: agreement is not transitive (A and B can agree, B
and C agree, A and C conflict), and a leader accumulates what it absorbs, so
later candidates are compared against the accumulation. What went away is the
`DeepDiff` per pair, not the pairing. It now starts at `index + 1` instead of
`index` — comparing a reprint to itself only ever merged a dict into itself,
which `mergedeep` skips outright via its `dest[key] is not source[key]` guard,
so dropping it is a no-op.

One deliberate behavior note: DeepDiff's `ignore_order` pairing decided
agreement by a *similarity threshold*, not by whether the reprints conflicted.
Two reprints agreeing on `name` merged if they had one other field each, but
conflicted if they had two each, and two reprints sharing no field at all came
back as a whole-root `values_changed`. The new rule states the intent directly:
agreement on every shared field, and sharing nothing is not agreement. On the
entire test corpus this is indistinguishable — see below.

### Reprint-name parsing

`comicfn2dict` plus its glom spec ran once per reprint, and
`dict(FILENAME_TO_REPRINT_SPECS)` rebuilt the spec on every one of those calls.
The parse is a pure function of the name and names repeat, so it is memoized
(`lru_cache(1024)`) and the spec is a module constant. On the 40-reprint
fixture that is 1368 cache hits against 32 misses, and it halves what is left
of the pass: **5.33 ms → 2.60 ms**.

The cached result is shared, so it is read-only by contract; everything that
reaches a reprint from it goes through `_prune_empty`, which builds a fresh
container at every mapping level. There is a test asserting two reprints with
the same name do not come to share a nested mapping.

### Duplicate `_to_dict` in the archive dump

`_dump_format_to_archive` computed `(schema, denormalized_metadata)` for `fmt`,
then the PDF branch — reached only when `fmt` *is* `MetadataFormats.PDF` —
called `self._to_dict(MetadataFormats.PDF)` again for the identical pair.
On the 40-reprint fixture that call is **2.83 ms**, paid on every PDF metadata
write.

### The three per-pass deepcopies

Measured by instrumenting each call site, 40-reprint fixture, per `to_dict()`:

| site | calls/pass | before | after |
| --- | ---: | ---: | ---: |
| `computed/__init__.py` — merged snapshot | 1.0 | 0.041 ms | 0.041 ms |
| `computed/__init__.py` — per-delta copy | 4.0 | 0.187 ms | *removed* |
| `metadata.py` — before the delete pass | 1.0 | 0.077 ms | 0.071 ms |
| **total** | | **0.306 ms** | **0.112 ms** |

They were never the bottleneck — 0.3% of the pass — but the per-delta copy is
the one the double-delta-application collapse made redundant, and it is gone.
Before that collapse the deltas were replayed onto a second copy of the merged
metadata, so each had to be a pristine independent tree. Now `ComicboxMetadata`
reads the accumulated snapshot back instead, the deltas are display-only, and
`mergedeep` never lends the source's objects to the destination: every branch
either recurses into the destination's own mapping or assigns a `deepcopy`.
Copying the delta first only did that same work twice. There is a test pinning
that non-aliasing property of the mergers, since it is what makes the removal
safe.

The other two are load bearing, confirmed by neutering each and watching an
invariant break:

- `computed/__init__.py` — consolidation merges reprints in place, so without
  the copy the box's cached merged metadata comes back carrying the computed
  pass's own conclusions. (`probe: with copy True, without False`)
- `metadata.py` — without it `_metadata` aliases the computed snapshot and the
  delete pass strips keys out of it. (`probe: publisher kept=True aliased=False`
  with the copy, `kept=False aliased=True` without.)

## Correctness

`to_string()` for **every archive in `tests/files` in every format**, plus the
reprint-heavy fixture at 1/2/5/30/32/64 reprints, dumped to one 290 KB file
before and after:

```
171d392d8cd3f616e177849078947758a64ae63465b5e496ea93e7a5321274ac  before.txt
171d392d8cd3f616e177849078947758a64ae63465b5e496ea93e7a5321274ac  after.txt
```

Byte for byte identical. The snapshot is deterministic (verified by hashing two
consecutive runs of the same tree).

`tests/unit/test_computed_reprints.py` adds 15 tests covering the agreement
rule, the normalization, the memo's read-only contract, the merger
non-aliasing property, and the two surviving deepcopies' invariants.

`make fix`, `make lint`, `make ty` clean. Full suite: **1847 passed, 1 skipped**.

## `deepdiff` is no longer a runtime dependency (breaking)

Nothing in the library imports it any more, so it moves from `[project]
dependencies` to the `test` group, where its two remaining callers live
(`tests/test_stories_title.py`, `tests/util/diff.py`).

Verified against a venv holding only the runtime dependencies, with
`importlib.util.find_spec("deepdiff") is None` asserted: reading an archive,
consolidating reprints, dumping all five formats, and `comicbox -p` all work.

Anything that was getting `deepdiff` transitively through comicbox now has to
depend on it directly.

## Follow-up, not in this PR

The fixture work surfaced a pre-existing crash unrelated to this
change: `ListField._sorted` raises `TypeError: '<' not supported between
instances of 'int' and 'str'` when two reprints tie on language and series name
but only one carries a `volume.number`, because the missing key sorts as `""`
against an int. Confirmed pre-existing — the old and new consolidation produce
identical computed output for the triggering input, and both then raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
