### PR TITLE
Fail loudly on colliding MetaSpec destinations; compile the scope channel in two phases

### DIFF
--- a/comicbox/formats/base/transforms/spec.py
+++ b/comicbox/formats/base/transforms/spec.py
@@ -1,9 +1,32 @@
-"""Transform maps."""
+"""
+Transform maps.
+
+A `MetaSpec` maps destination keypaths to source keypaths. `_create_specs`
+compiles a set of them into one glom spec in two phases, and refuses to compile
+a set whose declarations contradict each other.
+
+Destination keyspace: a compile owns its destinations. Two metaspecs claiming
+the same keypath, or one claiming a keypath nested inside another's, raise at
+import. glom's `assign` used to resolve those silently -- the later mapping won
+the value at the earlier one's slot, and a nested pair either lost the whole
+subtree or was set as an *attribute* of the enclosing spec and never reached the
+output.
+
+Scope channel: a metaspec with `assign_global` publishes its spec function's
+result into glom's per call globals, and other metaspecs read it back by naming
+`S.globals.comicbox.<key>` among their sources. glom evaluates a compiled dict
+in key insertion order, so phase one compiles the producers and phase two
+everything else. Declaration order no longer decides whether a read resolves.
+Only one producer per compile: a second publish replaces the whole scope
+mapping. Readers still supply their own default, because publishing happens at
+runtime over data that may hold nothing; the compile only proves a producer
+exists.
+"""
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NoReturn
 
 from glom import SKIP, A, Coalesce, Path, S, T, Val, assign
 
@@ -11,6 +34,7 @@ from comicbox.constants import ROOT_KEYPATH
 from comicbox.empty import is_empty
 
 GLOBAL_SCOPE_PREFIX = "S.globals.comicbox"
+_GLOBAL_SCOPE_PREFIX_PARTS = 3
 
 
 @dataclass
@@ -20,7 +44,164 @@ class MetaSpec:
     key_map: Mapping[str, str | tuple[str, ...]]
     spec: Callable | tuple | None = None
     inherit_root_keypath: bool = True
+    # Publish this mapping's result on the scope channel. See the module docstring.
     assign_global: bool = False
+
+
+_IndexedMetaSpec = tuple[int, MetaSpec]
+
+
+def _metaspec_label(index: int) -> str:
+    return f"metaspec[{index}]"
+
+
+def _roots_label(dest_root_keypath: str, source_root_keypath: str) -> str:
+    """Name the compile a declaration error came from."""
+    source = source_root_keypath or "(root)"
+    dest = dest_root_keypath or "(root)"
+    return f"{source} -> {dest}"
+
+
+class _ScopeChannel:
+    """The scope channel one compile declares."""
+
+    def __init__(self, roots_label: str) -> None:
+        """Start an empty channel for one compile."""
+        self._roots_label = roots_label
+        self._published: list[tuple[int, str]] = []
+        self._reads: list[tuple[int, str]] = []
+
+    def _raise(self, detail: str) -> NoReturn:
+        reason = f"MetaSpec scope error compiling {self._roots_label}: {detail}"
+        raise RuntimeError(reason)
+
+    def _read_tails(
+        self, index: int, source_keypaths: str | tuple[str, ...]
+    ) -> tuple[str, ...]:
+        """Return the scope keys one key map entry reads."""
+        if not isinstance(source_keypaths, tuple | list):
+            if source_keypaths.startswith(GLOBAL_SCOPE_PREFIX):
+                self._raise(
+                    f"{_metaspec_label(index)} reads {source_keypaths!r} as its only"
+                    " source. Only a tuple of sources reads the scope. A lone one"
+                    " compiles to a data path under the source root and never matches."
+                )
+            return ()
+        return tuple(
+            ".".join(Path.from_text(keypath).values()[_GLOBAL_SCOPE_PREFIX_PARTS:])
+            for keypath in source_keypaths
+            if keypath.startswith(GLOBAL_SCOPE_PREFIX)
+        )
+
+    def _add_producer(
+        self, index: int, metaspec: MetaSpec, reads: tuple[str, ...]
+    ) -> None:
+        if reads:
+            self._raise(
+                f"{_metaspec_label(index)} publishes to the scope and also reads"
+                f" {reads[0]!r} from it, but its read is evaluated first."
+            )
+        for dest in metaspec.key_map:
+            if "." in dest:
+                self._raise(
+                    f"{_metaspec_label(index)} publishes the dotted destination"
+                    f" {dest!r}. A producer publishes under one literal key while"
+                    " readers descend the path a part at a time, so no read could"
+                    " ever match it."
+                )
+            self._published.append((index, dest))
+
+    def add(self, index: int, metaspec: MetaSpec) -> None:
+        """Record what one metaspec publishes to and reads from the scope."""
+        reads = tuple(
+            tail
+            for source_keypaths in metaspec.key_map.values()
+            for tail in self._read_tails(index, source_keypaths)
+        )
+        if metaspec.assign_global:
+            self._add_producer(index, metaspec, reads)
+        self._reads.extend((index, tail) for tail in reads)
+
+    def validate(self) -> None:
+        """Check that one producer publishes every key that is read."""
+        if len(self._published) > 1:
+            publishers = ", ".join(
+                f"{_metaspec_label(index)} -> {dest!r}"
+                for index, dest in self._published
+            )
+            self._raise(
+                "only one destination may publish to the scope, because a second"
+                f" publish replaces the whole scope mapping, but {publishers} do."
+            )
+        published_keys = {dest for _, dest in self._published}
+        for index, tail in self._reads:
+            if tail not in published_keys:
+                self._raise(
+                    f"{_metaspec_label(index)} reads {GLOBAL_SCOPE_PREFIX}.{tail} but"
+                    " no metaspec in this compile publishes it, so the read would"
+                    " silently fall back to the spec function's own default."
+                )
+
+
+def _validate_scope_channel(
+    indexed_metaspecs: tuple[_IndexedMetaSpec, ...], roots_label: str
+) -> None:
+    """Refuse to compile a scope channel that cannot resolve."""
+    channel = _ScopeChannel(roots_label)
+    for index, metaspec in indexed_metaspecs:
+        channel.add(index, metaspec)
+    channel.validate()
+
+
+def _partition_metaspecs(
+    indexed_metaspecs: tuple[_IndexedMetaSpec, ...],
+) -> tuple[_IndexedMetaSpec, ...]:
+    """Order scope producers ahead of everything that might read them."""
+    producers = tuple(pair for pair in indexed_metaspecs if pair[1].assign_global)
+    consumers = tuple(pair for pair in indexed_metaspecs if not pair[1].assign_global)
+    return producers + consumers
+
+
+def _dest_prefixes(keypath: str) -> tuple[str, ...]:
+    """Return every keypath a destination nests inside."""
+    parts = keypath.split(".")
+    return tuple(".".join(parts[:index]) for index in range(1, len(parts)))
+
+
+class _DestKeyspace:
+    """The destination keypaths one compile has claimed."""
+
+    def __init__(self, roots_label: str) -> None:
+        """Start an empty keyspace for one compile."""
+        self._roots_label = roots_label
+        self._leaves: dict[str, str] = {}
+        self._branches: dict[str, str] = {}
+
+    def _find_conflict(self, keypath: str) -> tuple[str, str] | None:
+        """Return the claimed keypath this one collides with, and how."""
+        if keypath in self._leaves:
+            return keypath, "is already claimed by"
+        if enclosed := self._branches.get(keypath):
+            return enclosed, "encloses"
+        for prefix in _dest_prefixes(keypath):
+            if prefix in self._leaves:
+                return prefix, "nests inside"
+        return None
+
+    def claim(self, keypath: str, claimant: str) -> None:
+        """Record a destination, refusing one that collides with an earlier one."""
+        if conflict := self._find_conflict(keypath):
+            other_keypath, relation = conflict
+            reason = (
+                f"MetaSpec destination collision compiling {self._roots_label}:"
+                f" {claimant} -> {keypath!r} {relation} {other_keypath!r} from"
+                f" {self._leaves[other_keypath]}. One of them would be silently"
+                " discarded. Give them distinct destinations."
+            )
+            raise RuntimeError(reason)
+        self._leaves[keypath] = claimant
+        for prefix in _dest_prefixes(keypath):
+            self._branches.setdefault(prefix, keypath)
 
 
 def _path_str_from_tuple(head_keypath: str, tail_keypath: str) -> str:
@@ -40,7 +221,7 @@ def _get_multi_values_spec(
     if keypath.startswith(GLOBAL_SCOPE_PREFIX):
         tail_path_parts = tail_path.values()
         path = S.globals.comicbox
-        for part in tail_path_parts[3:]:
+        for part in tail_path_parts[_GLOBAL_SCOPE_PREFIX_PARTS:]:
             path = path[part]
     else:
         if source_root_path:
@@ -120,8 +301,12 @@ def _create_specs(
     source_root_keypath: str = "",
 ) -> MappingProxyType[str, Any]:
     """Create spec from metaspec map."""
+    roots_label = _roots_label(dest_root_keypath, source_root_keypath)
+    indexed_metaspecs = tuple(enumerate(args))
+    _validate_scope_channel(indexed_metaspecs, roots_label)
+    keyspace = _DestKeyspace(roots_label)
     specs = {}
-    for metaspec in args:
+    for index, metaspec in _partition_metaspecs(indexed_metaspecs):
         dest_head, source_head = (
             (dest_root_keypath, source_root_keypath)
             if metaspec.inherit_root_keypath and dest_root_keypath
@@ -136,6 +321,8 @@ def _create_specs(
                 source_keypaths,
             )
             if full_dest_keypath and spec:
+                claimant = f"{_metaspec_label(index)} key_map[{dest_keypath!r}]"
+                keyspace.claim(full_dest_keypath, claimant)
                 # Have to to double assign when assigning actual glom structures
                 # They get evaluated or something.
                 # But it's in the spec creator so not a huge deal.

--- a/comicbox/formats/metron_info/transform/__init__.py
+++ b/comicbox/formats/metron_info/transform/__init__.py
@@ -92,7 +92,7 @@ class MetronInfoTransform(BaseTransform):
     SCHEMA_CLASS = MetronInfoSchema
     SPECS_TO = create_specs_to_comicbox(
         MetaSpec(key_map=SIMPLE_KEY_MAP.inverse),
-        METRON_PRIMARY_SOURCE_KEY_TRANSFORM_TO_CB,  # must come before most other resources
+        METRON_PRIMARY_SOURCE_KEY_TRANSFORM_TO_CB,
         METRON_ARCS_TRANSFORM_TO_CB,
         METRON_COMMUNITY_RATING_TRANSFORM_TO_CB,
         METRON_CREDITS_TRANSFORM_TO_CB,

--- a/tests/unit/test_transform_spec_dest_collisions.py
+++ b/tests/unit/test_transform_spec_dest_collisions.py
@@ -1,0 +1,98 @@
+"""
+Two mappings may not claim the same destination keypath.
+
+`_create_specs` plants every destination with glom's ``assign``, which resolved
+a collision silently: the later mapping won the value but kept the earlier
+one's insertion slot, so one of the two declarations simply stopped existing.
+Nesting was worse. Claiming ``a`` after ``a.b`` replaced the whole subtree, and
+claiming ``a.b`` after ``a`` set the nested spec as an *attribute* of the
+enclosing ``Coalesce`` object, where nothing ever read it. Across 82 metaspecs
+no one can see that keyspace, so the compiler has to.
+"""
+
+from __future__ import annotations
+
+import pytest
+from glom import glom
+
+from comicbox.formats.base.transforms.spec import MetaSpec, create_specs_to_comicbox
+
+
+def _compile(*metaspecs: MetaSpec, root: str = ""):
+    return create_specs_to_comicbox(*metaspecs, comicbox_root_keypath=root)
+
+
+def test_exact_duplicate_dest_raises() -> None:
+    with pytest.raises(RuntimeError, match="is already claimed by"):
+        _compile(
+            MetaSpec(key_map={"dest": "one"}),
+            MetaSpec(key_map={"dest": "two"}),
+        )
+
+
+def test_leaf_then_nested_dest_raises() -> None:
+    """`a` first: the nested spec would be setattr'd onto it and vanish."""
+    with pytest.raises(RuntimeError, match="nests inside"):
+        _compile(
+            MetaSpec(key_map={"a": "one"}),
+            MetaSpec(key_map={"a.b": "two"}),
+        )
+
+
+def test_nested_then_leaf_dest_raises() -> None:
+    """`a.b` first: assigning `a` would replace the whole subtree."""
+    with pytest.raises(RuntimeError, match="encloses"):
+        _compile(
+            MetaSpec(key_map={"a.b": "one"}),
+            MetaSpec(key_map={"a": "two"}),
+        )
+
+
+def test_duplicate_within_one_key_map_raises() -> None:
+    """A key map can't hold the same key twice, but it can nest into itself."""
+    with pytest.raises(RuntimeError, match="nests inside"):
+        _compile(MetaSpec(key_map={"a": "one", "a.b": "two"}))
+
+
+def test_sibling_nested_dests_compile_and_run() -> None:
+    """Siblings share a branch without claiming it. Both must survive."""
+    specs = _compile(
+        MetaSpec(key_map={"series.name": "name"}),
+        MetaSpec(key_map={"series.volume": "volume"}),
+    )
+    assert glom({"name": "Bat", "volume": 2}, dict(specs)) == {
+        "series": {"name": "Bat", "volume": 2}
+    }
+
+
+def test_same_dest_in_separate_compiles_is_fine() -> None:
+    """Every compile owns its own keyspace. SPECS_TO and SPECS_FROM are two."""
+    assert _compile(MetaSpec(key_map={"dest": "one"}))
+    assert _compile(MetaSpec(key_map={"dest": "two"}))
+
+
+def test_collision_across_root_inheritance_is_caught() -> None:
+    """A rooted dest and a spelled out one address the same key."""
+    with pytest.raises(RuntimeError, match="is already claimed by"):
+        _compile(
+            MetaSpec(key_map={"dest": "one"}),
+            MetaSpec(key_map={"comicbox.dest": "two"}, inherit_root_keypath=False),
+            root="comicbox",
+        )
+
+
+def test_error_names_both_claimants_and_the_compile() -> None:
+    """The keyspace is invisible, so the error has to say where to look."""
+    with pytest.raises(RuntimeError) as exc_info:
+        create_specs_to_comicbox(
+            MetaSpec(key_map={"other": "zero"}),
+            MetaSpec(key_map={"dest": "one"}),
+            MetaSpec(key_map={"dest": "two"}),
+            format_root_keypath="MetronInfo",
+            comicbox_root_keypath="comicbox",
+        )
+    reason = str(exc_info.value)
+    assert "MetronInfo -> comicbox" in reason
+    assert "metaspec[1]" in reason
+    assert "metaspec[2]" in reason
+    assert "comicbox.dest" in reason

--- a/tests/unit/test_transform_spec_scope_phases.py
+++ b/tests/unit/test_transform_spec_scope_phases.py
@@ -1,0 +1,126 @@
+"""
+The scope channel resolves by compile phase, not by argument order.
+
+A metaspec with `assign_global` publishes its result into glom's per call
+globals and others read it back as `S.globals.comicbox.<key>`. glom evaluates
+the compiled dict in key insertion order, so a reader compiled ahead of the
+producer read nothing and fell through to its own default -- no error, no log,
+just the wrong id source on every tag in the file. The whole contract was one
+comment reading "must come before most other resources". Now the compiler
+plants producers in phase one and everything else in phase two, and refuses a
+channel that could not resolve at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from glom import glom
+
+from comicbox.formats.base.transforms.spec import (
+    GLOBAL_SCOPE_PREFIX,
+    MetaSpec,
+    create_specs_to_comicbox,
+)
+
+SCOPE_PID = f"{GLOBAL_SCOPE_PREFIX}.pid"
+FALLBACK = "THE-FALLBACK"
+
+
+def _publish(values: dict[str, Any]) -> dict[str, Any] | None:
+    """Publish the id source the file named, the way metron's producer does."""
+    if id_source := values.get("id"):
+        return {"pid": id_source}
+    return None
+
+
+def _read(values: dict[str, Any]) -> str:
+    """Read the published id source, or fall back the way ~15 call sites do."""
+    return values.get(SCOPE_PID, FALLBACK)
+
+
+def _producer(**kwargs: Any) -> MetaSpec:
+    return MetaSpec(
+        key_map={"pid": ("id",)}, spec=_publish, assign_global=True, **kwargs
+    )
+
+
+def _reader() -> MetaSpec:
+    return MetaSpec(key_map={"out": ("name", SCOPE_PID)}, spec=_read)
+
+
+def _compile(*metaspecs: MetaSpec):
+    return create_specs_to_comicbox(*metaspecs, comicbox_root_keypath="")
+
+
+def test_reader_declared_before_producer_still_reads() -> None:
+    """The regression test for the deleted ordering comment."""
+    specs = _compile(_reader(), _producer())
+    assert glom({"id": "metron", "name": "Bat"}, dict(specs))["out"] == "metron"
+
+
+def test_producer_declared_first_reads_the_same() -> None:
+    specs = _compile(_producer(), _reader())
+    assert glom({"id": "metron", "name": "Bat"}, dict(specs))["out"] == "metron"
+
+
+def test_runtime_missing_value_still_falls_back() -> None:
+    """Compile time strictness must not tighten runtime. A file may name none."""
+    specs = _compile(_reader(), _producer())
+    assert glom({"name": "Bat"}, dict(specs))["out"] == FALLBACK
+
+
+def test_scope_read_without_a_producer_raises() -> None:
+    with pytest.raises(RuntimeError, match="no metaspec in this compile publishes"):
+        _compile(_reader())
+
+
+def test_two_producing_metaspecs_raise() -> None:
+    """A second publish replaces the whole scope mapping."""
+    with pytest.raises(RuntimeError, match="only one destination may publish"):
+        _compile(
+            _producer(),
+            MetaSpec(key_map={"other": ("id",)}, spec=_publish, assign_global=True),
+            _reader(),
+        )
+
+
+def test_one_producer_with_two_destinations_raises() -> None:
+    with pytest.raises(RuntimeError, match="only one destination may publish"):
+        _compile(
+            MetaSpec(
+                key_map={"pid": ("id",), "other": ("id",)},
+                spec=_publish,
+                assign_global=True,
+            ),
+            _reader(),
+        )
+
+
+def test_producer_reading_the_scope_raises() -> None:
+    """Its own read is evaluated before its publish."""
+    with pytest.raises(RuntimeError, match="also reads"):
+        _compile(
+            MetaSpec(
+                key_map={"pid": ("id", SCOPE_PID)}, spec=_publish, assign_global=True
+            )
+        )
+
+
+def test_dotted_producer_destination_raises() -> None:
+    """`T['a.b']` is one literal key. A reader descends `['a']['b']`."""
+    with pytest.raises(RuntimeError, match="dotted destination"):
+        _compile(
+            MetaSpec(key_map={"a.pid": ("id",)}, spec=_publish, assign_global=True)
+        )
+
+
+def test_lone_string_scope_source_raises() -> None:
+    """Alone it compiles to a data path under the source root and never matches."""
+    with pytest.raises(RuntimeError, match="as its only source"):
+        _compile(_producer(), MetaSpec(key_map={"out": SCOPE_PID}, spec=_read))
+
+
+def test_a_producer_no_one_reads_is_allowed() -> None:
+    assert glom({"id": "metron"}, dict(_compile(_producer())))["pid"] == "metron"


### PR DESCRIPTION
## Context

The MetaSpec compiler plants every destination keypath with glom's `assign`, which resolved a collision silently. Verified against the current tree, all three modes lose a declaration outright:

| declaration | compiled result |
| --- | --- |
| `{'d': 'one'}` + `{'d': 'two'}` | `{'d': 2}` |
| `{'a': 'one'}` + `{'a.b': 'two'}` | `{'a': 1}` |
| `{'a.b': 'one'}` + `{'a': 'two'}` | `{'a': 2}` |

The last is the worst: glom's `assign` falls back to `setattr`, so the nested spec is set as an *attribute* of the enclosing `Coalesce` object and never reaches the output at all.

Across 82 metaspecs in 26 modules, compiled into 20 spec sets holding 318 destinations, that keyspace is not something a human can hold. **The audit found zero collisions today**, so this is a guardrail, not a bug fix — nothing changes for a caller that was already correct.

## Destination collisions raise

A compile owns its destinations. A duplicate or a nested pair raises `RuntimeError` at import, the same failure model as `_validate_registrations()`:

```
MetaSpec destination collision compiling MetronInfo -> comicbox: metaspec[2]
key_map['dest'] -> 'comicbox.dest' is already claimed by metaspec[1]
key_map['dest']. One of them would be silently discarded. Give them distinct
destinations.
```

Both claimants and the compile they belong to are named, because with 20 compiles neither alone locates the mistake.

## The scope channel is two-phase instead of order-dependent

A metaspec with `assign_global` publishes into glom's per-call globals and 15 others read it back. glom evaluates the compiled dict in key insertion order, so the entire contract was argument order plus one comment:

```python
METRON_PRIMARY_SOURCE_KEY_TRANSFORM_TO_CB,  # must come before most other resources
```

Declare the producer after a reader and every reader falls through to its own default — no error, no log, wrong id source on every tag in the file. Since #177 made those fallbacks reachable, that path is live, which is exactly what would mask the mistake.

Producers now compile in phase one and everything else in phase two, so the read resolves however the arguments are ordered. The comment is deleted; a test holds the contract instead. Verified both ways — with the partition disabled a reader declared first gets `THE-FALLBACK`, with it enabled it gets the published value.

Compiling also now refuses a channel that could never resolve: a read with no producer, a second producer (a second publish *replaces* the whole scope mapping rather than merging into it), a producer that reads the scope it publishes, a dotted producer destination, and a lone-string scope source, which compiles to a data path under the source root and never matches.

**Runtime is untouched.** A file that names no primary source still reaches every reader's default; the compile only proves a producer was declared.

## Notes

- No NEWS entry: per `news.md` these are user-facing headlines, and this has no user-visible effect. MetronInfo output is unchanged — the producer merely moves from insertion position 9 to 0, and both transform directions pass through marshmallow `load`, which rebuilds in field-declaration order.
- No new exception type. `comicbox/exceptions.py` scopes `ComicboxError` to operational errors and explicitly excludes programming errors; this is the latter, and nothing should catch it.

## Verification

`make fix`, `make lint`, `make ty`, `make complexity` all clean; `make test` 2005 passed, 1 pre-existing skip. 18 new tests in `tests/unit/test_transform_spec_dest_collisions.py` and `tests/unit/test_transform_spec_scope_phases.py`. The full suite imports `comicbox.formats`, so all 20 real compiles run both validators on every test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)