### PR TITLE
Drop the duplicated alt names block in metron_api _build_series

### DIFF
--- a/comicbox/formats/metron_api/transform.py
+++ b/comicbox/formats/metron_api/transform.py
@@ -77,8 +77,6 @@ def _build_series(issue: Mapping[str, Any]) -> dict[str, Any]:
         out["identifiers"] = {_METRON: build_identifier(_METRON, "series", sid)}
     if alt_names := alt_names_to_cb(s.get("alt_names"), s.get("name")):
         out["alternative_names"] = alt_names
-    if alt_names := alt_names_to_cb(s.get("alt_names"), s.get("name")):
-        out["alternative_names"] = alt_names
     return out
 
 


### PR DESCRIPTION
## What

`_build_series` in `comicbox/formats/metron_api/transform.py` ran the same statement twice:

```python
if alt_names := alt_names_to_cb(s.get("alt_names"), s.get("name")):
    out["alternative_names"] = alt_names
if alt_names := alt_names_to_cb(s.get("alt_names"), s.get("name")):
    out["alternative_names"] = alt_names
```

## Why it's dead

`alt_names_to_cb` (`comicbox/formats/base/online/transform_helpers.py:184`) builds a fresh `seen` set and `out` list on every call and mutates nothing, so the second call recomputed the same value and assigned it over itself.

It's dead under the other reading too: were `alt_names` ever a generator rather than the list mokkari returns, the second call would find it exhausted, return `[]`, and not assign at all — leaving the first assignment standing. Both ways the result is identical.

## Origin

Copy-paste artifact from #171, which moved a series' other names out of `_build_reprints` and into `_build_series` for the v3 change *"A series' other names live in `series.alternative_names` instead of being mixed into `reprints`"*. The inserted block landed twice in that commit.

## Verification

`make fix`, `make lint`, `make ty` clean; `make test` 1987 passed, 1 pre-existing skip. `test_metron_series_alternative_names` (`tests/unit/test_rich_transforms.py:266`) covers this exact path.

No NEWS entry — behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)