### PR TITLE
refactor(identifiers): define three shared identifier facts once

### DIFF
--- a/comicbox/enums/comicbox.py
+++ b/comicbox/enums/comicbox.py
@@ -29,7 +29,14 @@ class MangaEnum(Enum):
 
 
 class IdSources(Enum):
-    """Comic Database Namespace Identifiers."""
+    """
+    Comic Database Namespace Identifiers.
+
+    Declaration order is the best source ranking. Everything that must pick
+    one source derives its order from this list: ID_SOURCE_VALUES and
+    ranked_id_sources() in comicbox.identifiers, and compare_identifier_source
+    below.
+    """
 
     # Comic DBs
     METRON = "metron"

--- a/comicbox/formats/base/transforms/identifiers.py
+++ b/comicbox/formats/base/transforms/identifiers.py
@@ -12,7 +12,7 @@ from comicbox.formats.comicbox.schema import (
     PRIMARY_ID_SOURCE_KEY,
     URLS_KEY,
 )
-from comicbox.identifiers import ID_KEY_KEY, ID_TYPE_KEY
+from comicbox.identifiers import ID_KEY_KEY, ID_TYPE_KEY, ranked_id_sources
 from comicbox.identifiers.identifiers import (
     IDENTIFIER_PARTS_MAP,
     create_identifier,
@@ -73,13 +73,13 @@ def identifiers_transform_to_cb(
 
 def _identifier_from_cb(comicbox_identifiers: dict[str, dict[str, str]]) -> str:
     """Unparse the best identifier to a single urn string."""
-    for id_source in IdSources:
+    for id_source_str in ranked_id_sources(comicbox_identifiers):
         if (
-            (comicbox_identifier := comicbox_identifiers.get(id_source.value))
+            (comicbox_identifier := comicbox_identifiers.get(id_source_str))
             and (id_key := comicbox_identifier.get(ID_KEY_KEY))
             and (
                 urn_str := to_urn_string(
-                    id_source.value, comicbox_identifier.get(ID_TYPE_KEY, ""), id_key
+                    id_source_str, comicbox_identifier.get(ID_TYPE_KEY, ""), id_key
                 )
             )
         ):
@@ -111,11 +111,9 @@ def identifier_from_url(url_str: str) -> tuple[str, dict]:
     if not url_str:
         return "", {}
     id_source_str = get_id_source_from_url(url_str)
-    try:
-        id_source = IdSources(id_source_str)
-    except ValueError:
+    if not id_source_str:
         return "", {}
-    id_parts = IDENTIFIER_PARTS_MAP.get(id_source)
+    id_parts = IDENTIFIER_PARTS_MAP.get(IdSources(id_source_str))
     if not id_parts:
         return "", {}
     id_type, id_key = id_parts.parse_url_path(url_str)

--- a/comicbox/formats/comic_info/transform/identifiers.py
+++ b/comicbox/formats/comic_info/transform/identifiers.py
@@ -13,13 +13,12 @@ from comicbox.enums.comicbox import IdSources
 from comicbox.formats.base.transforms.spec import MetaSpec
 from comicbox.formats.comic_info.schema import GTIN_TAG
 from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY
-from comicbox.identifiers import ID_KEY_KEY
+from comicbox.identifiers import BARCODE_ID_SOURCES, ID_KEY_KEY
 from comicbox.identifiers.identifiers import create_identifier
 from comicbox.identifiers.urns import parse_string_identifier
 
 # A GTIN-13 or GTIN-14 barcode is all digits; an ISBN may carry hyphens and a
 # trailing X check digit. Comicbox records the one it looks like.
-_GTIN_ID_SOURCES = (IdSources.ISBN, IdSources.UPC, IdSources.GTIN)
 _ISBN_LENGTHS = frozenset({10, 13})
 
 
@@ -70,7 +69,7 @@ def _to_cb(cix_gtin: Any) -> dict:
 
 def _from_cb(comicbox_identifiers: dict[str, dict[str, str]]) -> str:
     """Write only a real barcode, never a database id."""
-    for id_source in _GTIN_ID_SOURCES:
+    for id_source in BARCODE_ID_SOURCES:
         identifier = comicbox_identifiers.get(id_source.value)
         if identifier and (id_key := identifier.get(ID_KEY_KEY)):
             return id_key

--- a/comicbox/formats/metron_info/transform/identifiers.py
+++ b/comicbox/formats/metron_info/transform/identifiers.py
@@ -20,7 +20,13 @@ from comicbox.formats.comicbox.schema import (
     URLS_KEY,
 )
 from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
-from comicbox.identifiers import DEFAULT_ID_TYPE, ID_KEY_KEY, ID_TYPE_KEY
+from comicbox.identifiers import (
+    BARCODE_ID_SOURCES,
+    DEFAULT_ID_TYPE,
+    ID_KEY_KEY,
+    ID_TYPE_KEY,
+    ranked_id_sources,
+)
 from comicbox.identifiers.identifiers import (
     create_identifier,
     get_id_source_from_url,
@@ -29,8 +35,14 @@ from comicbox.identifiers.identifiers import (
 
 PRIMARY_ATTRIBUTE = "@primary"
 SOURCE_ATTRIBUTE = "@source"
+# MetronInfo's <GTIN> holds only ISBN and UPC subtags, never the generic
+# GTIN, and its subtag names are the IdSources member names.
 GTIN_SUBTAG_ID_SOURCE_MAP = MappingProxyType(
-    {"ISBN": IdSources.ISBN.value, "UPC": IdSources.UPC.value}
+    {
+        id_source.name: id_source.value
+        for id_source in BARCODE_ID_SOURCES
+        if id_source is not IdSources.GTIN
+    }
 )
 ID_KEYPATH = "IDS.ID"
 URL_KEYPATH = "URLs.URL"
@@ -60,21 +72,12 @@ def _primary_id_source_from_ids(metron_ids: list[Any]) -> str | None:
     return None
 
 
-def get_url_id_source(url: str) -> str:
-    """Name the database a url belongs to, if comicbox knows it."""
-    # Matching only each source's canonical domain missed the other domains
-    # they answer on, like comicvine.com or the ten amazon country domains.
-    with suppress(ValueError):
-        return IdSources(get_id_source_from_url(url)).value
-    return ""
-
-
 def _primary_id_source_from_urls(metron_urls: list[Any]) -> str | None:
     for metron_url in metron_urls:
         if not is_item_primary(metron_url):
             continue
         if (url := get_cdata(metron_url)) and (
-            id_source_str := get_url_id_source(str(url))
+            id_source_str := get_id_source_from_url(str(url))
         ):
             return id_source_str
     return None
@@ -183,10 +186,8 @@ def _primary_index(candidates: list[str], primary_id_source_str: str) -> int:
     """
     if primary_id_source_str in candidates:
         return candidates.index(primary_id_source_str)
-    ranked = [id_source.value for id_source in IdSources]
-    for id_source_str in ranked:
-        if id_source_str in candidates:
-            return candidates.index(id_source_str)
+    if best_id_source_str := next(ranked_id_sources(candidates), ""):
+        return candidates.index(best_id_source_str)
     return 0
 
 
@@ -268,7 +269,7 @@ def _urls_from_cb(values: dict[str, Any]) -> list:
     primary_id_source_str = values.get(PRIMARY_ID_SOURCE_KEYPATH, DEFAULT_ID_SOURCE_STR)
     url_list = list(urls)
     url_sources = [
-        id_source_by_url.get(url) or get_url_id_source(url) for url in url_list
+        id_source_by_url.get(url) or get_id_source_from_url(url) for url in url_list
     ]
     index = _primary_index(url_sources, primary_id_source_str)
     metron_urls: list[dict[str, Any]] = [{"#text": url} for url in url_list]

--- a/comicbox/identifiers/__init__.py
+++ b/comicbox/identifiers/__init__.py
@@ -1,16 +1,32 @@
 """Identifier consts."""
 
 import re
+from collections.abc import Container, Iterator
 
 from comicbox.enums.comicbox import AlternateIdSources, IdSources
 
+# Ordered best source first, because IdSources declares them that way.
 ID_SOURCE_VALUES = tuple(id_source.value for id_source in IdSources)
 DEFAULT_ID_SOURCE = IdSources.COMICVINE
 DEFAULT_ID_TYPE = "issue"
 
+# The GTIN family: sources that are a barcode rather than a database id.
+# Ordered by write preference for a format with a single barcode tag: ISBN
+# first as the most specific, the generic GTIN last.
+BARCODE_ID_SOURCES = (IdSources.ISBN, IdSources.UPC, IdSources.GTIN)
+
 # Field names inside the comicbox identifier dict shape.
 ID_KEY_KEY = "key"
 ID_TYPE_KEY = "id_type"
+
+
+def ranked_id_sources(candidates: Container[str]) -> Iterator[str]:
+    """Yield the id source values in candidates, best ranked source first."""
+    return (
+        id_source_str
+        for id_source_str in ID_SOURCE_VALUES
+        if id_source_str in candidates
+    )
 
 
 _ALTERNATE_ID_SOURCES = tuple(id_source.value for id_source in AlternateIdSources)

--- a/comicbox/identifiers/identifiers.py
+++ b/comicbox/identifiers/identifiers.py
@@ -369,7 +369,12 @@ def create_identifier(
 
 
 def get_id_source_from_url(url: str) -> str:
-    """Parse the id source for a url."""
+    """
+    Name the database a url belongs to, or "" for one comicbox doesn't know.
+
+    Matches every domain a source answers on, like comicvine.com or the ten
+    amazon country domains, not just its canonical one.
+    """
     obj = urlparse(url)
     # The hostname, not the netloc: it is lowercased and carries neither the
     # port nor the userinfo, so metron.cloud:443 and Metron.Cloud both name
@@ -379,12 +384,10 @@ def get_id_source_from_url(url: str) -> str:
 
     parts.reverse()
     node = SOURCE_ALIAS_TREE
-    id_source_str = hostname
     for part in parts:
         node = node.get(part)
         if isinstance(node, IdSources):
-            id_source_str = node.value
-            break
+            return node.value
         if not node:
             break
-    return id_source_str
+    return ""

--- a/tests/unit/test_identifiers.py
+++ b/tests/unit/test_identifiers.py
@@ -286,11 +286,16 @@ def test_metron_url_path_strips_trailing_slash() -> None:
     )
 
 
-def test_get_id_source_from_url_unknown_domain_returns_hostname() -> None:
-    """An unrecognized domain falls back to returning the hostname itself."""
-    assert get_id_source_from_url("https://example.com/foo") == "example.com"
-    # The hostname is lowercased, so the fallback is too.
-    assert get_id_source_from_url("https://Example.COM/foo") == "example.com"
+def test_get_id_source_from_url_unknown_domain_names_nothing() -> None:
+    """
+    An unrecognized domain names no source.
+
+    It used to return the hostname itself, but a hostname is not a source:
+    every caller threw that result away, and inventing a source from it only
+    produced keys nothing could look up.
+    """
+    assert get_id_source_from_url("https://example.com/foo") == ""
+    assert get_id_source_from_url("https://Example.COM/foo") == ""
 
 
 def test_get_id_source_from_url_ignores_port_case_and_userinfo() -> None:

--- a/tests/unit/test_single_valued_tags.py
+++ b/tests/unit/test_single_valued_tags.py
@@ -28,6 +28,10 @@ def _comet_to_cb(native: dict[str, Any]) -> dict:
     return dict(_COMET.to_comicbox(loaded).get("comicbox", {}))
 
 
+def _comet_from_cb(sub_md: dict[str, Any]) -> dict:
+    return dict(_COMET.from_comicbox({"comicbox": sub_md}).get("comet", {}))
+
+
 def test_main_character_or_team_is_one_name() -> None:
     """A protagonist with a comma in their name is not two characters."""
     sub_md = _cix_to_cb({"MainCharacterOrTeam": "Hank McCoy, Beast"})
@@ -87,6 +91,24 @@ def test_comet_identifier_is_one_value() -> None:
     """CoMet's identifier is maxOccurs=1, so it is read whole."""
     sub_md = _comet_to_cb({"identifier": "urn:comicvine:issue:145269"})
     assert sub_md["identifiers"]["comicvine"]["key"] == "145269"
+
+
+def test_comet_identifier_writes_the_best_ranked_source() -> None:
+    """
+    One tag, many ids: the best ranked source wins.
+
+    Rank is IdSources declaration order, where metron precedes comicvine.
+    """
+    comet = _comet_from_cb(
+        {
+            "identifiers": {
+                "comicvine": {"key": "145269", "id_type": "issue"},
+                "metron": {"key": "99999", "id_type": "issue"},
+            }
+        }
+    )
+    # The issue type is the default, so the urn leaves it implicit.
+    assert comet["identifier"] == "urn:metron:99999"
 
 
 def test_comet_is_version_of_is_one_value() -> None:


### PR DESCRIPTION
Survey item D4 proposed folding "~600 near-parallel lines across seven `identifiers.py` files" into one table driven off `IDENTIFIER_PARTS_MAP`. Verifying that first changed the shape of the work, so this PR is the rescoped version — see below.

## What the premise turned out to be

Four of the seven files named `identifiers.py` are unrelated concerns (Marshmallow schemas, enum maps, the computed pipeline). The three real transform modules differ on inherent format semantics, not copy-paste: ComicInfo infers a barcode's kind from its shape, MetronInfo carries the source in an XML attribute and owns all the primary-flag machinery, CoMet parses a urn prefix. A single table would have needed ~10 parameter axes, five of them used by exactly one format, to remove ~30 lines of genuinely shared code. The bulk consolidation had already landed in V4 alpha (#136), which is where the "seven files" count came from.

What is real is that **three facts were each written out in two or three places** — the reason 12e9cba had to land the same fix in three files at once. This PR makes each of them land once.

## The three facts

**Best source wins.** Rank is `IdSources` declaration order. Both scan loops rebuilt it independently: `_identifier_from_cb` in the base transform and `_primary_index` in MetronInfo. They now share `ranked_id_sources()`.

It yields rather than returning a single winner, deliberately: `_identifier_from_cb` falls through to the next-ranked source when a key can't form a legal urn, while `_primary_index` commits to the first source present. A `best_id_source()` would have quietly changed the first — a book whose top-ranked key contained a `/` would have written no identifier at all instead of the runner-up's.

**Which sources are barcodes.** `BARCODE_ID_SOURCES` replaces ComicInfo's `_GTIN_ID_SOURCES`, and MetronInfo's `GTIN_SUBTAG_ID_SOURCE_MAP` now derives from it (subtag names are the enum member names) rather than restating it in a second shape. Derived insertion order is ISBN, UPC — identical to the literal it replaces, so reads, `<IDS>` exclusion and `<GTIN>` writes are unchanged.

**Which database a url belongs to.** `get_id_source_from_url` now returns `""` for an unrecognized domain instead of the hostname. Both production callers already threw a non-source result away behind the same `IdSources(...)`/`ValueError` guard, so the fallback was dead; MetronInfo's `get_url_id_source` wrapper is gone.

## No behavior change

Both scan loops were checked old-form against new-form over ~32k inputs — every ordered source pair crossed with keys that fail `to_urn_string` (slashes, spaces), empty keys, unknown and default id types, and candidate lists containing `""` and unknown sources. Identical throughout.

The one unit-visible change is the unknown-domain expectation in `tests/unit/test_identifiers.py`, updated in the same commit. Added a CoMet write-side ranking test, which nothing covered before.

No NEWS entry: nothing a user can observe changed.

## Verification

`make fix`, `make lint` (0 type errors, vulture and complexipy clean), `make ty`, and the full suite: **1988 passed, 1 skipped**, 91% coverage. The one radon rank-C item in the touched MetronInfo file (`_urls_from_cb`) was rank C before this change too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)