### PR TITLE
perf(cb7): batch the extract and release each page buffer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,14 @@
       config's `write.merge_mode` instead of forcing `additive`. The `WriteMode`
       enum is now `MergeMode`.
 
+- Performance
+    - Converting a CB7 reads its pages in batches instead of one at a time.
+      Every 7z read decompressed the archive's solid block from the start, so
+      conversion cost grew with the square of the page count, and py7zr's page
+      buffers were held until the file was closed. A 200 page, 117 MiB CB7
+      converts in 6.2s instead of 232s, with 318 MiB peak RSS instead of 1.9
+      GiB. Output is unchanged.
+
 - Fixes
     - A comic that can't be read no longer ends the batch. Every dispatch path —
       serial, `--recurse` and `-j N` — now logs the file and keeps going.

--- a/comicbox/box/archive/archive.py
+++ b/comicbox/box/archive/archive.py
@@ -11,6 +11,8 @@ from comicbox._pdf import PAGE_FORMAT_IMAGE, PDF_ENABLED
 from comicbox.box.archive.sniff import sniff_ext
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from pdffile import PDFFile
     from py7zr import SevenZipFile
     from py7zr.io import BytesIOFactory
@@ -58,17 +60,32 @@ class Archive:
         return file_obj.read() if file_obj else b""
 
     @staticmethod
+    def extract_7zipfile(
+        archive: SevenZipFile, factory: BytesIOFactory, filenames: Collection[str]
+    ) -> None:
+        """Decompress several 7z members into the factory in one pass."""
+        if not filenames:
+            return
+        archive.extract(targets=list(filenames), factory=factory)
+        # py7zr registers extract targets on a worker that survives the
+        # call, so reset before the next one to clear the registrations
+        # and rewind the file pointer to the start of the packed streams.
+        archive.reset()
+
+    @classmethod
     def _read_7zipfile(
-        archive: SevenZipFile, factory: BytesIOFactory | None, filename: str
+        cls, archive: SevenZipFile, factory: BytesIOFactory | None, filename: str
     ) -> bytes:
         """Read a single file from 7zip."""
         if not factory:
             return b""
-        archive.extract(targets=[filename], factory=factory)
-        file_obj = factory.products.get(filename)
-        data = file_obj.read() if file_obj else b""
-        archive.reset()
-        return data
+        if filename not in factory.products:
+            cls.extract_7zipfile(archive, factory, (filename,))
+        # Pop rather than get. py7zr's factory keeps every member it has
+        # ever decompressed, so a whole-archive read would otherwise hold
+        # every page resident until the box is closed.
+        file_obj = factory.products.pop(filename, None)
+        return file_obj.read() if file_obj else b""
 
     @staticmethod
     def _read_pdffile_rotated_render(

--- a/comicbox/box/archive/read.py
+++ b/comicbox/box/archive/read.py
@@ -13,8 +13,19 @@ from comicbox.box.archive.init import ComicboxArchiveInit
 from comicbox.enums.comicbox import FileTypeEnum
 from comicbox.exceptions import ArchiveError, UnsupportedArchiveTypeError
 
+# Decompressed bytes one batched 7z extract may hold resident at once.
+# A solid 7z folder is decompressed from its start on every extract call,
+# so pulling members out one at a time costs a full pass per member —
+# quadratic in page count. Batching buys back a linear number of passes
+# for a bounded amount of resident page data.
+_7Z_BATCH_MAX_BYTES = 64 * 1024 * 1024
+
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+
     from pdffile import PDFFile
+    from py7zr import FileInfo as SevenZipInfo
+    from py7zr import SevenZipFile
     from py7zr.io import BytesIOFactory
 
     from comicbox.box.archive.archiveinfo import InfoType
@@ -104,6 +115,52 @@ class ComicboxArchiveRead(ComicboxArchiveInit):
 
             self._7zfactory: BytesIOFactory | None = BytesIOFactory(maxsize)
         return self._7zfactory
+
+    def _get_7z_sizes(self) -> Mapping[str, int]:
+        """Map 7z member name to decompressed size, for batch budgeting."""
+        return {
+            info.filename: info.uncompressed
+            for info in cast("tuple[SevenZipInfo, ...]", self.infolist())
+        }
+
+    def _prefetch_7z(self, filenames: Sequence[str]) -> None:
+        """Decompress a batch of 7z members into the shared factory."""
+        factory = self._get_7zfactory()
+        if not factory:
+            return
+        archive = cast("SevenZipFile", self._get_archive())
+        Archive.extract_7zipfile(archive, factory, filenames)
+
+    def _iter_prefetched(self, filenames: Sequence[str]) -> Iterator[str]:
+        """
+        Yield filenames, decompressing them ahead in batches where it pays.
+
+        Only 7z benefits: every other archive type this reads can seek to
+        a member and decompress just that member, so they pass straight
+        through. Members already decompressed are still batched — the
+        reader pops each buffer as it consumes it, so a name can only be
+        resident once.
+        """
+        if self._file_type != FileTypeEnum.CB7:
+            yield from filenames
+            return
+        sizes = self._get_7z_sizes()
+        batch: list[str] = []
+        batch_bytes = 0
+        for filename in filenames:
+            size = sizes.get(filename, 0)
+            # Never emit an empty batch: a single member over the cap is
+            # its own batch rather than an error.
+            if batch and batch_bytes + size > _7Z_BATCH_MAX_BYTES:
+                self._prefetch_7z(batch)
+                yield from batch
+                batch = []
+                batch_bytes = 0
+            batch.append(filename)
+            batch_bytes += size
+        if batch:
+            self._prefetch_7z(batch)
+            yield from batch
 
     def _get_pdf_format(self, pdf_format: str = "", default: str = "") -> str:
         return pdf_format or (self._config.convert.pdf_pages or default)

--- a/comicbox/box/archive/write.py
+++ b/comicbox/box/archive/write.py
@@ -137,28 +137,32 @@ class ComicboxArchiveWrite(ComicboxArchiveRead):
         if not self._archive_cls or not self._path:
             reason = "Cannot write archive metadata without and archive path."
             raise ArchiveWriteError(reason)
-        infolist = self.infolist()
-        for info in infolist:
-            filename = self._get_filename_from_info(info)
-            if not filename:
-                continue
-            # Default pdf pages to whole-page jpegs: comic readers (and
-            # comicbox's own page regex) don't recognize raw pixmap ppm
-            # data, and the page render applies pdf display rotation.
-            pdf_format = self._get_pdf_format(default=PAGE_FORMAT_PIXMAP_JPEG)
+        filenames = tuple(
+            filename
+            for info in self.infolist()
+            if (filename := self._get_filename_from_info(info))
+        )
+        # Default pdf pages to whole-page jpegs: comic readers (and
+        # comicbox's own page regex) don't recognize raw pixmap ppm
+        # data, and the page render applies pdf display rotation.
+        pdf_format = self._get_pdf_format(default=PAGE_FORMAT_PIXMAP_JPEG)
+        # Read in batches. Reading a 7z member on its own re-decompresses
+        # its whole solid block, so copying page by page made conversion
+        # cost grow with the square of the page count.
+        for filename in self._iter_prefetched(filenames):
             props = {}
             data = self._archive_readfile(filename, pdf_format=pdf_format, props=props)
-            filename = self._ensure_image_suffix(filename, props)
+            write_name = self._ensure_image_suffix(filename, props)
             # images usually end up slightly larger with zip compression,
             # so store them. Decide from the final name — pdf pages only
             # gain their image suffix above.
             compress = (
                 ZIP_DEFLATED
-                if self.IMAGE_EXT_RE.search(filename) is None
+                if self.IMAGE_EXT_RE.search(write_name) is None
                 else ZIP_STORED
             )
             zf.writestr(
-                filename,
+                write_name,
                 data,
                 compress_type=compress,
                 compresslevel=9,

--- a/tests/unit/test_archive_read.py
+++ b/tests/unit/test_archive_read.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
+from sys import maxsize
+
+from py7zr import SevenZipFile
+from py7zr.io import BytesIOFactory
 
 from comicbox.box import Comicbox
 from comicbox.box.archive import archive as archive_module
+from comicbox.config import get_config
 from tests.const import CB7_SOURCE_PATH, CIX_CBZ_SOURCE_PATH, TEST_FILES_DIR
 
 RESOURCE_FORK_ARCHIVE = TEST_FILES_DIR / "macos_resource_fork.cbz"
@@ -162,3 +168,115 @@ def test_readfile_still_skips_a_real_archive_directory_entry():
         assert cb._archive_readfile("__MACOSX/") == b""
         # Only the directory entry is skipped; real members still read.
         assert cb._archive_readfile("CaptainScience#1_01.jpg")
+
+
+def _spy_on_7z_extract(monkeypatch) -> list[list[str]]:
+    """Record the target list of every py7zr extract call."""
+    batches: list[list[str]] = []
+    real_extract = SevenZipFile.extract
+
+    def spy_extract(self, path=None, targets=None, *args, **kwargs):
+        batches.append(list(targets) if targets is not None else [])
+        return real_extract(self, path, targets, *args, **kwargs)
+
+    monkeypatch.setattr(SevenZipFile, "extract", spy_extract)
+    return batches
+
+
+def test_cb7_conversion_batches_the_extract(tmp_path, monkeypatch) -> None:
+    """
+    Converting a CB7 pulls its members out in batches, not one at a time.
+
+    A solid 7z folder is decompressed from its start on every extract
+    call, so a page-at-a-time copy costs one full pass per page and makes
+    conversion quadratic in page count.
+    """
+    cb7 = tmp_path / "batched.cb7"
+    shutil.copy(CB7_SOURCE_PATH, cb7)
+    batches = _spy_on_7z_extract(monkeypatch)
+
+    config = get_config({"comicbox": {"convert": {"cbz": True}}})
+    with Comicbox(cb7, config=config) as cb:
+        pagenames = cb.get_page_filenames()
+        cb.dump()
+
+    copy_batches = [b for b in batches if len(b) > 1]
+    assert len(copy_batches) == 1, "the page copy did not batch into one pass"
+    assert set(copy_batches[0]) >= set(pagenames), "the batch did not cover every page"
+
+
+def test_cb7_batch_respects_the_resident_byte_cap(tmp_path, monkeypatch) -> None:
+    """A cap smaller than the archive splits the copy into several passes."""
+    from comicbox.box.archive import read as read_module
+
+    cb7 = tmp_path / "capped.cb7"
+    shutil.copy(CB7_SOURCE_PATH, cb7)
+    # Two of this fixture's ~4 KiB pages per batch.
+    monkeypatch.setattr(read_module, "_7Z_BATCH_MAX_BYTES", 9000)
+    batches = _spy_on_7z_extract(monkeypatch)
+
+    config = get_config({"comicbox": {"convert": {"cbz": True}}})
+    with Comicbox(cb7, config=config) as cb:
+        cb.dump()
+
+    copy_batches = [b for b in batches if len(b) > 1]
+    assert copy_batches, "the page copy never batched its extract"
+    assert max(len(b) for b in copy_batches) <= 3, (
+        "the byte cap did not bound the batch size"
+    )
+    assert len(copy_batches) > 1, "a capped copy should need several passes"
+
+
+def test_cb7_batch_conversion_copies_every_page_intact(tmp_path) -> None:
+    """Batching must not change a single output byte."""
+    import zipfile
+
+    cb7 = tmp_path / "intact.cb7"
+    shutil.copy(CB7_SOURCE_PATH, cb7)
+
+    factory = BytesIOFactory(maxsize)
+    with SevenZipFile(CB7_SOURCE_PATH) as z:
+        z.extractall(factory=factory)
+        source_pages = {
+            name: buf.read()
+            for name, buf in factory.products.items()
+            if name.lower().endswith(".jpg")
+        }
+    assert source_pages
+
+    config = get_config({"comicbox": {"convert": {"cbz": True}}})
+    with Comicbox(cb7, config=config) as cb:
+        cb.dump()
+
+    with zipfile.ZipFile(cb7.with_suffix(".cbz")) as zf:
+        written = {n: zf.read(n) for n in zf.namelist() if n.lower().endswith(".jpg")}
+    assert written == source_pages
+
+
+def test_7z_read_releases_each_page_buffer() -> None:
+    """
+    The factory must not retain a buffer for every page ever read.
+
+    py7zr's BytesIOFactory keeps every member it decompresses, so a
+    whole-archive read used to hold all of its pages resident until the
+    box was closed.
+    """
+    with Comicbox(CB7_SOURCE_PATH) as cb:
+        pagenames = cb.get_page_filenames()
+        assert len(pagenames) > 1
+        for pagename in pagenames:
+            assert cb.get_page_by_filename(pagename)
+            factory = cb._get_7zfactory()
+            assert factory is not None
+            assert not factory.products, (
+                f"{pagename}'s buffer was retained after the read"
+            )
+
+
+def test_7z_repeat_read_returns_the_same_bytes() -> None:
+    """Popping the buffer must not make a second read of a page come back empty."""
+    with Comicbox(CB7_SOURCE_PATH) as cb:
+        pagename = cb.get_page_filenames()[0]
+        first = cb.get_page_by_filename(pagename)
+        assert first
+        assert cb.get_page_by_filename(pagename) == first


### PR DESCRIPTION
## The problem

Converting a CB7 read one member per `py7zr` `extract()` call, with a full `archive.reset()` between reads. Two costs compounded:

1. **Quadratic decompression.** A 7z solid folder is decompressed from its start on every `extract()`, and members that aren't targets still get read and CRC-checked on the way past. Copying page by page therefore cost one full-archive pass *per page*.
2. **Every page held resident.** `py7zr`'s `BytesIOFactory` keeps every member it has ever decompressed in `products`. `_read_7zipfile` used `.get()`, so nothing was ever released; the factory was only freed wholesale by `close()`.

## The fix

- `_copy_archive_files_to_new_archive` builds its filename list up front and reads through a new `_iter_prefetched`, which decompresses members in batches instead of one at a time.
- Batches are capped at 64 MiB of resident page data (`_7Z_BATCH_MAX_BYTES`), budgeted from each member's `uncompressed` size, so a large archive gets a linear number of passes without unbounded memory. A single member over the cap becomes its own batch rather than an error.
- `_read_7zipfile` **pops** each product from the factory after reading it, so a name can only be resident once. It falls back to a single-member extract when the name isn't already prefetched, which keeps one-off metadata reads working unchanged.
- Non-7z formats pass straight through `_iter_prefetched` — zip, rar, tar and pdf can already seek to a single member, so there is nothing to win.

## Benchmark

200-page CB7, 116.6 MiB of JPEG pages, 53.6 MiB packed (LZMA2, one solid folder), converted to CBZ. macOS, Python 3.14. Both sides run with `write.stamp_notes` off, because the tagging note embeds a wall-clock timestamp that would otherwise make every run differ for reasons unrelated to page reading.

| | wall clock | peak RSS |
|---|---|---|
| before | 232.1 s | 1922.7 MiB |
| after | 6.3 s | 287.2 MiB |
| | **37× faster** | **6.7× less** |

A second before/after pair with the note stamp left on measured 253.6 s / 2075.7 MiB versus 6.6 s / 291.0 MiB, and a third run of the final code measured 6.2 s / 317.6 MiB — the effect is far larger than the run-to-run spread.

### Output is unchanged

Both outputs hash to `e816123234d8a1566a246a6814826c10d89e6647dca1e3642f4b4b53008678f6` and are both 122,318,540 bytes, over 201 members. The digest covers every member's name, bytes, and entry metadata — `compress_type`, CRC, compressed and uncompressed size, flag bits, extra field, external/internal attrs, create system — plus the archive comment.

The one field excluded is `date_time`: `zipfile` stamps each entry from the wall clock at write time, so raw container bytes can never match across two runs regardless of how the pages were read. Everything a reader can observe is identical.

## Tests

Five new tests in [tests/unit/test_archive_read.py](tests/unit/test_archive_read.py):

- `test_cb7_conversion_batches_the_extract` — the copy issues one batched extract covering every page, not one call per page.
- `test_cb7_batch_respects_the_resident_byte_cap` — a cap smaller than the archive splits the copy into several bounded passes.
- `test_cb7_batch_conversion_copies_every_page_intact` — converted page bytes equal the source's, member for member.
- `test_7z_read_releases_each_page_buffer` — `factory.products` is empty after each page read.
- `test_7z_repeat_read_returns_the_same_bytes` — popping the buffer doesn't make a second read of the same page come back empty.

The first three of those fail on `develop`. `make fix`, `make lint`, `make ty` clean; full suite 1860 passed, 1 skipped (pre-existing).

## Noted, not fixed

`ComicboxArchivePages.get_pages` reads page by page through the same `_archive_readfile` and has the identical quadratic profile for anything that walks a CB7's pages (extract, cover-hash fan-out). It's a two-line change to route it through `_iter_prefetched`, but it's outside what this PR was scoped to, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
