### PR TITLE
perf(online): parallel cover fetch, shared CV client, working series cache, bounded fan-out

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -214,6 +214,17 @@
       explicit-id, stored-id and series-cache fast paths.
 
 - Performance
+    - Online tagging is faster. Candidate covers download in parallel over one
+      connection, Comic Vine reuses one client for the whole run, and series
+      caching now works across a series that spans several years, where it used
+      to search again for every issue.
+    - `comicbox --online` batches by series like `OnlineSession` already did, so
+      tagging a run costs one search instead of one per issue.
+    - Comic Vine searches spend a bounded number of API calls per comic, and no
+      single call can wait indefinitely on a rate limit. Raise `api_budget` to
+      `thorough` for the old unbounded search.
+    - Rate-limit waits are interruptible everywhere, so Ctrl-C is no longer
+      ignored for minutes at a time.
     - Comicbox starts about a third faster. Importing it no longer compiles the
       XSD and JSON Schema documents for every metadata format, and the CLI no
       longer assembles its help tables on every run. Both are built the first

--- a/comicbox/box/online_lookup.py
+++ b/comicbox/box/online_lookup.py
@@ -69,17 +69,21 @@ from comicbox.formats.base.online.profile import (
 )
 from comicbox.formats.base.online.prompt import cli_selector
 from comicbox.formats.base.online.selector import SelectorContext
+from comicbox.formats.base.online.series_cache import claim_series
 from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
 from comicbox.formats.metron_api.online_source import MetronOnlineSource
 from comicbox.formats.sources import MetadataSources
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, MutableMapping
+    from collections.abc import Callable, MutableMapping, Sequence
     from pathlib import Path
 
     from comicbox.config.settings import OnlineSettings
     from comicbox.events import Event, EventHandler
-    from comicbox.formats.base.online.cover_hash import CoverHashUrlCache
+    from comicbox.formats.base.online.cover_hash import (
+        CoverFetchPool,
+        CoverHashUrlCache,
+    )
     from comicbox.formats.base.online.profile import Candidate
     from comicbox.formats.base.online.selector import SelectorCallback, SelectorResult
     from comicbox.formats.base.online.sources.base import OnlineSource
@@ -202,11 +206,34 @@ def _series_fingerprint(profile: ComicProfile) -> str:
     step-6 prompt-cache fingerprint which incorporates candidate
     volume_ids. Same series across different issues collapses to the
     same string here.
+
+    Every component must be a property of the SERIES, never of the
+    issue. `profile.year` is the issue's own cover year, so including it
+    (as this did until 2026-08) gave every issue of a run that spans
+    more than one calendar year its own key — the cache missed on
+    exactly the multi-issue batches it exists to accelerate, and the
+    unit fixture that should have caught it held the year constant.
+
+    The two discriminators that replace it are genuinely series-level:
+
+    - `volume` — the ordinal from "Vol. 2", already year-sanitized by
+      `_resolve_volume` (a 4-digit value is rejected as a mis-filed
+      year), so it separates reboots when the file carries one.
+    - `series_start_year` — the year the run began. Sparse (Metron
+      writes it; most embedded formats don't), so it discriminates when
+      present and costs nothing when absent.
+
+    Residual collision: two same-name, same-publisher runs where neither
+    file carries a volume ordinal or a start year now share a key. That
+    resolves itself rather than mis-tagging — `_try_series_cache_lookup`
+    falls back to the full search when the cached volume has no such
+    issue, leaving the entry intact.
     """
     series = (profile.series or "").strip().lower()
     publisher = (profile.publisher or "").strip().lower()
-    year = str(profile.year or "")
-    return f"{series}|{year}|{publisher}"
+    volume = str(profile.volume or "")
+    start_year = str(profile.series_start_year or "")
+    return f"{series}|{volume}|{start_year}|{publisher}"
 
 
 def _detect_cv_id_disagreement(
@@ -275,6 +302,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
     # run_online_lookup() calls report this first-run outcome.
     _online_lookup_won: bool = False
     _cover_hash_url_cache: CoverHashUrlCache | None = None
+    _cover_fetch_pool: CoverFetchPool | None = None
     _local_cover_phash_computed: bool = False
     _local_cover_phash_value: str | None = None
     # Built once per lookup run (5 call sites); invalidated whenever the
@@ -486,6 +514,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             publisher=fields.get("publisher"),
             page_count=fields.get("page_count"),
             volume=fields.get("volume"),
+            series_start_year=fields.get("series_start_year"),
         )
         self._profile_cache = profile
         return profile
@@ -539,17 +568,21 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         First-writer-wins: a falsy-group collision (two unrelated comics
         that happened to share a series fingerprint) can't overwrite an
         already-resolved entry. Fires ``SeriesIdentified`` only on first
-        population for this fingerprint. Locking — when needed for
-        concurrent callers — is the OnlineSession's responsibility; the
-        cache passed in here can be a thread-safe wrapper.
+        population for this fingerprint.
+
+        ``claim_series`` makes "was I the first writer?" a single
+        operation, so concurrent callers (the CLI's `-j N` pool, which
+        shares one cache across workers) get exactly one winner and
+        therefore exactly one event. A plain dict from a single-threaded
+        caller still works — it degrades to the check-then-set this used
+        to do inline.
         """
         if self._series_cache is None or candidate.volume_id is None:
             return
         fingerprint = _series_fingerprint(self._build_profile())
         key = (source.name, fingerprint)
-        if key in self._series_cache:
+        if not claim_series(self._series_cache, key, candidate.volume_id):
             return
-        self._series_cache[key] = candidate.volume_id
         self._emit(
             SeriesIdentified(
                 path=getattr(self, "_path", None),
@@ -559,58 +592,95 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             )
         )
 
-    def _candidate_cover_hash_fetcher(self, url: str) -> str | None:
+    def _get_cover_hash_cache(self) -> CoverHashUrlCache | None:
         """
-        Download a candidate cover from URL and return its pHash, with caching.
+        Lazily open the shared cover-hash sqlite cache; None when caching is OFF.
 
-        Used by the matcher for sources that don't ship a precomputed hash
-        (ComicVine, GCD). Local writes go through the shared
-        cover-hashes sqlite cache.
+        One connection for the box's lifetime (see `CoverHashUrlCache`),
+        so a top-K batch costs one query in and one transaction out
+        instead of two connections per candidate.
         """
-        from comicbox.formats.base.online.cover_hash import (
-            CoverHashUrlCache,
-            compute_phash,
-        )
+        from comicbox.config.settings import CacheMode
 
-        if not url:
+        if self._config.online.cache.mode is CacheMode.OFF:
             return None
+        if self._cover_hash_url_cache is None:
+            from comicbox.formats.base.online.cover_hash import CoverHashUrlCache
 
-        cache = self._cover_hash_url_cache
-        if cache is None:
             cache_dir = self._config.online.cache.dir
             if cache_dir is None:
                 from platformdirs import user_cache_path
 
                 cache_dir = user_cache_path("comicbox") / "online"
             cache_dir.mkdir(parents=True, exist_ok=True)
-            cache = CoverHashUrlCache(cache_dir / "cover_hashes.sqlite")
-            self._cover_hash_url_cache = cache
+            self._cover_hash_url_cache = CoverHashUrlCache(
+                cache_dir / "cover_hashes.sqlite"
+            )
+        return self._cover_hash_url_cache
 
-        from comicbox.config.settings import CacheMode
+    def _get_cover_fetch_pool(self) -> CoverFetchPool:
+        """Lazily build the bounded download pool; one httpx client per box."""
+        if self._cover_fetch_pool is None:
+            from comicbox.formats.base.online.cover_hash import CoverFetchPool
 
-        if self._config.online.cache.mode is CacheMode.OFF:
-            cache = None
-        if cache is not None and (cached := cache.get(url)):
-            return cached
+            self._cover_fetch_pool = CoverFetchPool()
+        return self._cover_fetch_pool
 
-        try:
-            import httpx
+    def _candidate_cover_hash_batch_fetcher(
+        self, urls: Sequence[str]
+    ) -> dict[str, str]:
+        """
+        Resolve many candidate cover URLs to pHashes in one pass.
 
-            response = httpx.get(url, timeout=15.0, follow_redirects=True)
-            response.raise_for_status()
-        except Exception as exc:
-            logger.warning(f"online: cover download failed ({url}): {exc}")
+        Used by the matcher for sources that don't ship a precomputed
+        hash (ComicVine, GCD). Cache lookups collapse into a single
+        query; the remaining misses download concurrently over one
+        shared HTTP client and are written back in one transaction.
+        URLs that fail to download or hash are simply absent from the
+        result — the matcher reads that as "no cover signal".
+        """
+        wanted = [u for u in dict.fromkeys(urls) if u]
+        if not wanted:
+            return {}
+        cache = self._get_cover_hash_cache()
+        resolved = cache.get_many(wanted) if cache is not None else {}
+        missing = [u for u in wanted if u not in resolved]
+        if not missing:
+            return resolved
+        fetched = self._get_cover_fetch_pool().fetch_hashes(missing)
+        if cache is not None and fetched:
+            cache.set_many(fetched.items())
+        resolved.update(fetched)
+        return resolved
+
+    def _candidate_cover_hash_fetcher(self, url: str) -> str | None:
+        """
+        Download a candidate cover from URL and return its pHash, with caching.
+
+        The single-URL entry point, kept for callers that resolve one
+        candidate at a time; the matcher's hot path goes through
+        `_candidate_cover_hash_batch_fetcher` instead.
+        """
+        if not url:
             return None
+        return self._candidate_cover_hash_batch_fetcher((url,)).get(url)
 
+    def _close_cover_hash_resources(self) -> None:
+        """Release the cover-hash sqlite connection and HTTP client."""
+        if self._cover_hash_url_cache is not None:
+            self._cover_hash_url_cache.close()
+            self._cover_hash_url_cache = None
+        if self._cover_fetch_pool is not None:
+            self._cover_fetch_pool.close()
+            self._cover_fetch_pool = None
+
+    @override
+    def close(self) -> None:
+        """Close the archive, then release online-lookup resources."""
         try:
-            phash = compute_phash(response.content)
-        except Exception as exc:
-            logger.warning(f"online: cover pHash failed ({url}): {exc}")
-            return None
-
-        if cache is not None:
-            cache.set(url, phash)
-        return phash
+            super().close()
+        finally:
+            self._close_cover_hash_resources()
 
     def _local_cover_phash(self) -> str | None:
         """Compute the comic's pHash on demand, cached on the box instance."""
@@ -650,7 +720,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             self._build_profile(),
             candidates,
             local_hash_provider=self._local_cover_phash,
-            candidate_hash_fetcher=self._candidate_cover_hash_fetcher,
+            candidate_hash_batch_fetcher=self._candidate_cover_hash_batch_fetcher,
             threshold=threshold,
             min_confidence=min_conf,
             disambiguation_margin=margin,

--- a/comicbox/formats/base/online/cover_hash.py
+++ b/comicbox/formats/base/online/cover_hash.py
@@ -17,11 +17,16 @@ The matcher invocation policy decides *when* hashing runs:
 from __future__ import annotations
 
 import sqlite3
-from contextlib import closing
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
+
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     from imagehash import ImageHash
 
 # pHash is an 8x8 = 64 bit hash. Keep this constant for clarity in the
@@ -68,40 +73,167 @@ def cover_score(local_hash: str, candidate_hash: str) -> float:
 
 
 class CoverHashUrlCache:
-    """Tiny SQLite cache mapping cover URLs to their pHash strings."""
+    """
+    Tiny SQLite cache mapping cover URLs to their pHash strings.
+
+    Holds ONE connection for its lifetime rather than reconnecting per
+    call. The matcher hashes up to 15 candidates per ambiguous comic, so
+    the old reconnect-per-`get`/`set` cost two fresh connections per
+    candidate — pure overhead on the hot path. `check_same_thread=False`
+    plus `_lock` keeps that single connection safe for the cover-fetch
+    pool's workers and for `-j N` boxes sharing one cache object.
+    """
+
+    # SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 on older builds;
+    # chunk `IN (...)` lookups well under it.
+    _MAX_VARS = 500
 
     def __init__(self, db_path: Any) -> None:
         """Open / create the sqlite cache file at `db_path`."""
         self._db_path = str(db_path)
-        # `with conn:` only manages the transaction; sqlite3 context managers
-        # never close the connection, so closing() is needed to avoid leaking
-        # one per call (each method reconnects to stay thread-safe under -j).
-        with closing(self._connect()) as conn, conn:
-            conn.execute(
+        self._lock = threading.Lock()
+        self._conn = self._connect()
+        with self._lock, self._conn:
+            self._conn.execute(
                 "CREATE TABLE IF NOT EXISTS cover_hashes "
                 "(url TEXT PRIMARY KEY, phash TEXT NOT NULL)"
             )
         # Insert-or-replace only, so this rarely accumulates free pages, but
-        # reclaim them if it ever does (e.g. churned cover URLs).
+        # reclaim them if it ever does (e.g. churned cover URLs). Runs on a
+        # separate connection — VACUUM cannot run inside a transaction.
         from comicbox.formats.base.online.vacuum import vacuum_if_bloated
 
         vacuum_if_bloated(self._db_path)
 
     def _connect(self) -> sqlite3.Connection:
-        return sqlite3.connect(self._db_path)
+        # Serialized by `_lock`, so the same connection is safe to hand to
+        # the cover-fetch pool's worker threads.
+        return sqlite3.connect(self._db_path, check_same_thread=False)
 
     def get(self, url: str) -> str | None:
         """Return the cached pHash for a cover URL, or None if absent."""
-        with closing(self._connect()) as conn:
-            row = conn.execute(
-                "SELECT phash FROM cover_hashes WHERE url = ?", (url,)
-            ).fetchone()
-        return row[0] if row else None
+        return self.get_many((url,)).get(url)
+
+    def get_many(self, urls: Sequence[str]) -> dict[str, str]:
+        """
+        Return the cached pHash for every URL that has one.
+
+        One query per chunk instead of one connection per URL — the
+        batch cover-fetch path resolves a whole top-K set in a single
+        round-trip against the cache before any download starts.
+        """
+        wanted = [u for u in dict.fromkeys(urls) if u]
+        if not wanted:
+            return {}
+        found: dict[str, str] = {}
+        with self._lock:
+            for i in range(0, len(wanted), self._MAX_VARS):
+                chunk = wanted[i : i + self._MAX_VARS]
+                placeholders = ",".join("?" * len(chunk))
+                rows = self._conn.execute(
+                    f"SELECT url, phash FROM cover_hashes WHERE url IN ({placeholders})",  # noqa: S608 — placeholders only, values are bound
+                    chunk,
+                ).fetchall()
+                found.update({row[0]: row[1] for row in rows})
+        return found
 
     def set(self, url: str, phash: str) -> None:
         """Store a pHash for a cover URL, overwriting any previous value."""
-        with closing(self._connect()) as conn, conn:
-            conn.execute(
+        self.set_many(((url, phash),))
+
+    def set_many(self, pairs: Iterable[tuple[str, str]]) -> None:
+        """Store many URL → pHash mappings in one transaction."""
+        rows = [(url, phash) for url, phash in pairs if url and phash]
+        if not rows:
+            return
+        with self._lock, self._conn:
+            self._conn.executemany(
                 "INSERT OR REPLACE INTO cover_hashes(url, phash) VALUES (?, ?)",
-                (url, phash),
+                rows,
             )
+
+    def close(self) -> None:
+        """Close the connection. Safe to call more than once."""
+        with self._lock:
+            # sqlite3's close() is itself a no-op once closed, so the
+            # connection can stay non-optional and every reader avoids a
+            # None check on the hot path.
+            self._conn.close()
+
+
+# Cap on concurrent cover downloads. The matcher hashes up to 15
+# candidates (`_top_k_for_hashing`), so 8 clears a full top-K in two
+# waves. These GETs hit the sources' image CDNs, NOT their rate-limited
+# API hosts, so they are not governed by simyan/mokkari's limiters — but
+# a burst is still multiplied by `-j N` workers, so keep it modest.
+MAX_COVER_FETCH_WORKERS = 8
+
+_COVER_FETCH_TIMEOUT_S = 15.0
+
+
+class CoverFetchPool:
+    """
+    Downloads cover images concurrently and returns their pHashes.
+
+    Owns ONE `httpx.Client` for its lifetime, so a top-K batch reuses
+    pooled connections instead of paying a TCP+TLS handshake per
+    candidate. Failures are logged and dropped exactly as the serial
+    path did — a cover that won't download is a missing signal, never a
+    failed lookup.
+    """
+
+    def __init__(self, max_workers: int = MAX_COVER_FETCH_WORKERS) -> None:
+        """Record the worker ceiling; the HTTP client is built on first use."""
+        self._max_workers = max(1, max_workers)
+        self._client: Any = None
+        self._lock = threading.Lock()
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    import httpx
+
+                    self._client = httpx.Client(
+                        timeout=_COVER_FETCH_TIMEOUT_S, follow_redirects=True
+                    )
+        return self._client
+
+    def fetch_hash(self, url: str) -> str | None:
+        """Download one cover and return its pHash, or None on any failure."""
+        try:
+            response = self._get_client().get(url)
+            response.raise_for_status()
+        except Exception as exc:
+            logger.warning(f"online: cover download failed ({url}): {exc}")
+            return None
+        try:
+            return compute_phash(response.content)
+        except Exception as exc:
+            logger.warning(f"online: cover pHash failed ({url}): {exc}")
+            return None
+
+    def fetch_hashes(self, urls: Sequence[str]) -> dict[str, str]:
+        """
+        Download many covers concurrently; return `{url: phash}` for the wins.
+
+        URLs that fail to download or hash are simply absent from the
+        result. Order is irrelevant — the caller maps back by URL.
+        """
+        unique = [u for u in dict.fromkeys(urls) if u]
+        if not unique:
+            return {}
+        if len(unique) == 1:
+            phash = self.fetch_hash(unique[0])
+            return {unique[0]: phash} if phash else {}
+        workers = min(self._max_workers, len(unique))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            hashes = zip(unique, executor.map(self.fetch_hash, unique), strict=True)
+            return {url: phash for url, phash in hashes if phash}
+
+    def close(self) -> None:
+        """Close the HTTP client. Safe to call more than once."""
+        with self._lock:
+            if self._client is not None:
+                self._client.close()
+                self._client = None

--- a/comicbox/formats/base/online/matcher.py
+++ b/comicbox/formats/base/online/matcher.py
@@ -39,6 +39,8 @@ from comicbox.formats.base.online.signals import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from comicbox.config.settings import OnlineSettings
     from comicbox.formats.base.online.profile import Candidate, ComicProfile
 
@@ -49,6 +51,14 @@ LocalHashProvider = Callable[[], str | None]
 # Callable that fetches and hashes a candidate cover URL, with caching.
 # Returns the hex hash string or None if unavailable.
 CandidateHashFetcher = Callable[[str], str | None]
+
+# Callable that resolves MANY candidate cover URLs at once, returning
+# `{url: hash}` for the ones that resolved. Absent keys mean "no hash for
+# that cover" — same meaning as `CandidateHashFetcher` returning None.
+# Supplying this lets the whole top-K download concurrently instead of
+# one blocking round-trip per candidate; see
+# `comicbox.formats.base.online.cover_hash.CoverFetchPool`.
+CandidateHashBatchFetcher = Callable[["Sequence[str]"], "dict[str, str]"]
 
 
 # Metadata-signal weights. Sum to 0.80; the remaining 0.20 is reserved
@@ -565,14 +575,26 @@ def _should_invoke_hashing(
 def _resolve_candidate_hash(
     candidate: Candidate,
     candidate_hash_fetcher: CandidateHashFetcher | None,
+    prefetched: dict[str, str] | None = None,
 ) -> str | None:
-    """Get a candidate's pHash, preferring precomputed value."""
+    """
+    Get a candidate's pHash, preferring precomputed value.
+
+    ``prefetched`` is the batch pre-pass's `{url: hash}` map. A URL
+    present there is answered without touching the network; a URL the
+    batch pass already tried and failed is absent from the map, and
+    since the batch covered every hashable candidate in the top-K,
+    absence means "no hash" rather than "not looked at yet" — so we do
+    NOT fall back to a per-URL fetch and re-pay the failed download.
+    """
     if candidate.precomputed_cover_hash:
         return candidate.precomputed_cover_hash
-    if candidate_hash_fetcher is None:
-        return None
     cover_url = candidate.summary.cover_url
     if not cover_url:
+        return None
+    if prefetched is not None:
+        return prefetched.get(cover_url)
+    if candidate_hash_fetcher is None:
         return None
     try:
         return candidate_hash_fetcher(cover_url)
@@ -584,10 +606,43 @@ def _resolve_candidate_hash(
         return None
 
 
+def _prefetch_candidate_hashes(
+    ranked: list[Candidate],
+    top_k: int,
+    candidate_hash_batch_fetcher: CandidateHashBatchFetcher,
+) -> dict[str, str]:
+    """
+    Resolve every hashable top-K cover in ONE batch call.
+
+    The candidates that need a download are exactly those inside the
+    top-K with a cover URL and no precomputed hash. Collecting them
+    upfront lets the fetcher run them concurrently over a shared HTTP
+    client and answer the cache in a single query, instead of the
+    serial download-per-candidate the scoring loop used to drive.
+
+    A failing batch degrades to an empty map, which the scoring loop
+    reads as "no cover signal" — the same outcome the serial path
+    produced when every download failed.
+    """
+    urls = [
+        url
+        for c in ranked[:top_k]
+        if not c.precomputed_cover_hash and (url := c.summary.cover_url)
+    ]
+    if not urls:
+        return {}
+    try:
+        return candidate_hash_batch_fetcher(urls)
+    except Exception as exc:
+        logger.warning(f"online: batch cover-hash fetch failed: {exc}")
+        return {}
+
+
 def _apply_cover_hashing(
     ranked: list[Candidate],
     local_hash: str,
     candidate_hash_fetcher: CandidateHashFetcher | None,
+    candidate_hash_batch_fetcher: CandidateHashBatchFetcher | None = None,
 ) -> list[Candidate]:
     """
     Hash the top K candidates and re-rank by blended score.
@@ -598,8 +653,18 @@ def _apply_cover_hashing(
     scales up to 15. Candidates inside K are marked
     `cover_hash_attempted` whether or not a hash came back, so the
     tiebreak can tell "this cover doesn't help" from "we never looked".
+
+    When a batch fetcher is supplied, every download for the top-K is
+    issued up front and concurrently (`_prefetch_candidate_hashes`);
+    the loop below then only scores. Ordering, scoring and the tiebreak
+    are identical either way — only *when* the bytes arrive changes.
     """
     top_k = _top_k_for_hashing(len(ranked))
+    prefetched = (
+        _prefetch_candidate_hashes(ranked, top_k, candidate_hash_batch_fetcher)
+        if candidate_hash_batch_fetcher is not None
+        else None
+    )
     rescored: list[Candidate] = []
     for i, c in enumerate(ranked):
         if i >= top_k:
@@ -608,7 +673,7 @@ def _apply_cover_hashing(
         # Attempted from here on, whatever the outcome — the tiebreak
         # reads this to tell an unhelpful cover from an unexamined one.
         attempted = replace(c, cover_hash_attempted=True)
-        cand_hash = _resolve_candidate_hash(c, candidate_hash_fetcher)
+        cand_hash = _resolve_candidate_hash(c, candidate_hash_fetcher, prefetched)
         if not cand_hash:
             rescored.append(attempted)
             continue
@@ -638,6 +703,7 @@ class OnlineMatcher:
         *,
         local_hash_provider: LocalHashProvider | None = None,
         candidate_hash_fetcher: CandidateHashFetcher | None = None,
+        candidate_hash_batch_fetcher: CandidateHashBatchFetcher | None = None,
         threshold: float = _DEFAULT_CONFIDENCE_THRESHOLD,
         min_confidence: float = 0.50,
         disambiguation_margin: float = 0.10,
@@ -651,6 +717,11 @@ class OnlineMatcher:
         candidates carry a `precomputed_cover_hash` (string-compare); other
         sources fall through to ``candidate_hash_fetcher`` for
         download-and-hash with caching. Both kinds mix in the same ranking.
+
+        ``candidate_hash_batch_fetcher``, when supplied, takes precedence
+        for the download path: the whole top-K is resolved in one
+        concurrent batch rather than one blocking GET at a time. The
+        ranking it produces is identical.
         """
         scored: list[Candidate] = []
         for c in candidates:
@@ -671,7 +742,9 @@ class OnlineMatcher:
         local_hash = local_hash_provider()
         if not local_hash:
             return scored
-        return _apply_cover_hashing(scored, local_hash, candidate_hash_fetcher)
+        return _apply_cover_hashing(
+            scored, local_hash, candidate_hash_fetcher, candidate_hash_batch_fetcher
+        )
 
     def resolve(
         self,

--- a/comicbox/formats/base/online/profile.py
+++ b/comicbox/formats/base/online/profile.py
@@ -33,6 +33,13 @@ class ComicProfile:
     # used as a soft search filter for sources that support it (Metron's
     # `series_volume`); CV's API has no ordinal-volume filter.
     volume: int | None = None
+    # The year the SERIES began, not this issue's cover year (that's
+    # `year`). Only some sources populate it — Metron writes
+    # `comicbox.series.start_year`, most embedded formats don't — so it
+    # is frequently None. Used by the series-level fingerprints, where a
+    # per-issue field would fork the key for every issue of a
+    # multi-year run.
+    series_start_year: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -200,5 +207,8 @@ def accumulate_profile_fields(fields: dict[str, Any], md: dict) -> None:
     )
     if (parsed := parse_year(raw_year)) is not None:
         fields["year"] = parsed
+    raw_start = glom(md, "comicbox.series.start_year", default=None)
+    if (parsed_start := parse_year(raw_start)) is not None:
+        fields["series_start_year"] = parsed_start
     if (v := _resolve_volume(md)) is not None:
         fields["volume"] = v

--- a/comicbox/formats/base/online/retry.py
+++ b/comicbox/formats/base/online/retry.py
@@ -11,11 +11,13 @@ responses — are never retried.
 from __future__ import annotations
 
 import re
-import time
+import threading
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
 from loguru import logger
+
+from comicbox.exceptions import OnlineLookupAbortedError
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -113,6 +115,66 @@ _RATE_LIMIT_SCHEDULE: Final[tuple[float, ...]] = (
 # stay at `max_retries=5` (31s total budget for transient 5xx). Going
 # higher for rate-limit gives the schedule above room to play out fully.
 _MAX_RATE_LIMIT_RETRIES: Final[int] = len(_RATE_LIMIT_SCHEDULE)
+
+# Wall-clock ceiling on ALL the waiting one decorated call may do.
+#
+# The attempt budgets above bound the NUMBER of retries but not the time
+# they take. Our own two schedules are bounded by construction — the
+# generic one sums to 31s, the rate-limit one to 2910s — but the
+# server-hint path is not: `_MAX_RETRY_AFTER_S` caps a single honored
+# `retry_after` at 3600s and nothing caps the sum, so eight of them let
+# one call block a worker for the better part of a day.
+#
+# 1 hour is chosen to bound that path while leaving `_RATE_LIMIT_SCHEDULE`
+# free to play out in full. That schedule's 8-attempt plateau tail is not
+# arbitrary: it was tuned against the 2026-05-15-stress-100 run, where a
+# high-fan-out fixture under `-j 8` needed every one of those attempts to
+# clear a rate-limit cascade without dropping its series. A tighter
+# ceiling would silently undo that — 900s, say, would stop it at 4
+# attempts. Lower this only with that regression in hand.
+#
+# Checked BEFORE sleeping: a delay that would breach the ceiling ends the
+# retry loop instead of being truncated, because a truncated rate-limit
+# wait just burns the next attempt on the same 429.
+_MAX_TOTAL_WAIT_S: Final[float] = 3600.0
+
+# Process-wide cancel signal for retry sleeps. Set it and every waiting
+# call wakes up and abandons its retry loop.
+#
+# The waits here are minutes long, so a plain `time.sleep` makes Ctrl-C
+# feel broken and makes a programmatic cancel impossible to honor
+# promptly. `OnlineSession` has always injected its own cancellable sleep
+# per instance (see `_resolve_sleep`), but that left every other caller —
+# the CLI included — sleeping uninterruptibly. This makes interruptible
+# the DEFAULT; the per-instance override still wins where it is set.
+_cancel_event = threading.Event()
+
+
+def request_cancel() -> None:
+    """Wake every in-flight retry sleep and abandon its retry loop."""
+    _cancel_event.set()
+
+
+def clear_cancel() -> None:
+    """Reset the cancel signal so later calls may retry normally."""
+    _cancel_event.clear()
+
+
+def is_cancelled() -> bool:
+    """Whether a cancel has been requested."""
+    return _cancel_event.is_set()
+
+
+def interruptible_sleep(seconds: float) -> None:
+    """
+    Sleep, waking early and raising if a cancel is requested.
+
+    Raising (rather than returning early) is what stops the retry loop
+    from immediately re-issuing the call it was backing off from.
+    """
+    if _cancel_event.wait(seconds):
+        msg = "online: retry wait cancelled"
+        raise OnlineLookupAbortedError(msg)
 
 
 def _is_rate_limit(exc: BaseException) -> bool:
@@ -225,6 +287,8 @@ def _plan_retry(
     attempt: int,
     rate_limit_attempt: int,
     max_retries: int,
+    waited: float = 0.0,
+    max_wait: float = _MAX_TOTAL_WAIT_S,
 ) -> tuple[float, str, bool] | None:
     """
     Decide whether and how to retry. Returns (delay, budget_label, is_rate_limit).
@@ -234,6 +298,11 @@ def _plan_retry(
     (`_RATE_LIMIT_SCHEDULE`); generic retriable errors use the caller's
     `max_retries` and the exponential schedule. A server-supplied
     `retry_after` hint always wins over both.
+
+    ``waited`` is how long this call has already slept. A delay that
+    would push the total past ``max_wait`` returns ``None`` rather than a
+    shortened delay: waiting out only part of a rate-limit window spends
+    an attempt on a request that is still going to be refused.
     """
     is_rate_limit = _is_rate_limit(exc)
     if is_rate_limit:
@@ -248,6 +317,8 @@ def _plan_retry(
         delay = _delay_for_rate_limit(rate_limit_attempt)
     else:
         delay = min(_delay_for(attempt), _MAX_DELAY_S)
+    if waited + delay > max_wait:
+        return None
     if is_rate_limit:
         budget = (
             f"rate-limit attempt {rate_limit_attempt + 1}/{_MAX_RATE_LIMIT_RETRIES}"
@@ -265,13 +336,17 @@ def _handle_retry_exception(
     rate_limit_attempt: int,
     max_retries: int,
     sleep: Callable[[float], None],
-) -> bool:
+    waited: float = 0.0,
+    max_wait: float = _MAX_TOTAL_WAIT_S,
+) -> float | None:
     """
-    Sleep through one retriable failure. Return True iff the budget remains.
+    Sleep through one retriable failure. Return the delay slept, or None.
 
     Raises ``exc`` immediately when it's non-retriable (programmer / auth
-    errors); returns False when the applicable budget is exhausted so the
-    caller can break out of its retry loop.
+    errors); returns ``None`` when the applicable budget — attempts or
+    the ``max_wait`` wall clock — is exhausted, so the caller can break
+    out of its retry loop. The returned delay feeds back in as
+    ``waited`` on the next call.
     """
     if not _is_retriable(exc):
         raise exc
@@ -280,14 +355,21 @@ def _handle_retry_exception(
         attempt=attempt,
         rate_limit_attempt=rate_limit_attempt,
         max_retries=max_retries,
+        waited=waited,
+        max_wait=max_wait,
     )
     if plan is None:
-        return False
+        if waited > 0:
+            logger.info(
+                f"{func_name}: giving up after {waited:.0f}s of retry waits "
+                f"(ceiling {max_wait:.0f}s)"
+            )
+        return None
     delay, budget, is_rate_limit = plan
     cause = "rate-limit" if is_rate_limit else type(exc).__name__
     logger.info(f"{func_name}: {cause}, retrying in {delay:.1f}s ({budget})")
     sleep(delay)
-    return True
+    return delay
 
 
 def _notify_rate_limit_listener(
@@ -341,12 +423,20 @@ def _run_with_retries(
     *,
     max_retries: int,
     sleep: Callable[[float], None],
+    max_wait: float = _MAX_TOTAL_WAIT_S,
 ) -> T:
-    """Drive ``func`` through the retry budget; re-raise on exhaustion."""
+    """
+    Drive ``func`` through the retry budget; re-raise on exhaustion.
+
+    Two budgets bound the loop: the per-kind attempt counts, and
+    ``max_wait`` — the total time spent sleeping across every attempt.
+    Whichever runs out first ends it.
+    """
     sleep = _resolve_sleep(args, sleep)
     last_exc: BaseException | None = None
     attempt = 0
     rate_limit_attempt = 0
+    waited = 0.0
     while True:
         try:
             return func(*args, **kwargs)
@@ -360,15 +450,19 @@ def _run_with_retries(
                 rate_limit_attempt=rate_limit_attempt,
                 max_retries=max_retries,
             )
-            if not _handle_retry_exception(
+            slept = _handle_retry_exception(
                 exc,
                 func_name=func.__name__,  # ty: ignore[unresolved-attribute]
                 attempt=attempt,
                 rate_limit_attempt=rate_limit_attempt,
                 max_retries=max_retries,
                 sleep=sleep,
-            ):
+                waited=waited,
+                max_wait=max_wait,
+            )
+            if slept is None:
                 break
+            waited += slept
             if _is_rate_limit(exc):
                 rate_limit_attempt += 1
             else:
@@ -380,7 +474,8 @@ def _run_with_retries(
 def with_retry(
     *,
     max_retries: int = 5,
-    sleep: Callable[[float], None] = time.sleep,
+    sleep: Callable[[float], None] = interruptible_sleep,
+    max_wait_s: float = _MAX_TOTAL_WAIT_S,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     Wrap a callable with retry-on-rate-limit / 5xx; never retries auth errors.
@@ -396,13 +491,29 @@ def with_retry(
     When the exception carries a `retry_after` attribute (mokkari does
     this), we honor it directly — server hint always wins over our
     blind schedules.
+
+    ``max_wait_s`` bounds the TOTAL time one call may spend sleeping
+    across all its attempts. Without it the attempt budgets alone allow
+    a single call to block for the better part of an hour (rate-limit
+    schedule) or several (an honored server hint per attempt).
+
+    The default ``sleep`` is `interruptible_sleep`, so a cancel wakes
+    waiting calls everywhere rather than only in `OnlineSession`, which
+    used to be the sole injector of a cancellable sleep. Pass
+    ``sleep=time.sleep`` for an uninterruptible wait; a per-instance
+    ``retry_sleep`` attribute still overrides both (`_resolve_sleep`).
     """
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> T:
             return _run_with_retries(
-                func, args, kwargs, max_retries=max_retries, sleep=sleep
+                func,
+                args,
+                kwargs,
+                max_retries=max_retries,
+                sleep=sleep,
+                max_wait=max_wait_s,
             )
 
         return wrapper

--- a/comicbox/formats/base/online/series_cache.py
+++ b/comicbox/formats/base/online/series_cache.py
@@ -1,0 +1,150 @@
+"""
+Thread-safe series cache for series-first batching (plan §3.10).
+
+Maps ``(source_name, series_fingerprint)`` to the resolved upstream
+volume/series id, so the second and later issues of a series skip the
+cold-path candidate search and ask the source directly for "issue N in
+volume V".
+
+The population rule is FIRST WRITER WINS: a falsy-group collision (two
+unrelated comics that happened to share a fingerprint) must never
+overwrite an already-resolved entry. Expressing that as ``if key in
+cache: return`` followed by ``cache[key] = value`` is fine for the
+sequential caller (``OnlineSession.tag_many``) but races once the CLI's
+``-j N`` thread pool drives it: two workers can both pass the membership
+test and both claim to be the first writer, emitting two
+``SeriesIdentified`` events for one series.
+
+``SeriesCache`` closes that by making the claim a single locked
+operation. It stays a plain ``MutableMapping`` so callers that just want
+a dict — and the tests that pass one — keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING
+
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+SeriesCacheKey = tuple[str, str]
+
+
+def filename_series_fingerprint(path: Path) -> str:
+    """
+    Lightweight series fingerprint derived from the filename alone.
+
+    Lets a batch dispatcher cluster same-series comics together *before*
+    opening any archives, so the first issue of each cluster pays for the
+    cold-path search and the rest read the resolved volume id back out of
+    the cache. Both dispatchers use it: `OnlineSession.tag_many` and the
+    CLI's `Runner`.
+
+    Falls back to the bare filename when comicfn2dict can't extract a
+    series — those files won't benefit from batching but won't break it
+    either (they sort to a deterministic "by filename" bucket).
+
+    Deliberately mirrors `_series_fingerprint`'s component choice (see
+    comicbox/box/online_lookup.py): the per-issue year is excluded,
+    because clustering by it would scatter a multi-year run into one
+    cluster per year and hand the cache a fresh cold path for each — the
+    opposite of what the clustering is for. The volume ordinal is kept,
+    since that is what separates reboots.
+    """
+    from comicfn2dict import comicfn2dict
+
+    try:
+        parsed = comicfn2dict(path.name)
+    except Exception:  # pragma: no cover — comicfn2dict is permissive
+        return path.name.lower()
+    series = str(parsed.get("series") or "").strip().lower()
+    volume = str(parsed.get("volume") or "").strip()
+    return f"{series}|{volume}" if series else f"~{path.name.lower()}"
+
+
+class SeriesCache(MutableMapping[SeriesCacheKey, int]):
+    """A ``dict`` of resolved volume ids with an atomic first-writer claim."""
+
+    def __init__(self) -> None:
+        """Start empty."""
+        self._data: dict[SeriesCacheKey, int] = {}
+        self._lock = threading.Lock()
+
+    def claim(self, key: SeriesCacheKey, volume_id: int) -> bool:
+        """
+        Populate `key` and return True only if this caller was the first.
+
+        The membership test and the insert happen under one lock, so
+        exactly one concurrent caller is told it won — which is what the
+        ``SeriesIdentified`` event and the first-writer-wins contract
+        both rely on.
+        """
+        with self._lock:
+            if key in self._data:
+                return False
+            self._data[key] = volume_id
+            return True
+
+    def snapshot(self) -> dict[SeriesCacheKey, int]:
+        """Return a consistent copy. Useful for persistence."""
+        with self._lock:
+            return dict(self._data)
+
+    @override
+    def __getitem__(self, key: SeriesCacheKey) -> int:
+        """Return the resolved volume id for `key`."""
+        with self._lock:
+            return self._data[key]
+
+    @override
+    def __setitem__(self, key: SeriesCacheKey, value: int) -> None:
+        """Set `key`, overwriting. Prefer `claim` for first-writer-wins."""
+        with self._lock:
+            self._data[key] = value
+
+    @override
+    def __delitem__(self, key: SeriesCacheKey) -> None:
+        """Drop `key`."""
+        with self._lock:
+            del self._data[key]
+
+    @override
+    def __iter__(self) -> Iterator[SeriesCacheKey]:
+        """Iterate a snapshot, so mutation during iteration is safe."""
+        return iter(self.snapshot())
+
+    @override
+    def __len__(self) -> int:
+        """Count the resolved series."""
+        with self._lock:
+            return len(self._data)
+
+    @override
+    def __contains__(self, key: object) -> bool:
+        """Membership test."""
+        with self._lock:
+            return key in self._data
+
+
+def claim_series(
+    cache: MutableMapping[SeriesCacheKey, int], key: SeriesCacheKey, volume_id: int
+) -> bool:
+    """
+    First-writer-wins population that works on any MutableMapping.
+
+    Uses `SeriesCache.claim` when the mapping provides it (the concurrent
+    case) and falls back to check-then-set for a plain dict, which is all
+    a single-threaded caller needs.
+    """
+    claim = getattr(cache, "claim", None)
+    if claim is not None:
+        return bool(claim(key, volume_id))
+    if key in cache:
+        return False
+    cache[key] = volume_id
+    return True

--- a/comicbox/formats/base/online/series_filter.py
+++ b/comicbox/formats/base/online/series_filter.py
@@ -122,6 +122,45 @@ _MAX_RESULTS_OVERRIDES: Final[MappingProxyType[Effort, int]] = MappingProxyType(
 )
 
 
+# Per-budget cap on how many per-volume issue-list API calls one search
+# may spend. Distinct from `_MAX_RESULTS_OVERRIDES`, which caps how many
+# volumes DISCOVERY returns: `_discover_volumes` unions a fuzzy and a
+# narrow result set, each capped at that number, so the surviving volume
+# list can be twice the cap — and each survivor costs one `list_issues`
+# call, or two when the cover-date window comes back empty. A 20-volume
+# cap therefore admits up to ~80 rate-limited calls for ONE comic, which
+# at ComicVine's 1/sec is over a minute of wall clock before the matcher
+# sees anything.
+#
+# This is a pre-call throttle in the same family as the name filter: it
+# decides whether to spend a call, never what to do with a result. The
+# matcher's ranking of whatever comes back is untouched.
+#
+# THOROUGH is deliberately absent — "spend API budget freely" is its
+# whole contract, so it keeps the unbounded fan-out.
+_MAX_CALLS_OVERRIDES: Final[MappingProxyType[Effort, int]] = MappingProxyType(
+    {
+        # BALANCED: 20 covers the full default discovery cap for the
+        # common case where fuzzy and narrow agree, and only bites on
+        # the pathological union where they don't.
+        Effort.BALANCED: 20,
+        # MINIMAL already caps discovery at 5 volumes; 10 lets every one
+        # of them take its year-window retry and stop there.
+        Effort.MINIMAL: 10,
+    }
+)
+
+
+def max_calls_for(budget: Effort) -> int | None:
+    """
+    Return the per-search issue-list call budget, or None for unlimited.
+
+    None means THOROUGH (or an unrecognized budget): no per-search cap,
+    matching that mode's "spend freely" contract.
+    """
+    return _MAX_CALLS_OVERRIDES.get(budget)
+
+
 def threshold_for(budget: Effort) -> float:
     """Return the per-budget filter threshold in `[0, 1]`."""
     return _THRESHOLDS.get(budget, 0.0)

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import sqlite3
 import threading
+import time
 from contextlib import closing, suppress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from loguru import logger
@@ -34,6 +36,7 @@ from comicbox.formats.base.online.profile import (
 )
 from comicbox.formats.base.online.retry import with_retry
 from comicbox.formats.base.online.series_filter import (
+    max_calls_for,
     should_keep_volume_name,
 )
 from comicbox.formats.base.online.sources.base import (
@@ -52,11 +55,54 @@ if TYPE_CHECKING:
 
     from comicbox.formats.base.online.profile import ComicProfile
 
-# Cache files already housekept this process; sources (and thus clients)
-# are rebuilt per file, and re-running the same purge/drop/vacuum SQL for
-# every file of a batch would be pure overhead.
+# Cache files already housekept this process. Keyed by cache PATH, not by
+# client: distinct credential sets share one `comicvine_cache.sqlite`, so
+# the shared-session cache below doesn't subsume this guard even though it
+# makes it a no-op in the common single-credential case.
 _maintained_cache_paths: set[str] = set()
 _maintenance_lock = threading.Lock()
+
+# Wall-clock ceiling for one `search()`'s per-volume fan-out. At CV's
+# 1/sec pacing this is ~40 issue-list calls' worth of time, so it only
+# bites when the calls are also being slowed by retries or rate-limit
+# backoff — precisely the case where the fan-out would otherwise stall a
+# batch behind one pathological comic. The volume discovery calls
+# themselves are outside it: they are the search, not the fan-out.
+_SEARCH_DEADLINE_S = 45.0
+
+# Clients are shared process-wide across the credential set that built
+# them (see `_get_session`), keyed by (api_key, base_url). Sources are
+# rebuilt per file by `_build_active_online_sources`
+# (comicbox/box/online_lookup.py), so without sharing, every file of a
+# batch paid for a fresh `Comicvine`: a new requests session (no
+# connection reuse across files), a new requests_cache sqlite handle, a
+# new ratelimit-bucket file handle, and a re-run of the cache
+# maintenance path. simyan 3.x keeps its rate-limit state in a sqlite
+# bucket file rather than in memory, so sharing is about connection and
+# handle reuse rather than about rate-limit visibility — that part
+# already worked across instances.
+#
+# Contract: FIRST BUILD WINS, matching `metron_api`'s session cache. The
+# client (and the response cache baked into it) is constructed from the
+# settings of whichever source instance hits the cache miss; later
+# same-credential sources reuse it even if their own cache settings
+# differ, and we warn once when they do. Entries are deliberately never
+# evicted: the cache is bounded by distinct credential sets used in one
+# process.
+_session_cache: dict[tuple[str, str], tuple[Any, tuple]] = {}
+_session_cache_lock = threading.Lock()
+
+
+def reset_shared_sessions() -> None:
+    """
+    Drop every shared simyan client. Test seam; not used in production.
+
+    Unit tests build ad-hoc sources with throwaway credentials and
+    tmp_path cache dirs; without this the first test's client would be
+    handed to every later test that reuses a credential set.
+    """
+    with _session_cache_lock:
+        _session_cache.clear()
 
 
 def _drop_v2_cache_table(cache_path: Path) -> None:
@@ -74,6 +120,49 @@ def _drop_v2_cache_table(cache_path: Path) -> None:
         conn.execute("DROP TABLE IF EXISTS queries")
 
 
+@dataclass
+class _SearchBudget:
+    """
+    Pre-call spend limit for one `search()`: N issue-list calls, T seconds.
+
+    ComicVine's fan-out is the one place a single comic can cost an
+    unbounded amount of wall clock: `_discover_volumes` unions two
+    capped result sets, so the volume list can reach 2x the discovery
+    cap, and every survivor costs one rate-limited `list_issues` call
+    (two when the cover-date window comes back empty). At 1/sec that is
+    minutes for one comic, and there was nothing to stop it.
+
+    Both limits gate whether a call is ISSUED. Neither looks at a
+    response, so the effort/api-budget contract — pre-call fan-out
+    throttling only — holds. Whatever calls do go out are ranked exactly
+    as before.
+
+    ``max_calls=None`` means unlimited (THOROUGH).
+    """
+
+    max_calls: int | None
+    deadline: float | None
+    spent: int = 0
+    dropped: int = 0
+
+    def take(self) -> bool:
+        """Claim one call. False when the budget or the clock is out."""
+        if self.max_calls is not None and self.spent >= self.max_calls:
+            self.dropped += 1
+            return False
+        if self.deadline is not None and time.monotonic() >= self.deadline:
+            self.dropped += 1
+            return False
+        self.spent += 1
+        return True
+
+    def exhausted_reason(self) -> str:
+        """Why the budget stopped, for the log line."""
+        if self.max_calls is not None and self.spent >= self.max_calls:
+            return f"call budget ({self.max_calls}) exhausted"
+        return f"search deadline ({_SEARCH_DEADLINE_S:.0f}s) reached"
+
+
 class ComicVineOnlineSource(OnlineSource):
     """Wraps simyan for the ComicVine API."""
 
@@ -87,15 +176,56 @@ class ComicVineOnlineSource(OnlineSource):
         return bool(self._credentials.key)
 
     def _get_session(self) -> Comicvine:
-        """Build the simyan client once per source lifetime, then reuse it."""
+        """
+        Return the process-wide simyan client shared by this credential set.
+
+        Sources are rebuilt per file (`_build_active_online_sources` in
+        comicbox/box/online_lookup.py), so memoizing on `self` alone gave
+        every file of a batch its own client — a fresh HTTPS connection
+        pool, response-cache handle and ratelimit-bucket handle per
+        comic. Memoizing by (api_key, base_url) at module scope lets
+        every file, and every thread in `Runner._run_parallel`'s pool,
+        reuse one. See `_session_cache` for the first-build-wins
+        contract.
+        """
         if self._client is None:
-            self._client = self._build_session()
+            # Warn here rather than in _build_session so ignored-config
+            # warnings don't depend on winning the session-cache miss;
+            # warn_once keeps them at one line per process either way.
+            self._warn_ignored_rate_limit_overrides()
+            self._client = self._get_or_build_shared_session()
         return self._client
+
+    def _session_config_signature(self) -> tuple:
+        """Return the per-instance settings a built client bakes in."""
+        cache = self._settings.cache
+        return (cache.mode, cache.dir, cache.ttl)
+
+    def _get_or_build_shared_session(self) -> Comicvine:
+        key = (self._credentials.key or "", self._credentials.url or "")
+        signature = self._session_config_signature()
+        with _session_cache_lock:
+            entry = _session_cache.get(key)
+            if entry is None:
+                client = self._build_session()
+                _session_cache[key] = (client, signature)
+                return client
+        client, built_signature = entry
+        if built_signature != signature:
+            # First build wins (see the _session_cache comment); tell the
+            # user their differing cache config is not taking effect.
+            warn_once(
+                f"{self.name}:session-config-mismatch",
+                f"online {self.name}: reusing the existing shared simyan "
+                "client; this instance's differing cache settings "
+                f"{signature} are ignored in favor of the client's "
+                f"{built_signature}",
+            )
+        return client
 
     def _build_session(self) -> Comicvine:
         from simyan.comicvine import Comicvine
 
-        self._warn_ignored_rate_limit_overrides()
         # Both paths are always passed explicitly — simyan's defaults land
         # in ~/.cache/simyan, outside comicbox's cache dir.
         cache_path = self.cache_db_path()
@@ -622,6 +752,7 @@ class ComicVineOnlineSource(OnlineSource):
         # picks the real values for `fast` (currently 0.7 placeholder).
         name_threshold = self._effort_name_threshold()
 
+        budget = self._new_search_budget()
         candidates: list[Candidate] = []
         for vol in volumes:
             candidates.extend(
@@ -632,9 +763,28 @@ class ComicVineOnlineSource(OnlineSource):
                     issue_number=issue_number,
                     year=year,
                     name_threshold=name_threshold,
+                    budget=budget,
                 )
             )
+        if budget.dropped:
+            # Never truncate silently: a short candidate list has to be
+            # distinguishable from a thin one upstream.
+            logger.info(
+                f"online {self.name}: {budget.exhausted_reason()} after "
+                f"{budget.spent} issue-list call(s) for "
+                f"series={profile.series!r}; {budget.dropped} volume(s) "
+                "not queried. Raise api_budget to `thorough` to search "
+                "them all."
+            )
         return candidates
+
+    def _new_search_budget(self) -> _SearchBudget:
+        """Resolve this search's pre-call fan-out limits from the effort knob."""
+        from comicbox.config.settings import resolve_effort
+
+        max_calls = max_calls_for(resolve_effort(self._settings, self.name))
+        deadline = None if max_calls is None else time.monotonic() + _SEARCH_DEADLINE_S
+        return _SearchBudget(max_calls=max_calls, deadline=deadline)
 
     def _candidates_for_volume(
         self,
@@ -645,6 +795,7 @@ class ComicVineOnlineSource(OnlineSource):
         issue_number: str | None,
         year: int | None,
         name_threshold: float,
+        budget: _SearchBudget | None = None,
     ) -> list[Candidate]:
         """
         Apply pre-call filters and (if kept) fetch the volume's matching issues.
@@ -652,9 +803,11 @@ class ComicVineOnlineSource(OnlineSource):
         Pre-filters in order: start_year causality (skip volumes that
         started after the comic), then series-name fuzzy match (skip
         volumes whose name diverges from `profile.series` past the
-        api_budget threshold). Both filters log at debug level so
-        calibration runs can audit drops. The actual `list_issues` call
-        only fires for volumes that survive both gates.
+        api_budget threshold), then the per-search call/deadline budget.
+        The name filters log at debug level so calibration runs can audit
+        drops; the budget's drops are counted and reported once by the
+        caller. The actual `list_issues` call only fires for volumes that
+        survive every gate.
 
         The volume's aliases are read off the already-fetched search
         result — no extra API call — and both widen the name gate and
@@ -680,6 +833,8 @@ class ComicVineOnlineSource(OnlineSource):
                 f"{name_threshold:.2f}, api_budget pre-filter)."
             )
             return []
+        if budget is not None and not budget.take():
+            return []
         try:
             return self._list_with_year_retry(
                 session,
@@ -688,6 +843,7 @@ class ComicVineOnlineSource(OnlineSource):
                 vol.name,
                 year=year,
                 alt_series=alt_series,
+                budget=budget,
             )
         except OnlineLookupAbortedError:
             # An abort ends the whole lookup; it is not a source-side
@@ -709,6 +865,7 @@ class ComicVineOnlineSource(OnlineSource):
         *,
         year: int | None,
         alt_series: tuple[str, ...] = (),
+        budget: _SearchBudget | None = None,
     ) -> list[Candidate]:
         """
         Per-volume issue lookup with a year-window filter and one fallback.
@@ -718,6 +875,11 @@ class ComicVineOnlineSource(OnlineSource):
         the year filter — cover_date can be missing on CV issues, and
         we'd rather see *something* and let the matcher score it than
         wrongly drop the right answer.
+
+        That fallback is a second rate-limited call, so it claims from
+        the same per-search budget the first one did. This is why the
+        budget is counted in CALLS rather than in volumes: a volume can
+        cost one or two.
         """
         candidates = self._list_issues_by_volume(
             session,
@@ -728,6 +890,8 @@ class ComicVineOnlineSource(OnlineSource):
             alt_series=alt_series,
         )
         if candidates or year is None:
+            return candidates
+        if budget is not None and not budget.take():
             return candidates
         return self._list_issues_by_volume(
             session,

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -37,6 +37,7 @@ from comicbox.events import FileError, PromptDeferred, PromptResolvedFromCache
 # import path; the definition lives in comicbox.exceptions so it shares
 # the ComicboxError base.
 from comicbox.exceptions import OnlineConfigurationError, OnlineLookupAbortedError
+from comicbox.formats.base.online.series_cache import filename_series_fingerprint
 
 # Re-exported so batch callers get the run estimator off the same Codex-facing
 # façade as the session it estimates; the implementation lives in
@@ -525,7 +526,7 @@ class OnlineSession:
         """
         path_list = list(paths)
         if self._series_batching:
-            path_list = sorted(path_list, key=_filename_series_fingerprint)
+            path_list = sorted(path_list, key=filename_series_fingerprint)
         for path in path_list:
             if self._cancel.is_set():
                 yield OnlineResult(path=path, cancelled=True)
@@ -860,6 +861,14 @@ def _prompt_fingerprint(
     to the same fingerprint because their candidate volume_ids match —
     enabling the cache to auto-apply the user's prior series choice to
     every subsequent issue of that run.
+
+    Series-level means series-level: the issue's own cover year is
+    excluded for the same reason `_series_fingerprint` excludes it (see
+    comicbox/box/online_lookup.py) — it forked the key per issue on any
+    run spanning more than one year, so the user was re-prompted for a
+    series they had already disambiguated. The volume ordinal and the
+    series start year take its place, on top of the candidate
+    volume_ids, which already carry most of the discrimination.
     """
     series = (profile.series or "").strip().lower()
     publisher = (profile.publisher or "").strip().lower()
@@ -871,26 +880,12 @@ def _prompt_fingerprint(
     # fingerprint, equivalent to "same exact candidate list."
     if not volume_ids:
         volume_ids = tuple(sorted(c.issue_id for c in candidates))
-    parts = (source, series, str(profile.year or ""), publisher, repr(volume_ids))
+    parts = (
+        source,
+        series,
+        str(profile.volume or ""),
+        str(profile.series_start_year or ""),
+        publisher,
+        repr(volume_ids),
+    )
     return "|".join(parts)
-
-
-def _filename_series_fingerprint(path: Path) -> str:
-    """
-    Lightweight series fingerprint derived from the filename alone.
-
-    Used by ``tag_many`` to group same-series comics together *before*
-    opening any archives. Falls back to the bare filename when comicfn2dict
-    can't extract a series — those files won't benefit from series
-    batching but won't break it either (they sort to a deterministic
-    "by filename" bucket).
-    """
-    from comicfn2dict import comicfn2dict
-
-    try:
-        parsed = comicfn2dict(path.name)
-    except Exception:  # pragma: no cover — comicfn2dict is permissive
-        return path.name.lower()
-    series = str(parsed.get("series") or "").strip().lower()
-    year = str(parsed.get("year") or "")
-    return f"{series}|{year}" if series else f"~{path.name.lower()}"

--- a/comicbox/run.py
+++ b/comicbox/run.py
@@ -17,6 +17,10 @@ from comicbox.exceptions import OnlineLookupAbortedError, UnsupportedArchiveType
 from comicbox.formats.base.online import outcome_stats
 from comicbox.formats.base.online.auto_engage import resolve_auto_engaged_budget
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
+from comicbox.formats.base.online.series_cache import (
+    SeriesCache,
+    filename_series_fingerprint,
+)
 from comicbox.logger import init_logging
 
 if TYPE_CHECKING:
@@ -48,6 +52,14 @@ class Runner:
         #: wrong; `comicbox.cli.main` exits non-zero when it's non-empty.
         self.failure_count = 0
         self._failure_lock = threading.Lock()
+        #: Batch-wide series cache for online tagging (series-first
+        #: batching, plan §3.10). `OnlineSession` has always had one; the
+        #: CLI did not, so `comicbox --online` re-ran the full candidate
+        #: search for every issue of a series even inside one `-j N`
+        #: batch. A plain dict guarded by a lock: the pool's workers all
+        #: read and write it, and `_maybe_populate_series_cache` needs
+        #: `in` / `__setitem__` to stay consistent between them.
+        self._series_cache = SeriesCache()
         init_logging(self._config.general.loglevel)
 
     def _iter_recurse(self, path: Path) -> Iterator[Path]:
@@ -123,8 +135,28 @@ class Runner:
                 return
 
         with Comicbox(path, config=self._config) as car:
+            if self._config.online.lookup.enabled:
+                car.set_series_cache(self._series_cache)
             car.print_file_header()
             car.run()
+
+    def _order_for_series_batching(self, paths: list[Path]) -> list[Path]:
+        """
+        Cluster same-series files together so the series cache can hit.
+
+        Mirrors `OnlineSession.tag_many`: the first issue of each cluster
+        pays for the cold-path search and resolves the volume id; the
+        rest of the cluster reads it back and goes straight to the
+        volume-scoped issue lookup. Sorting by fingerprint makes the
+        cluster order deterministic, so re-runs produce the same
+        cache-key sequence.
+
+        Only reorders when online lookup is on — for every other
+        operation the input order is the user's and we leave it alone.
+        """
+        if not self._config.online.lookup.enabled:
+            return paths
+        return sorted(paths, key=filename_series_fingerprint)
 
     def recurse(self, path: Path) -> None:
         """Perform operations recursively on files (single-threaded)."""
@@ -244,6 +276,15 @@ class Runner:
             # actual processing is unchanged.
             paths = self._expand_paths()
             self._maybe_auto_engage_api_budget(len(paths))
+            if self._config.online.lookup.enabled:
+                # Online serial runs dispatch over the EXPANDED, clustered
+                # list so the series cache sees same-series files
+                # back-to-back. Offline runs keep the original
+                # one-call-per-configured-path control flow, which is what
+                # `--recurse` directory handling is written against.
+                for path in self._order_for_series_batching(paths):
+                    self._run_one(path)
+                return
             for raw in self._config.paths or ():
                 self._run_one(raw)
             return
@@ -258,4 +299,4 @@ class Runner:
         if len(paths) == 1:
             self._run_one(paths[0])
             return
-        self._run_parallel(paths, jobs)
+        self._run_parallel(self._order_for_series_batching(paths), jobs)

--- a/tests/calibration/run.py
+++ b/tests/calibration/run.py
@@ -53,11 +53,11 @@ from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
 from comicbox.formats.metron_api.online_source import MetronOnlineSource
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Sequence
 
     from comicbox.config.settings import OnlineSettings
     from comicbox.formats.base.online.matcher import (
-        CandidateHashFetcher,
+        CandidateHashBatchFetcher,
         LocalHashProvider,
     )
     from comicbox.formats.base.online.profile import Candidate
@@ -408,12 +408,14 @@ class _HashProviderBox(Protocol):
 
     def _local_cover_phash(self) -> str | None: ...
 
-    def _candidate_cover_hash_fetcher(self, url: str) -> str | None: ...
+    def _candidate_cover_hash_batch_fetcher(
+        self, urls: Sequence[str]
+    ) -> dict[str, str]: ...
 
 
 def _hash_providers(
     cb: _HashProviderBox, fixture: _Fixture
-) -> tuple[LocalHashProvider | None, CandidateHashFetcher | None]:
+) -> tuple[LocalHashProvider | None, CandidateHashBatchFetcher | None]:
     """
     Return the cover-hash providers the matcher should use for this fixture.
 
@@ -424,10 +426,13 @@ def _hash_providers(
     We gate on `cover_quality`:
 
     - **full** — pass both providers. `_local_cover_phash` reads the
-      first archive page and hashes it; `_candidate_cover_hash_fetcher`
-      downloads ComicVine cover URLs (Metron candidates ship a
-      precomputed hash) into the shared SQLite cache. This is the
-      production hashing path, just driven from the harness.
+      first archive page and hashes it;
+      `_candidate_cover_hash_batch_fetcher` resolves the whole top-K's
+      ComicVine cover URLs at once (Metron candidates ship a precomputed
+      hash) against the shared SQLite cache, downloading the misses
+      concurrently. This is the production hashing path, just driven
+      from the harness — it tracks whichever fetcher production uses, so
+      the timings the harness reports stay comparable to a real run.
     - **thumbnail** / **missing** — return (None, None). Slimlib's
       shrunk covers and missing-cover fixtures produce noise at best
       and degrade the metadata-only signal at worst. We'd rather see
@@ -437,7 +442,7 @@ def _hash_providers(
     if fixture.cover_quality != "full":
         return None, None
     # Bind to the instance methods (mixin-provided on Comicbox).
-    return cb._local_cover_phash, cb._candidate_cover_hash_fetcher
+    return cb._local_cover_phash, cb._candidate_cover_hash_batch_fetcher
 
 
 def _format_duration(seconds: float) -> str:
@@ -603,7 +608,7 @@ def _score_one(
                 profile,
                 candidates,
                 local_hash_provider=local_provider,
-                candidate_hash_fetcher=candidate_fetcher,
+                candidate_hash_batch_fetcher=candidate_fetcher,
             )
     except Exception as exc:
         return _Outcome(

--- a/tests/calibration/test_harness_filter.py
+++ b/tests/calibration/test_harness_filter.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from tests.calibration._harness_helpers import make_outcome, write_outcomes
 from tests.calibration.run import _Fixture
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _outcome = make_outcome
 _write_outcomes = write_outcomes
@@ -97,8 +101,10 @@ class _FakeBox:
     def _local_cover_phash(self) -> str | None:
         return "deadbeef"
 
-    def _candidate_cover_hash_fetcher(self, url: str) -> str | None:
-        return f"hash:{url}"
+    def _candidate_cover_hash_batch_fetcher(
+        self, urls: Sequence[str]
+    ) -> dict[str, str]:
+        return {url: f"hash:{url}" for url in urls}
 
 
 def test_hash_providers_full_returns_methods() -> None:
@@ -140,9 +146,12 @@ def test_hash_providers_call_through_returns_box_results() -> None:
     assert local is not None
     assert fetcher is not None
     assert local() == "deadbeef"
-    assert fetcher("https://example.test/cover.jpg") == (
-        "hash:https://example.test/cover.jpg"
-    )
+    # The batch fetcher resolves a whole top-K at once, which is what
+    # production passes the matcher.
+    assert fetcher(["https://example.test/a.jpg", "https://example.test/b.jpg"]) == {
+        "https://example.test/a.jpg": "hash:https://example.test/a.jpg",
+        "https://example.test/b.jpg": "hash:https://example.test/b.jpg",
+    }
 
 
 # --------------------------------------- _resolve_retry_outcomes_path fallback

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ real defaults — just nothing from the user's machine.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from typing import TYPE_CHECKING
 
@@ -40,6 +41,7 @@ import pytest
 import comicbox.box  # noqa: F401  # pyright: ignore[reportUnusedImport]
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
@@ -66,9 +68,31 @@ _scrub_environ_at_collection()
 @pytest.fixture(autouse=True)
 def _hermetic_comicbox_env(  # pyright: ignore[reportUnusedFunction]
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Strip ``COMICBOX_*`` env vars and isolate confuse from user config."""
+) -> Iterator[None]:
+    """
+    Strip ``COMICBOX_*`` env vars and isolate confuse from user config.
+
+    Also clears the online sources' process-wide client caches on the way
+    out. Both Metron and Comic Vine memoize their upstream client by
+    credential set at module scope so a batch reuses one connection pool;
+    that cache outlives a test, so without this a fake client built with
+    throwaway credentials would be handed to every later test that
+    happens to reuse them.
+    """
     for key in list(os.environ):
         if key.startswith("COMICBOX"):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("COMICBOXDIR", str(tmp_path))
+    yield
+    _reset_shared_online_sessions()
+
+
+def _reset_shared_online_sessions() -> None:
+    """Clear both sources' shared-client caches, if they were imported."""
+    comicvine = sys.modules.get("comicbox.formats.comicvine_api.online_source")
+    if comicvine is not None:
+        comicvine.reset_shared_sessions()
+    metron = sys.modules.get("comicbox.formats.metron_api.online_source")
+    if metron is not None:
+        with metron._session_cache_lock:
+            metron._session_cache.clear()

--- a/tests/unit/test_comicvine.py
+++ b/tests/unit/test_comicvine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from contextlib import closing
 from datetime import timedelta
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ from typing_extensions import override
 
 from comicbox.config.settings import (
     CacheMode,
+    Effort,
     OnlineCacheSettings,
     OnlineSettings,
     OnlineSourceCredentials,
@@ -20,8 +22,11 @@ from comicbox.config.settings import (
     OnlineTuningSettings,
 )
 from comicbox.formats.base.online.profile import ComicProfile
+from comicbox.formats.base.online.series_filter import max_calls_for
 from comicbox.formats.comicvine_api.online_source import (
     ComicVineOnlineSource,
+    _SearchBudget,
+    reset_shared_sessions,
 )
 from comicbox.version import USER_AGENT
 
@@ -968,12 +973,19 @@ def test_build_session_drops_v2_queries_table(
     assert "queries" not in tables
 
 
-def test_build_session_warns_on_ignored_rate_limit_override(
+def test_get_session_warns_on_ignored_rate_limit_override(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """CV per_second/per_hour overrides can't flow into simyan 3.x — warn."""
+    """
+    CV per_second/per_hour overrides can't flow into simyan 3.x — warn.
+
+    Driven through `_get_session`, not `_build_session`: the warning
+    deliberately fires on every source that carries the ignored config,
+    not only on the one that wins the shared-client cache miss.
+    """
     from loguru import logger as loguru_logger
 
+    reset_shared_sessions()
     messages: list[str] = []
     handler_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
     try:
@@ -987,7 +999,167 @@ def test_build_session_warns_on_ignored_rate_limit_override(
         settings = OnlineSettings(
             cache=OnlineCacheSettings(dir=tmp_path), tuning=tuning
         )
-        _build_with_fake(monkeypatch, settings)
+        monkeypatch.setattr("simyan.comicvine.Comicvine", _FakeComicvine)
+        creds = OnlineSourceCredentials(key="warn-key")
+        ComicVineOnlineSource(creds, settings)._get_session()
     finally:
         loguru_logger.remove(handler_id)
+        reset_shared_sessions()
     assert any("ignored" in message for message in messages)
+
+
+def test_get_session_shared_across_source_instances(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Same credentials → one client, even across separately built sources.
+
+    `_build_active_online_sources` rebuilds sources per file, so this is
+    what keeps a batch from paying for a fresh simyan client (and its
+    connection pool and sqlite handles) per comic.
+    """
+    reset_shared_sessions()
+    try:
+        monkeypatch.setattr("simyan.comicvine.Comicvine", _FakeComicvine)
+        settings = _make_cache_settings(tmp_path)
+        creds = OnlineSourceCredentials(key="shared-key")
+        first = ComicVineOnlineSource(creds, settings)._get_session()
+        second = ComicVineOnlineSource(creds, settings)._get_session()
+        assert first is second
+    finally:
+        reset_shared_sessions()
+
+
+def test_get_session_not_shared_across_credentials(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A different api_key gets its own client."""
+    reset_shared_sessions()
+    try:
+        monkeypatch.setattr("simyan.comicvine.Comicvine", _FakeComicvine)
+        settings = _make_cache_settings(tmp_path)
+        first = ComicVineOnlineSource(
+            OnlineSourceCredentials(key="key-a"), settings
+        )._get_session()
+        second = ComicVineOnlineSource(
+            OnlineSourceCredentials(key="key-b"), settings
+        )._get_session()
+        assert first is not second
+    finally:
+        reset_shared_sessions()
+
+
+def test_get_session_warns_when_reused_with_different_cache_settings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """First build wins; the loser is told its cache config is ignored."""
+    from loguru import logger as loguru_logger
+
+    reset_shared_sessions()
+    messages: list[str] = []
+    handler_id = loguru_logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        monkeypatch.setattr("simyan.comicvine.Comicvine", _FakeComicvine)
+        creds = OnlineSourceCredentials(key="mismatch-key")
+        ComicVineOnlineSource(creds, _make_cache_settings(tmp_path))._get_session()
+        other = tmp_path / "other"
+        other.mkdir()
+        ComicVineOnlineSource(creds, _make_cache_settings(other))._get_session()
+    finally:
+        loguru_logger.remove(handler_id)
+        reset_shared_sessions()
+    assert any("ignored in favor of" in message for message in messages)
+
+
+# ------------------------------------------------ per-search fan-out budget
+
+
+def _many_volume_source(
+    monkeypatch: pytest.MonkeyPatch, count: int, effort: Effort
+) -> tuple[ComicVineOnlineSource, _FakeCV]:
+    """Build a CV source facing `count` equally-plausible volumes."""
+    volumes = [_FakeBasicVolume(vid=i, name="Conan") for i in range(1, count + 1)]
+    issues = {
+        i: [_FakeBasicIssue(iid=i * 10, number="7", volume_name="Conan")]
+        for i in range(1, count + 1)
+    }
+    fake_cv = _FakeCV(volumes=volumes, issues_by_volume=issues)
+    tuning = OnlineTuningSettings(
+        per_source={"comicvine": OnlineSourceTuning(effort=effort)}
+    )
+    src = ComicVineOnlineSource(
+        OnlineSourceCredentials(key="test-key"), OnlineSettings(tuning=tuning)
+    )
+    monkeypatch.setattr(src, "_get_session", lambda: fake_cv)
+    return src, fake_cv
+
+
+def test_search_caps_issue_list_calls_at_the_effort_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A wide fan-out can't spend unbounded rate-limited calls on one comic.
+
+    Every surviving volume costs a `list_issues` call at CV's 1/sec, so
+    an uncapped fan-out is minutes of wall clock for a single file.
+    """
+    src, fake_cv = _many_volume_source(monkeypatch, count=40, effort=Effort.BALANCED)
+    src.search(ComicProfile(series="Conan", issue="7", issue_int=7))
+    assert len(fake_cv.list_issues_calls) == max_calls_for(Effort.BALANCED)
+
+
+def test_search_budget_is_pre_call_not_post_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The budget drops CALLS, never results.
+
+    Effort/api_budget is a pre-call fan-out throttle; every candidate
+    that a spent call returned still reaches the matcher.
+    """
+    src, fake_cv = _many_volume_source(monkeypatch, count=40, effort=Effort.BALANCED)
+    candidates = src.search(ComicProfile(series="Conan", issue="7", issue_int=7))
+    assert len(candidates) == len(fake_cv.list_issues_calls)
+
+
+def test_thorough_effort_keeps_the_unbounded_fan_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`thorough` means spend freely — no per-search cap."""
+    assert max_calls_for(Effort.THOROUGH) is None
+    src, fake_cv = _many_volume_source(monkeypatch, count=40, effort=Effort.THOROUGH)
+    src.search(ComicProfile(series="Conan", issue="7", issue_int=7))
+    assert len(fake_cv.list_issues_calls) == 40
+
+
+def test_search_reports_volumes_it_did_not_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Truncation is never silent — a short candidate list says why."""
+    from loguru import logger as loguru_logger
+
+    messages: list[str] = []
+    handler_id = loguru_logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        src, _ = _many_volume_source(monkeypatch, count=40, effort=Effort.BALANCED)
+        src.search(ComicProfile(series="Conan", issue="7", issue_int=7))
+    finally:
+        loguru_logger.remove(handler_id)
+    assert any("not queried" in message for message in messages)
+
+
+def test_search_budget_deadline_stops_the_fan_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled fan-out stops on the clock even with calls left."""
+    budget = _SearchBudget(max_calls=100, deadline=time.monotonic() - 1.0)
+    assert budget.take() is False
+    assert budget.dropped == 1
+    assert "deadline" in budget.exhausted_reason()
+
+
+def test_search_budget_unlimited_never_stops() -> None:
+    """`max_calls=None` with no deadline is the THOROUGH contract."""
+    budget = _SearchBudget(max_calls=None, deadline=None)
+    assert all(budget.take() for _ in range(50))
+    assert budget.dropped == 0

--- a/tests/unit/test_cover_hash.py
+++ b/tests/unit/test_cover_hash.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from io import BytesIO
 from typing import TYPE_CHECKING
 
 import pytest
 from PIL import Image
+from typing_extensions import override
 
 from comicbox.formats.base.online.cover_hash import (
     HASH_BITS,
+    CoverFetchPool,
     CoverHashUrlCache,
     compute_phash,
     cover_score,
@@ -18,6 +21,7 @@ from comicbox.formats.base.online.cover_hash import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -102,3 +106,119 @@ def test_cover_hash_url_cache_creates_table(tmp_path: Path) -> None:
         ).fetchall()
     table_names = [r[0] for r in rows]
     assert "cover_hashes" in table_names
+
+
+# ------------------------------------------------ batch cache + fetch pool
+
+
+def test_cover_hash_url_cache_get_many_round_trip(tmp_path: Path) -> None:
+    """One query answers a whole top-K instead of one connection per URL."""
+    cache = CoverHashUrlCache(tmp_path / "c.sqlite")
+    cache.set_many([("http://a", "aaaa"), ("http://b", "bbbb")])
+    assert cache.get_many(["http://a", "http://b", "http://missing"]) == {
+        "http://a": "aaaa",
+        "http://b": "bbbb",
+    }
+    cache.close()
+
+
+def test_cover_hash_url_cache_reuses_one_connection(tmp_path: Path) -> None:
+    """The connection is held for the cache's lifetime, not per call."""
+    cache = CoverHashUrlCache(tmp_path / "c.sqlite")
+    first = cache._conn
+    cache.set("http://a", "aaaa")
+    cache.get("http://a")
+    assert cache._conn is first
+    cache.close()
+
+
+def test_cover_hash_url_cache_set_many_ignores_blanks(tmp_path: Path) -> None:
+    """Empty URLs and empty hashes are never stored."""
+    cache = CoverHashUrlCache(tmp_path / "c.sqlite")
+    cache.set_many([("", "aaaa"), ("http://a", ""), ("http://b", "bbbb")])
+    assert cache.get_many(["", "http://a", "http://b"]) == {"http://b": "bbbb"}
+    cache.close()
+
+
+def test_cover_hash_url_cache_get_many_chunks_large_input(tmp_path: Path) -> None:
+    """More URLs than SQLite's variable limit still resolve in full."""
+    cache = CoverHashUrlCache(tmp_path / "c.sqlite")
+    pairs = [(f"http://u{i}", f"h{i}") for i in range(cache._MAX_VARS * 2 + 7)]
+    cache.set_many(pairs)
+    assert cache.get_many([u for u, _ in pairs]) == dict(pairs)
+    cache.close()
+
+
+def test_cover_hash_url_cache_close_is_idempotent(tmp_path: Path) -> None:
+    """Closing twice is safe — the box closes it, and so may a caller."""
+    cache = CoverHashUrlCache(tmp_path / "c.sqlite")
+    cache.close()
+    cache.close()
+
+
+class _StubPool(CoverFetchPool):
+    """A pool whose single-cover fetch is stubbed; no network, no PIL."""
+
+    def __init__(self, stub: Callable[[str], str | None], max_workers: int = 8) -> None:
+        super().__init__(max_workers=max_workers)
+        self._stub = stub
+        self.seen: list[str] = []
+
+    @override
+    def fetch_hash(self, url: str) -> str | None:
+        self.seen.append(url)
+        return self._stub(url)
+
+
+def test_cover_fetch_pool_fetches_concurrently() -> None:
+    """
+    The pool overlaps downloads instead of serializing them.
+
+    These GETs hit the sources' image CDNs, not their rate-limited API
+    hosts, so serializing them was pure wall-clock loss: the matcher
+    hashes up to 15 candidates for one ambiguous comic.
+    """
+    barrier = threading.Barrier(3, timeout=5)
+
+    def stub(url: str) -> str:
+        # Blocks until all three are in flight; a serial pool never gets
+        # here and the barrier times out.
+        barrier.wait()
+        return f"hash-{url[-1]}"
+
+    pool = _StubPool(stub, max_workers=3)
+    assert pool.fetch_hashes(["http://a", "http://b", "http://c"]) == {
+        "http://a": "hash-a",
+        "http://b": "hash-b",
+        "http://c": "hash-c",
+    }
+    pool.close()
+
+
+def test_cover_fetch_pool_drops_failures() -> None:
+    """A cover that won't hash is a missing signal, never a failed lookup."""
+    pool = _StubPool(lambda url: None if url.endswith("b") else "ok", max_workers=2)
+    assert pool.fetch_hashes(["http://a", "http://b"]) == {"http://a": "ok"}
+    pool.close()
+
+
+def test_cover_fetch_pool_dedupes_urls() -> None:
+    """Two candidates sharing a cover URL cost one download."""
+    pool = _StubPool(lambda _url: "h", max_workers=4)
+    pool.fetch_hashes(["http://a", "http://a", "http://a"])
+    assert pool.seen == ["http://a"]
+    pool.close()
+
+
+def test_cover_fetch_pool_empty_input_does_no_work() -> None:
+    """No URLs means no client, no threads."""
+    pool = CoverFetchPool()
+    assert pool.fetch_hashes([]) == {}
+    assert pool._client is None
+
+
+def test_cover_fetch_pool_close_is_idempotent() -> None:
+    """Closing an unused pool, or one already closed, is safe."""
+    pool = CoverFetchPool()
+    pool.close()
+    pool.close()

--- a/tests/unit/test_online_matcher.py
+++ b/tests/unit/test_online_matcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -1397,3 +1398,129 @@ def test_matcher_uses_candidate_hash_fetcher_for_no_precomputed() -> None:
     # the policy may skip hashing. The test asserts the fetcher is wired:
     # if invoked, it received our URL.
     assert all(call == "http://example.com/x.jpg" for call in fetcher_calls)
+
+
+# ------------------------------------------------ batch cover-hash fetching
+
+
+def _ambiguous_pair(cover_a: str, cover_b: str) -> list[Candidate]:
+    """Two same-score candidates, so hashing is invoked to separate them."""
+    return [
+        Candidate(
+            source="comicvine",
+            issue_id=1,
+            summary=CandidateSummary(
+                series="Watchmen",
+                issue="1",
+                year=1986,
+                publisher="DC",
+                page_count=None,
+                cover_url=cover_a,
+                variant_label=None,
+            ),
+            volume_id=10,
+        ),
+        Candidate(
+            source="comicvine",
+            issue_id=2,
+            summary=CandidateSummary(
+                series="Watchmen",
+                issue="1",
+                year=1986,
+                publisher="DC",
+                page_count=None,
+                cover_url=cover_b,
+                variant_label=None,
+            ),
+            volume_id=20,
+        ),
+    ]
+
+
+def test_batch_fetcher_resolves_the_whole_top_k_in_one_call() -> None:
+    """
+    Every top-K cover is requested up front, not one blocking GET at a time.
+
+    That single call is what lets the downloads overlap; serially they
+    cost one round-trip per candidate for one comic.
+    """
+    profile = ComicProfile(series="Watchmen", issue="1", issue_int=1, year=1986)
+    candidates = _ambiguous_pair("http://a", "http://b")
+    batches: list[list[str]] = []
+
+    def batch_fetcher(urls):
+        batches.append(list(urls))
+        return {"http://a": "0" * 16, "http://b": "f" * 16}
+
+    OnlineMatcher().rank(
+        profile,
+        candidates,
+        local_hash_provider=lambda: "0" * 16,
+        candidate_hash_batch_fetcher=batch_fetcher,
+    )
+    assert len(batches) == 1
+    assert sorted(batches[0]) == ["http://a", "http://b"]
+
+
+def test_batch_and_serial_fetchers_rank_identically() -> None:
+    """Concurrency changes when bytes arrive, never the ordering."""
+    profile = ComicProfile(series="Watchmen", issue="1", issue_int=1, year=1986)
+    hashes = {"http://a": "f" * 16, "http://b": "0" * 16}
+
+    serial = OnlineMatcher().rank(
+        profile,
+        _ambiguous_pair("http://a", "http://b"),
+        local_hash_provider=lambda: "0" * 16,
+        candidate_hash_fetcher=hashes.get,
+    )
+    batched = OnlineMatcher().rank(
+        profile,
+        _ambiguous_pair("http://a", "http://b"),
+        local_hash_provider=lambda: "0" * 16,
+        candidate_hash_batch_fetcher=lambda urls: {
+            u: hashes[u] for u in urls if u in hashes
+        },
+    )
+    assert [c.issue_id for c in serial] == [c.issue_id for c in batched]
+    assert [c.score for c in serial] == [c.score for c in batched]
+
+
+def test_batch_fetcher_failure_degrades_to_no_cover_signal() -> None:
+    """A broken batch leaves metadata ranking intact rather than raising."""
+    profile = ComicProfile(series="Watchmen", issue="1", issue_int=1, year=1986)
+
+    def exploding_fetcher(urls):
+        msg = "network down"
+        raise RuntimeError(msg)
+
+    ranked = OnlineMatcher().rank(
+        profile,
+        _ambiguous_pair("http://a", "http://b"),
+        local_hash_provider=lambda: "0" * 16,
+        candidate_hash_batch_fetcher=exploding_fetcher,
+    )
+    assert len(ranked) == 2
+    assert all(c.cover_score is None for c in ranked)
+    # Still marked attempted — the tiebreak must tell "no usable cover"
+    # from "never looked", and we did look.
+    assert all(c.cover_hash_attempted for c in ranked)
+
+
+def test_batch_fetcher_skips_candidates_with_precomputed_hashes() -> None:
+    """Metron's precomputed hash costs no download."""
+    profile = ComicProfile(series="Watchmen", issue="1", issue_int=1, year=1986)
+    candidates = _ambiguous_pair("http://a", "http://b")
+    candidates[0] = replace(candidates[0], precomputed_cover_hash="0" * 16)
+    requested: list[str] = []
+
+    def batch_fetcher(urls):
+        requested.extend(urls)
+        return {}
+
+    OnlineMatcher().rank(
+        profile,
+        candidates,
+        local_hash_provider=lambda: "0" * 16,
+        candidate_hash_batch_fetcher=batch_fetcher,
+    )
+    assert requested == ["http://b"]

--- a/tests/unit/test_online_retry.py
+++ b/tests/unit/test_online_retry.py
@@ -6,7 +6,15 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from comicbox.formats.base.online.retry import _RATE_LIMIT_SCHEDULE, with_retry
+from comicbox.exceptions import OnlineLookupAbortedError
+from comicbox.formats.base.online.retry import (
+    _MAX_TOTAL_WAIT_S,
+    _RATE_LIMIT_SCHEDULE,
+    clear_cancel,
+    interruptible_sleep,
+    request_cancel,
+    with_retry,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -523,3 +531,109 @@ def test_api_key_redacted_inside_nested_exception_args() -> None:
     chain = "".join(traceback.format_exception(excinfo.value))
     assert "SECRETKEY123" not in chain
     assert "api_key=REDACTED" in chain
+
+
+# --- wall-clock ceiling -----------------------------------------------------
+
+
+def test_total_wait_ceiling_stops_a_server_hint_loop() -> None:
+    """
+    An honored `retry_after` per attempt is otherwise unbounded in total.
+
+    `_MAX_RETRY_AFTER_S` caps ONE hint at an hour; nothing capped the sum,
+    so eight of them could park a worker for most of a day.
+    """
+    sleeps, fake_sleep = _capture_sleeps()
+
+    @with_retry(max_retries=1, sleep=fake_sleep)
+    def fn() -> str:
+        raise _FakeRateLimitError(retry_after=3600.0)
+
+    with pytest.raises(_FakeRateLimitError):
+        fn()
+    assert sum(sleeps) <= _MAX_TOTAL_WAIT_S
+    # One 3600s hint exactly fills the ceiling; a second would breach it.
+    assert len(sleeps) == 1
+
+
+def test_total_wait_ceiling_is_configurable_per_call() -> None:
+    """A tighter ceiling ends the loop sooner, without truncating a delay."""
+    sleeps, fake_sleep = _capture_sleeps()
+
+    @with_retry(max_retries=1, sleep=fake_sleep, max_wait_s=100.0)
+    def fn() -> str:
+        raise _FakeRateLimitError
+
+    with pytest.raises(_FakeRateLimitError):
+        fn()
+    # 30 + 60 = 90 fits; the next scheduled delay (120) would breach 100,
+    # so the loop ends rather than sleeping a shortened, useless wait.
+    assert sleeps == [30.0, 60.0]
+
+
+def test_ceiling_leaves_the_tuned_rate_limit_schedule_intact() -> None:
+    """
+    The default ceiling must not silently shorten `_RATE_LIMIT_SCHEDULE`.
+
+    That schedule's 8-attempt tail was tuned against a `-j 8` rate-limit
+    cascade; a ceiling below its 2910s total would undo that fix without
+    anything failing.
+    """
+    assert sum(_RATE_LIMIT_SCHEDULE) <= _MAX_TOTAL_WAIT_S
+
+
+# --- cancellable sleep is the default ---------------------------------------
+
+
+def test_default_sleep_is_interruptible() -> None:
+    """
+    Every caller gets cancellable waits, not just OnlineSession.
+
+    The waits here run to minutes, so an uninterruptible default made
+    Ctrl-C look broken for CLI users and left a programmatic cancel with
+    nothing to interrupt.
+    """
+    calls = 0
+
+    @with_retry(max_retries=3)
+    def fn() -> str:
+        nonlocal calls
+        calls += 1
+        raise _FakeRateLimitError
+
+    request_cancel()
+    try:
+        with pytest.raises(OnlineLookupAbortedError):
+            fn()
+    finally:
+        clear_cancel()
+    # Cancelled during the first backoff, so the call is never replayed.
+    assert calls == 1
+
+
+def test_interruptible_sleep_returns_normally_when_not_cancelled() -> None:
+    """With no cancel pending it is an ordinary (short) sleep."""
+    clear_cancel()
+    interruptible_sleep(0.001)
+
+
+def test_instance_retry_sleep_still_overrides_the_new_default() -> None:
+    """OnlineSession's per-instance cancellable sleep keeps winning."""
+    sleeps, fake_sleep = _capture_sleeps()
+
+    class _Source:
+        retry_sleep = staticmethod(fake_sleep)
+        on_rate_limit = None
+
+        @with_retry(max_retries=2)
+        def fetch(self) -> str:
+            raise _FakeRateLimitError
+
+    request_cancel()
+    try:
+        with pytest.raises(_FakeRateLimitError):
+            _Source().fetch()
+    finally:
+        clear_cancel()
+    # The instance sleep ran instead of the cancelling default.
+    assert sleeps

--- a/tests/unit/test_run_parallel.py
+++ b/tests/unit/test_run_parallel.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from loguru import logger as loguru_logger
+from typing_extensions import Self
 
 from comicbox.config import get_config
 from comicbox.config.settings import (
@@ -21,6 +22,7 @@ from comicbox.config.settings import (
     OnlineSourceCredentials,
 )
 from comicbox.formats.base.online.rate_limits import METRON_DEFAULT_PER_MINUTE
+from comicbox.formats.base.online.series_cache import SeriesCache
 from comicbox.run import Runner
 from tests.const import CIX_CBZ_SOURCE_PATH
 
@@ -416,3 +418,87 @@ def test_recurse_batch_survives_a_corrupt_file(tmp_path: Path) -> None:
     assert len(errors) == 1
     assert str(corrupt) in errors[0]["message"]
     assert runner.failure_count == 1
+
+
+# ------------------------------------------------ CLI series batching
+
+
+def _online_runner(tmp_path: Path, names: list[str]) -> tuple[Runner, list[str]]:
+    """Build a Runner over `names` with online lookup enabled."""
+    for name in names:
+        (tmp_path / name).write_bytes(b"")
+    settings = _metron_settings()
+    paths = tuple(str(tmp_path / name) for name in names)
+    return Runner(replace(settings, paths=paths)), list(paths)
+
+
+def test_runner_owns_one_series_cache_for_the_batch() -> None:
+    """
+    The CLI gets a series cache; it used to have none at all.
+
+    Without it, `comicbox --online` re-ran the full candidate search for
+    every issue of a series even inside a single batch — the exact work
+    `OnlineSession` has always skipped.
+    """
+    runner = Runner(_metron_settings())
+    assert isinstance(runner._series_cache, SeriesCache)
+    assert len(runner._series_cache) == 0
+
+
+def test_series_cache_is_wired_into_each_box(tmp_path: Path) -> None:
+    """Every file of an online batch shares the runner's one cache."""
+    runner, paths = _online_runner(tmp_path, ["Spider-Man #001 (2018).cbz"])
+    seen: list[Any] = []
+
+    class _FakeBox:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            return None
+
+        def set_series_cache(self, cache: Any) -> None:
+            seen.append(cache)
+
+        def print_file_header(self) -> None:
+            return None
+
+        def run(self) -> None:
+            return None
+
+    with patch("comicbox.run.Comicbox", lambda *_a, **_kw: _FakeBox()):
+        runner.run_on_file(paths[0])
+    assert seen == [runner._series_cache]
+
+
+def test_online_batch_is_clustered_by_series(tmp_path: Path) -> None:
+    """
+    Same-series files run back-to-back so the cache's cold path runs once.
+
+    Interleaved input order is the realistic case — a recursive walk
+    sorts by path, which mixes series whenever they share a directory.
+    """
+    names = [
+        "Spider-Man #001 (2018).cbz",
+        "Batman #001 (2011).cbz",
+        "Spider-Man #014 (2019).cbz",
+        "Batman #027 (2013).cbz",
+    ]
+    runner, paths = _online_runner(tmp_path, names)
+    ordered = [
+        Path(p).name for p in runner._order_for_series_batching(list(map(Path, paths)))
+    ]
+    spider = [i for i, n in enumerate(ordered) if n.startswith("Spider")]
+    batman = [i for i, n in enumerate(ordered) if n.startswith("Batman")]
+    assert spider == [spider[0], spider[0] + 1]
+    assert batman == [batman[0], batman[0] + 1]
+
+
+def test_offline_batch_keeps_user_order(tmp_path: Path) -> None:
+    """Reordering is an online-lookup optimization; nothing else pays for it."""
+    names = ["z.cbz", "a.cbz", "m.cbz"]
+    for name in names:
+        (tmp_path / name).write_bytes(b"")
+    paths = [tmp_path / name for name in names]
+    runner = Runner(get_config(Namespace(comicbox=Namespace())))
+    assert runner._order_for_series_batching(paths) == paths

--- a/tests/unit/test_series_cache.py
+++ b/tests/unit/test_series_cache.py
@@ -49,6 +49,50 @@ def test_series_fingerprint_ignores_issue_level_fields() -> None:
     assert _series_fingerprint(p1) == _series_fingerprint(p2)
 
 
+def test_series_fingerprint_ignores_per_issue_cover_year() -> None:
+    """
+    A run spanning several years is ONE series, so it is one cache key.
+
+    This is the case the cache exists for and the one it used to miss:
+    `year` is the issue's cover year, so every calendar year of a run
+    minted its own key. The fixtures above all pin the same year, which
+    is why nothing caught it.
+    """
+    p1 = ComicProfile(series="Spider-Man", issue="1", year=2018, publisher="Marvel")
+    p2 = ComicProfile(series="Spider-Man", issue="14", year=2019, publisher="Marvel")
+    p3 = ComicProfile(series="Spider-Man", issue="27", year=2020, publisher="Marvel")
+    assert _series_fingerprint(p1) == _series_fingerprint(p2) == _series_fingerprint(p3)
+
+
+def test_series_fingerprint_separates_volume_ordinals() -> None:
+    """A reboot carrying "Vol. 2" doesn't share a key with Vol. 1."""
+    p1 = ComicProfile(series="Spider-Man", year=2018, publisher="Marvel", volume=1)
+    p2 = ComicProfile(series="Spider-Man", year=2018, publisher="Marvel", volume=2)
+    assert _series_fingerprint(p1) != _series_fingerprint(p2)
+
+
+def test_series_fingerprint_separates_series_start_years() -> None:
+    """Two runs of the same name are distinct when their start years differ."""
+    p1 = ComicProfile(
+        series="Batman", year=1975, publisher="DC", series_start_year=1940
+    )
+    p2 = ComicProfile(
+        series="Batman", year=2015, publisher="DC", series_start_year=2011
+    )
+    assert _series_fingerprint(p1) != _series_fingerprint(p2)
+
+
+def test_series_fingerprint_start_year_is_series_level_not_issue_level() -> None:
+    """Two issues of one run share a key even at different cover years."""
+    p1 = ComicProfile(
+        series="Batman", year=2011, publisher="DC", series_start_year=2011
+    )
+    p2 = ComicProfile(
+        series="Batman", year=2015, publisher="DC", series_start_year=2011
+    )
+    assert _series_fingerprint(p1) == _series_fingerprint(p2)
+
+
 # --- mock source ------------------------------------------------------------
 
 

--- a/tests/unit/test_session_series_batching.py
+++ b/tests/unit/test_session_series_batching.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from comicbox.online_session import (
-    OnlineCredentials,
-    OnlineSession,
-    _filename_series_fingerprint,
-)
+from comicbox.formats.base.online.series_cache import filename_series_fingerprint
+from comicbox.online_session import OnlineCredentials, OnlineSession
 
 VALID = OnlineCredentials(metron_user="u", metron_password="p")
 
@@ -20,19 +17,37 @@ def test_filename_fingerprint_groups_same_series() -> None:
     """Two issues of the same series share a filename fingerprint."""
     a = Path("Spider-Man #001 (2018).cbz")
     b = Path("Spider-Man #002 (2018).cbz")
-    assert _filename_series_fingerprint(a) == _filename_series_fingerprint(b)
+    assert filename_series_fingerprint(a) == filename_series_fingerprint(b)
+
+
+def test_filename_fingerprint_groups_across_cover_years() -> None:
+    """
+    One run spanning several years is one cluster, not one per year.
+
+    The clustering has to agree with the cache key it feeds — keying on
+    the filename year split a multi-year run into a cold-path search per
+    year, which is the batching working against itself.
+    """
+    a = Path("Spider-Man #001 (2018).cbz")
+    b = Path("Spider-Man #014 (2019).cbz")
+    c = Path("Spider-Man #027 (2020).cbz")
+    assert (
+        filename_series_fingerprint(a)
+        == filename_series_fingerprint(b)
+        == filename_series_fingerprint(c)
+    )
 
 
 def test_filename_fingerprint_separates_series() -> None:
     a = Path("Spider-Man #001 (2018).cbz")
     b = Path("Batman #001 (2018).cbz")
-    assert _filename_series_fingerprint(a) != _filename_series_fingerprint(b)
+    assert filename_series_fingerprint(a) != filename_series_fingerprint(b)
 
 
 def test_filename_fingerprint_falls_back_on_unparseable() -> None:
     """When comicfn2dict yields no series, fingerprint prefixes with ~."""
     # Issue-only filenames yield no series under comicfn2dict.
-    fp = _filename_series_fingerprint(Path("#42 (2020).cbz"))
+    fp = filename_series_fingerprint(Path("#42 (2020).cbz"))
     assert fp.startswith("~")
 
 


### PR DESCRIPTION
Four independent sources of online-tagging wall clock. Each is I/O-bound work
the code was doing more of than it needed to, and none of them changes what the
matcher decides — the calibration outcomes below are bit-for-bit identical.

## 1. Cover hashing ran one candidate at a time

`_apply_cover_hashing` walked the top-K serially. Every miss paid a fresh
TCP+TLS handshake (`httpx.get` per call), and `CoverHashUrlCache` opened a new
sqlite connection for each `get` *and* each `set` — so up to 15 round-trips and
30 connections for one ambiguous comic. These GETs hit the sources' **image
CDNs**, not their rate-limited API hosts, so nothing was gaining from the
serialization.

The matcher now takes an optional `candidate_hash_batch_fetcher` and resolves
the whole top-K in one pre-pass: one `get_many` against the cache, the misses
downloaded concurrently (8 workers) over one pooled `httpx.Client`, one
`set_many` back. `CoverHashUrlCache` holds one connection for its lifetime.
Scoring, `cover_hash_attempted` marking, ordering and the tiebreak are
untouched — only *when* the bytes arrive moved.

## 2. ComicVine rebuilt its client for every file

`_get_session` memoized on `self`, but `_build_active_online_sources` constructs
a source per `Comicbox` — i.e. per file. Every comic in a batch built a new
`Comicvine`: new requests session, new requests_cache sqlite handle, new
ratelimit-bucket handle. Metron solved this a while back with a
credential-keyed process-wide session cache; ComicVine now has the same one,
keyed by `(api_key, base_url)`, same first-build-wins contract and same
`warn_once` on a config mismatch.

**On the global guards:** `_maintained_cache_paths` and `_refreshed_cache_paths`
are now no-ops in the common case, but I kept both. They key on the **cache
path**, not the client — two different credential sets share one
`comicvine_cache.sqlite`, and `refresh_cache_unlink_once` also serves Metron.
Each is a single set lookup, so the cost of keeping them is nil and deleting
them would trade a correctness guard for tidiness.

## 3. The series cache never hit on a real library

`_series_fingerprint` keyed on `profile.year` — which is the **issue's** cover
year, not the series'. Any run spanning more than one calendar year minted a
fresh key per issue, so the series cache missed on exactly the batches it exists
to accelerate, and `OnlineSession`'s prompt-dedup cache re-prompted for a series
the user had already disambiguated. `tests/unit/test_series_cache.py` pinned the
year across both of its profiles, which is why nothing ever failed.

The key is now genuinely series-level. The cover year is dropped; two
series-level discriminators replace it:

- `volume` — the ordinal from "Vol. 2", already year-sanitized by
  `_resolve_volume` (4-digit values are rejected as mis-filed years).
- `series_start_year` — new on `ComicProfile`, read from
  `comicbox.series.start_year`. Sparse (Metron writes it, most embedded formats
  don't), so it discriminates when present and costs nothing when absent.

Same treatment for `_prompt_fingerprint` and for the filename clustering that
feeds them both.

**Residual risk, stated plainly:** two same-name, same-publisher runs where
neither file carries a volume ordinal or a start year now share a key. That
resolves rather than mis-tags — `_try_series_cache_lookup` falls back to the
full search when the cached volume has no such issue, and leaves the entry
intact.

**And the CLI got a series cache at all.** `Runner` had none, so
`comicbox --online` re-ran the full candidate search for every issue of a series
even inside one batch — the work `OnlineSession` has always skipped. It now
shares one across the batch (serial and `-j N`) and clusters its paths the same
way `tag_many` does. `SeriesCache` makes the first-writer claim a single locked
operation, because the thread pool is the first caller to share a cache across
threads and check-then-set would let two workers both claim a series and emit
two `SeriesIdentified` events.

## 4. Nothing bounded a search or a wait

CV's fan-out unions two capped discovery sets — so the volume list reaches 2x
the cap — and spends one or two `list_issues` calls per survivor: up to ~80
rate-limited calls for a single comic. `search()` now carries a per-search call
budget and deadline, resolved from the effort knob beside the existing pre-call
name filter, and reports what it skipped instead of truncating silently.
`thorough` stays unbounded, as its contract says.

Both are **pre-call** gates that decide whether to issue a call; neither looks at
a response. The effort/api-budget semantics are unchanged.

`retry.py` gains a total-wait ceiling. Our own schedules are bounded by
construction, but the server-hint path was not: `_MAX_RETRY_AFTER_S` caps *one*
honored `retry_after` at an hour and nothing capped the sum, so eight of them
could park a worker for most of a day. **I set the ceiling at 1h rather than
something tighter on purpose** — `_RATE_LIMIT_SCHEDULE`'s 8-attempt plateau tail
was tuned against the 2026-05-15-stress-100 `-j 8` cascade, and a 900s ceiling
would silently cut it to 4 attempts and undo that fix. There's a test asserting
the ceiling stays above the schedule's total so a future tightening can't do it
by accident. Lower it only with that regression in hand.

The cancellable sleep is now the **default** rather than an `OnlineSession`-only
opt-in, so a cancel reaches CLI users too. The per-instance `retry_sleep`
override still wins.

## Benchmarks

**Live A/B** — 10 calibration fixtures (Conan 2004, Lois Lane 2019, Watchmen
1986), `--max-per-search 5`. Methodology: the ComicVine **response** cache is
shared and warm across every run, so upstream latency and CV's 1/sec pacing are
held constant and identical on both sides; only `cover_hashes.sqlite` is wiped
before each run. That isolates exactly what changed.

| run | `develop` | this branch |
| --- | --------- | ----------- |
| 1 | 9.1s | 8.2s |
| 2 | 9.8s | 3.6s |
| 3 | 8.0s | 3.0s |
| 4 | 6.3s | 2.8s |
| 5 | 6.3s | 2.8s |
| **steady-state median (3–5)** | **6.3s** | **2.8s** — 2.2x |

Runs 1–2 include response-cache warm-in on both sides; 3–5 are steady state.

**Outcome parity** — every paired run compared on `top_issue_id`, `outcome`,
`n_candidates`, `api_call_counts` and `top_score` (to 1e-9):

```
baseline3 vs branch3: 20 outcomes -> IDENTICAL
baseline4 vs branch4: 20 outcomes -> IDENTICAL
baseline5 vs branch5: 20 outcomes -> IDENTICAL
tallies: {'correct': 6, 'no_expected_id': 10, 'wrong': 4} on both
```

**Cover-hash micro-benchmark** — deterministic, no network, 15-candidate top-K
at a 60ms simulated per-cover latency (conservative; real CDN GETs are slower):

| | serial | batched |
| --- | --- | --- |
| cold cache | 1043 ms | 143 ms — 7.3x |

**Deterministic counts** — same script run in both worktrees:

| | `develop` | this branch |
| --- | --- | --- |
| simyan clients built for 50 files | 50 | **1** |
| cold-path searches, 75 issues across 4 runs | 12 | **4** |
| `list_issues` cap per search (`balanced`) | unlimited (≤80) | **20** |
| worst-case wait for one call (server-hint path) | 8.0h | **1.0h** |

Per-series detail for row 2 — note Kabuki, where the cache was previously
useless:

```
Conan (2004)                   47 issues over 4y →  4 → 1 search
Lois Lane (2019)               12 issues over 2y →  2 → 1 search
Watchmen (1986)                12 issues over 2y →  2 → 1 search
Kabuki Library Edition (2015)   4 issues over 4y →  4 → 1 search  (0 → 3 cache hits)
```

**A caveat on scope:** I could not run a full cold-cache end-to-end A/B. The
warm-up pass hit ComicVine's 200/hr cap and a single fixture then sat in
rate-limit backoff for **450s and counting** on `develop` — with no ceiling to
stop it. That is itself the clearest evidence for the item-4 changes, but it
means the live table above measures the cover-hash path specifically rather than
a cold end-to-end run. The other three items are measured deterministically
instead, which is exact and reproducible without credentials.

## Also here

`tests/calibration/run.py` now drives the batch fetcher. Its `_hash_providers`
docstring promises "the production hashing path, just driven from the harness" —
leaving it pinned to the single-URL fetcher would have had it timing a path no
real run takes.

## Verification

`make fix`, `make lint`, `make ty` all clean; full suite **1913 passed, 1
skipped**. New coverage for the batch cache and fetch pool, CV shared-session
reuse and credential separation, fingerprint stability across cover years, the
CLI series-cache wiring and clustering, the CV per-search budget and deadline,
the retry wall-clock ceiling, and the interruptible default sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
