### PR TITLE
fix(fields): rank sort key types so a missing key can't collide with an int

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,10 @@
       enum is now `MergeMode`.
 
 - Fixes
+    - Reading a comic no longer fails when two reprints tie on every sort key up
+      to one that only one of them has. A reprint carrying a `volume` with an
+      `issue_count` but no `number` used to abort the whole dump with
+      `TypeError: '<' not supported between instances of 'int' and 'str'`.
     - A comic that can't be read no longer ends the batch. Every dispatch path —
       serial, `--recurse` and `-j N` — now logs the file and keeps going.
       Previously `comicbox a.cbz b.cbz c.cbz` stopped at the first unreadable

--- a/comicbox/formats/base/fields/collection_fields.py
+++ b/comicbox/formats/base/fields/collection_fields.py
@@ -2,6 +2,7 @@
 
 import re
 from collections.abc import Iterable, Mapping
+from decimal import Decimal
 from typing import Any
 
 from glom import glom
@@ -12,6 +13,32 @@ from typing_extensions import override
 from comicbox.empty import filter_list_empty, is_empty
 from comicbox.formats.base.fields.fields import StringField
 from comicbox.formats.base.fields.number_fields import IntegerField
+
+# Sort keys are compared element by element, so every element in a slot must be
+# comparable with its siblings. Nothing guarantees they share a type: a reprint
+# missing `volume.number` substitutes an empty value into a slot where its
+# sibling holds an int, and `int < str` is a TypeError. Ranking the type first
+# means unlike types are ordered by rank and never compared to each other.
+_EMPTY_RANK = 0
+_NUMBER_RANK = 1
+_STRING_RANK = 2
+_OTHER_RANK = 3
+_NUMBER_TYPES = (int, float, Decimal)
+
+
+def _comparable(value: Any) -> tuple[int, Any]:
+    """Pair a sort key element with a rank for its comparability class."""
+    if is_empty(value):
+        # Absent and explicitly empty elements share a rank so they still
+        # dedupe together, and sort first like the old empty string did.
+        return (_EMPTY_RANK, "")
+    if isinstance(value, str):
+        return (_STRING_RANK, value)
+    if isinstance(value, _NUMBER_TYPES):
+        # Numbers stay numbers: 2 must keep sorting before 10.
+        return (_NUMBER_RANK, value)
+    # Dates, and anything else unhashable or unorderable against its own kind.
+    return (_OTHER_RANK, str(value))
 
 
 def case_insensitive_dict(d: dict) -> dict:
@@ -65,10 +92,9 @@ class ListField(fields.List):
             for key_path in self._sort_keys:
                 sort_value = glom(value, key_path, default=None)
                 sort_value = self.get_tag_value(sort_value)
-                sort_value = "" if sort_value is None else sort_value
-                key.append(sort_value)
+                key.append(_comparable(sort_value))
         else:
-            key = (self.get_tag_value(value),)
+            key = (_comparable(self.get_tag_value(value)),)
         key = tuple(key)
 
         # Combine elements that dedupe to the same key. dict.update() returns

--- a/tests/unit/test_list_field_sort_key_types.py
+++ b/tests/unit/test_list_field_sort_key_types.py
@@ -1,0 +1,125 @@
+"""
+ListField sorts lists whose sort key slots hold mixed types.
+
+`_sort_value` substituted `""` for a key the element didn't have, so a reprint
+carrying `volume: {issue_count: 12}` and no `volume.number` put a string in the
+slot where its sibling put an int. Once the pair tied on every earlier key,
+`sorted()` compared the two and raised
+`TypeError: '<' not supported between instances of 'int' and 'str'`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from marshmallow import Schema
+from marshmallow.fields import Nested
+
+from comicbox.box import Comicbox
+from comicbox.formats import MetadataFormats
+from comicbox.formats.base.fields.collection_fields import ListField
+from comicbox.formats.comicbox.schema.publishing import ReprintSchema
+
+# The comicbox schema's own reprint sort keys.
+_REPRINT_SORT_KEYS = (
+    "language",
+    "series.sort_name",
+    "series.name",
+    "volume.number",
+    "volume.number_to",
+    "issue",
+)
+
+# Both reprints share a series name, so the tie falls through to volume.number,
+# which only the second one has.
+_COMICBOX_JSON = json.dumps(
+    {
+        "comicbox": {
+            "issue": "1",
+            "reprints": [
+                {
+                    "name": "Strange Academy v1 #001 (1990)",
+                    "volume": {"issue_count": 12},
+                },
+                {"name": "Strange Academy v2 #002 (1991)"},
+            ],
+        }
+    }
+)
+
+
+class _ReprintsSchema(Schema):
+    """A stand-in for the comicbox schema's reprints field."""
+
+    reprints = ListField(Nested(ReprintSchema), sort_keys=_REPRINT_SORT_KEYS)
+
+
+def _dump(reprints: list[dict]) -> list:
+    dumped = _ReprintsSchema().dump({"reprints": reprints})
+    assert isinstance(dumped, Mapping)
+    return dumped["reprints"]
+
+
+def test_a_missing_key_beside_an_int_sorts() -> None:
+    """The empty slot no longer compares against the int beside it."""
+    dumped = _dump(
+        [
+            {"series": {"name": "Strange Academy"}, "volume": {"number": 2}},
+            {"series": {"name": "Strange Academy"}, "volume": {"issue_count": 12}},
+        ]
+    )
+    # Absent sorts first, and neither element was lost to deduplication.
+    assert [reprint["volume"] for reprint in dumped] == [
+        {"issue_count": 12},
+        {"number": 2},
+    ]
+
+
+def test_a_string_key_beside_an_int_sorts() -> None:
+    """Unlike types are ranked apart rather than compared."""
+    dumped = _dump(
+        [
+            {"series": {"name": "Strange Academy"}, "volume": {"number": 2}},
+            {"series": {"name": "Strange Academy"}, "issue": "1"},
+        ]
+    )
+    assert len(dumped) == 2
+
+
+def test_numbers_still_sort_numerically() -> None:
+    """Ranking by type must not degrade ints into lexical strings."""
+    dumped = _dump(
+        [
+            {"series": {"name": "Strange Academy"}, "volume": {"number": n}}
+            for n in (10, 2, 1)
+        ]
+    )
+    assert [reprint["volume"]["number"] for reprint in dumped] == [1, 2, 10]
+
+
+def test_an_absent_key_still_dedupes_with_an_empty_one() -> None:
+    """Absent and empty share a rank, so they collide as they always did."""
+    dumped = _dump(
+        [
+            {"series": {"name": "Strange Academy"}, "issue": "1", "name": "A"},
+            {
+                "series": {"name": "Strange Academy"},
+                "issue": "1",
+                "language": "",
+                "name": "B",
+            },
+        ]
+    )
+    assert len(dumped) == 1
+
+
+def test_heterogeneous_reprints_dump_end_to_end() -> None:
+    """The comicbox dump used to raise straight out of `to_dict`."""
+    with Comicbox() as car:
+        car.add_metadata(_COMICBOX_JSON, MetadataFormats.COMICBOX_JSON)
+        reprints = car.to_dict()["comicbox"]["reprints"]
+    assert [reprint["name"] for reprint in reprints] == [
+        "Strange Academy v1 #001 (1990)",
+        "Strange Academy v2 #002 (1991)",
+    ]


### PR DESCRIPTION
## Problem

`ListField._sort_value` in [collection_fields.py](comicbox/formats/base/fields/collection_fields.py) substituted `""` for a sort key an element didn't have. When two elements tied on every earlier key and disagreed about whether they carried the next one, `sorted(sort_dict.items())` compared that `""` against its sibling's value:

```
TypeError: '<' not supported between instances of 'int' and 'str'
```

That aborts the entire dump, not just the sort.

The reprints sort keys are `("language", "series.sort_name", "series.name", "volume.number", "volume.number_to", "issue")`. `_get_computed_from_reprint_names` only fills keys that aren't already present, and it checks `volume` as a whole — so a reprint parsed from a name that already carries `volume: {issue_count: 12}` never gets a `volume.number`, and lands in that slot as `""` next to a sibling's int.

Reproduces on `develop`:

```python
import json
from comicbox.box import Comicbox
from comicbox.formats import MetadataFormats

md = {"comicbox": {"issue": "1", "reprints": [
    {"name": "Strange Academy v1 #001 (1990)", "volume": {"issue_count": 12}},
    {"name": "Strange Academy v2 #002 (1991)"},
]}}
with Comicbox() as car:
    car.add_metadata(json.dumps(md), MetadataFormats.COMICBOX_JSON)
    car.to_dict()
```

Pre-existing, and unrelated to the reprint-consolidation perf work in #188 — it surfaced while building a perf fixture there.

## Fix

Pair every sort key element with a rank for its comparability class, so unlike types order by rank and are never compared to each other:

| rank | class | value |
| --- | --- | --- |
| 0 | empty / absent | `""` |
| 1 | `int`, `float`, `Decimal` | as-is |
| 2 | `str` | as-is |
| 3 | anything else (dates, unhashables) | `str(value)` |

Two properties this preserves rather than changes:

- **Numbers stay numbers.** Coercing the whole key to a string would have sorted `10` before `2`. Ranking keeps ints comparing as ints within their rank.
- **Deduplication is unchanged.** The sort key is also the dedupe key, so the mapping has to stay injective per type. Absent and explicitly empty elements share the lowest rank, which keeps the collision they already had and keeps their old position at the front of the list.

Since ranking only fires between types that previously raised, no list that sorted before sorts differently now.

The `else` branch (no `sort_keys`) gets the same treatment, which incidentally makes a list of unhashable elements sortable instead of raising `TypeError: unhashable type: 'dict'` on the dict insert.

## Tests

New [tests/unit/test_list_field_sort_key_types.py](tests/unit/test_list_field_sort_key_types.py) covers the missing-key-beside-an-int collision, a string beside an int, that numbers still sort numerically rather than lexically, that absent still dedupes with explicitly empty, and the end-to-end `to_dict()` from the report.

Full suite green with the pdf extra: 1860 passed, 1 skipped. `make lint`, `make typecheck` and `make ty` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)