### PR TITLE
refactor(online): one owner for the mutable lookup policy

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,9 @@
     - The ambiguous-match prompt trims its per-candidate detail lines on a
       quieted run (`-QQ` and up, or a `loglevel` above `INFO` in the config). It
       always claimed to and never did.
+    - A match mode or unattended choice made at a prompt applies to the whole
+      rest of the batch. Under `-j N` a sibling file could resolve partly under
+      the old setting, and `ask` never stuck at all in library sessions.
     - Writing MetronInfo no longer invents extra credits. Only `Painter` still
       writes Penciller, Inker and Colorist.
     - `breakdowns`, `finishes`, `plotter` and `scripter` keep their own role

--- a/comicbox/box/online_lookup.py
+++ b/comicbox/box/online_lookup.py
@@ -70,6 +70,7 @@ from comicbox.formats.base.online.profile import (
 from comicbox.formats.base.online.prompt import cli_selector
 from comicbox.formats.base.online.selector import SelectorContext
 from comicbox.formats.base.online.series_cache import claim_series
+from comicbox.formats.base.online.session_state import OnlineSessionState
 from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
 from comicbox.formats.metron_api.online_source import MetronOnlineSource
 from comicbox.formats.sources import MetadataSources
@@ -274,11 +275,20 @@ class ComicboxOnlineLookup(ComicboxNormalize):
 
     # Process-wide lock around the selector callback. Under `-j N` parallel
     # batch runs we serialise prompts so output stays readable and the user
-    # can see which file is being asked about.
+    # can see which file is being asked about. It guards only the callback
+    # itself; the mutable lookup policy has its own lock (OnlineSessionState).
     _PROMPT_LOCK: ClassVar[threading.Lock] = threading.Lock()
 
     # Per-instance selector override; falls back to the default CLI prompt.
     _online_selector: SelectorCallback | None = None
+
+    # Session-supplied owner of the two mutable lookup settings (match and
+    # prompts). A Runner or OnlineSession shares one across every box it
+    # spawns so a `set_policy` / `set_unattended` answered on one file is
+    # in force for the next. Unset for a standalone Comicbox: the lazy
+    # fallback below then makes a private one seeded from this box's
+    # config, keeping single-file use self-contained.
+    _online_session_state: OnlineSessionState | None = None
 
     # Per-instance event handler; emits SearchStarted / AutoWritten / etc.
     # for callers driving online lookup programmatically (OnlineSession).
@@ -328,6 +338,30 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         """Register a session-level series cache for series-first batching."""
         self._series_cache = cache
 
+    def set_online_session_state(self, state: OnlineSessionState | None) -> None:
+        """
+        Register the session-level owner of match mode and prompt policy.
+
+        Share one across every box of a batch so a `set_policy` /
+        `set_unattended` answered at a prompt outlives the file it was
+        answered on. A sibling worker already resolving a file finishes it
+        under the policy it started with and picks the change up on its
+        next file.
+        """
+        self._online_session_state = state
+
+    def _get_online_session_state(self) -> OnlineSessionState:
+        """Get the session state, defaulting to a box-private one."""
+        if self._online_session_state is None:
+            self._online_session_state = OnlineSessionState.from_lookup(
+                self._config.online.lookup
+            )
+        return self._online_session_state
+
+    def _session_online(self) -> OnlineSettings:
+        """Read the live lookup policy onto this box's online settings."""
+        return self._get_online_session_state().overlay(self._config.online)
+
     def set_retry_sleep(self, sleep: Callable[[float], None] | None) -> None:
         """
         Register a retry-sleep override for this box's online sources.
@@ -354,14 +388,13 @@ class ComicboxOnlineLookup(ComicboxNormalize):
     def _mark_online_lookup_done(self) -> None:
         self._online_lookup_done_flag = True
 
-    def _warn_unconfigured_source(self, name: str) -> None:
+    def _warn_unconfigured_source(self, name: str, online: OnlineSettings) -> None:
         """
         Loud warning when a user-requested source can't run for credential reasons.
 
         Quiet skip when the source was only included via the `all` sentinel
         — in that case we don't know the user wanted this specific source.
         """
-        online = self._config.online
         explicit_id = online.lookup.ids.get(name)
         if explicit_id is not None:
             logger.warning(
@@ -384,7 +417,9 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 f"configured (missing credentials); skipping"
             )
 
-    def _build_active_online_sources(self) -> list[OnlineSource]:
+    def _build_active_online_sources(
+        self, online: OnlineSettings
+    ) -> list[OnlineSource]:
         """
         Resolve which configured online sources participate in this run.
 
@@ -394,7 +429,6 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         Metron the fallback. An empty/None selection runs every
         configured source in the factory map's default order.
         """
-        online: OnlineSettings = self._config.online
         selected = online.lookup.sources
         names = selected or tuple(self._ONLINE_SOURCE_FACTORIES)
         active: list[OnlineSource] = []
@@ -407,11 +441,11 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 continue
             creds = online.auth.sources.get(name)
             if creds is None:
-                self._warn_unconfigured_source(name)
+                self._warn_unconfigured_source(name, online)
                 continue
             source = factory(creds, online)
             if not source.is_configured():
-                self._warn_unconfigured_source(name)
+                self._warn_unconfigured_source(name, online)
                 continue
             source.on_rate_limit = self._on_source_rate_limit
             source.retry_sleep = self._retry_sleep
@@ -703,7 +737,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         return self._local_cover_phash_value
 
     def _resolve_with_matcher(
-        self, source_name: str, candidates: list[Candidate]
+        self, source_name: str, candidates: list[Candidate], online: OnlineSettings
     ) -> Resolution:
         from comicbox.config.online.settings import (
             resolve_auto_threshold,
@@ -711,7 +745,6 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             resolve_min_confidence,
         )
 
-        online = self._config.online
         threshold = resolve_auto_threshold(online, source_name)
         min_conf = resolve_min_confidence(online, source_name)
         margin = resolve_disambiguation_margin(online, source_name)
@@ -730,28 +763,6 @@ class ComicboxOnlineLookup(ComicboxNormalize):
     def _selector_for_run(self) -> SelectorCallback:
         return self._online_selector or cli_selector
 
-    def _apply_session_lookup_override(self, **changes: Any) -> None:
-        """
-        Mutate the shared ``OnlineLookupSettings`` in place for session changes.
-
-        Used for ``set_unattended`` / ``set_policy`` from the prompt path.
-        The dataclasses are frozen, but the box's config is shared by
-        reference across all Comicbox instances spawned from the same
-        Runner. Replacing the nested slot via ``object.__setattr__``
-        propagates the change to every in-flight worker thread without
-        breaking the dataclass invariants for other callers.
-
-        The read-replace-write swap runs under the class-level
-        ``_PROMPT_LOCK`` (never held here — callers run after the locked
-        selector call returns) so two workers resolving prompts
-        back-to-back under ``-j N`` can't lose one of the two changes to
-        a stale snapshot.
-        """
-        with type(self)._PROMPT_LOCK:  # noqa: SLF001 — class-level lock by design
-            new_lookup = replace(self._config.online.lookup, **changes)
-            new_online = replace(self._config.online, lookup=new_lookup)
-            object.__setattr__(self._config, "online", new_online)
-
     def _handle_prompt(
         self, source: OnlineSource, candidates: tuple[Candidate, ...]
     ) -> bool:
@@ -762,8 +773,8 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         so concurrent worker threads (when `-j N > 1`) don't garble each
         other's prompts. Re-resolves and re-prompts when the selector
         requests a session-level setting change (`set_unattended` /
-        `set_policy`) so the new setting takes effect on the current
-        candidate set immediately.
+        `set_policy`), reading the session state back so the new setting
+        takes effect on the current candidate set immediately.
 
         Returns True when the prompt led to accepted metadata.
         """
@@ -790,9 +801,11 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 )
             )
             if action in {"set_unattended", "set_policy"}:
-                if not self._apply_session_action(source, action, payload):
+                if not self._apply_session_action(source.name, action, payload):
                     return False
-                resolution = self._resolve_existing(source.name, list(current))
+                resolution = self._resolve_existing(
+                    source.name, list(current), self._session_online()
+                )
                 terminal = self._apply_terminal_resolution(
                     source, resolution, path, context="after session change"
                 )
@@ -820,53 +833,58 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         ctx = SelectorContext(
             file_path=getattr(self, "_path", None),
             source=source.name,
-            settings=self._config,
+            # Overlaid so a selector reading the current match mode or
+            # prompt policy sees the live session values, not the ones
+            # config resolution started the run with.
+            settings=replace(self._config, online=self._session_online()),
             triggered_hashing=any(c.cover_score is not None for c in candidates),
         )
         with type(self)._PROMPT_LOCK:  # noqa: SLF001 — class-level lock by design
             return selector(self._build_profile(), candidates, ctx)
 
     def _apply_session_action(
-        self, source: OnlineSource, action: str, payload: int | str | None
+        self, source_name: str, action: str, payload: int | str | None
     ) -> bool:
         """
         Apply a `set_unattended` / `set_policy` action to the session.
 
-        Returns True on success, False if the payload was malformed (in
-        which case the prompt has been recorded as declined and the
+        The single validator for these two actions: the session reads the
+        state this writes, so there is no second implementation to keep in
+        step. Returns True on success, False if the payload was malformed
+        (in which case the prompt has been recorded as declined and the
         caller should bail out).
         """
         if action == "set_unattended":
-            self._apply_session_lookup_override(prompts=Prompts.NEVER)
-            logger.info(f"online {source.name}: session set to unattended via prompt")
+            self._get_online_session_state().set_prompts(Prompts.NEVER)
+            logger.info(f"online {source_name}: session set to unattended via prompt")
             return True
         if not isinstance(payload, str):
             logger.warning(
-                f"online {source.name}: set_policy requires a policy name; "
+                f"online {source_name}: set_policy requires a policy name; "
                 f"got {payload!r}"
             )
-            outcome_stats.record_prompt_declined(source.name)
+            outcome_stats.record_prompt_declined(source_name)
             return False
         try:
             new_match = MatchMode(payload)
         except ValueError:
             logger.warning(
-                f"online {source.name}: unknown match mode {payload!r}; "
+                f"online {source_name}: unknown match mode {payload!r}; "
                 "expected one of ask | careful | auto | eager"
             )
-            outcome_stats.record_prompt_declined(source.name)
+            outcome_stats.record_prompt_declined(source_name)
             return False
-        self._apply_session_lookup_override(match=new_match)
+        self._get_online_session_state().set_match(new_match)
         logger.info(
-            f"online {source.name}: session match mode set to {new_match.value} via prompt"
+            f"online {source_name}: session match mode set to {new_match.value} via prompt"
         )
         return True
 
     def _resolve_existing(
-        self, source_name: str, ranked: list[Candidate]
+        self, source_name: str, ranked: list[Candidate], online: OnlineSettings
     ) -> Resolution:
         """Re-apply policy to an already-ranked candidate list."""
-        return OnlineMatcher().resolve(ranked, self._config.online, source_name)
+        return OnlineMatcher().resolve(ranked, online, source_name)
 
     def _apply_terminal_resolution(
         self,
@@ -1019,7 +1037,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         # ResolutionKind.PROMPT — invoke the selector callback.
         return self._handle_prompt(source, resolution.candidates)
 
-    def _search_path(self, source: OnlineSource) -> bool:
+    def _search_path(self, source: OnlineSource, online: OnlineSettings) -> bool:
         """Search → rank → resolve → fetch on accept. True when accepted."""
         profile = self._build_profile()
         path = getattr(self, "_path", None)
@@ -1039,7 +1057,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                 "(no matching issues in the database)"
             )
             return False
-        resolution = self._resolve_with_matcher(source.name, candidates)
+        resolution = self._resolve_with_matcher(source.name, candidates, online)
         return self._apply_resolution(source, resolution, path)
 
     def _emit_auto_written(self, source: OnlineSource, issue_id: int) -> None:
@@ -1061,7 +1079,9 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             )
         )
 
-    def _lookup_one_source(self, source: OnlineSource) -> _SourceOutcome:
+    def _lookup_one_source(
+        self, source: OnlineSource, online: OnlineSettings
+    ) -> _SourceOutcome:
         """
         Drive the lookup for one source and report what it did.
 
@@ -1072,7 +1092,6 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         fuzzy-matching behind a failed pin, but only a landed fetch
         reports ``applied``.
         """
-        online = self._config.online
         # Explicit --id is the strongest user signal. It overrides
         # --rematch and the stored-id fast path.
         explicit_ids = online.lookup.ids
@@ -1113,7 +1132,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         if not online.lookup.rematch and self._try_series_cache_lookup(source):
             return _SourceOutcome(applied=True)
 
-        return _SourceOutcome(applied=self._search_path(source))
+        return _SourceOutcome(applied=self._search_path(source, online))
 
     def _try_series_cache_lookup(self, source: OnlineSource) -> bool:  # noqa: PLR0911
         """
@@ -1240,7 +1259,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             # can take, including the explicit-id, stored-id and
             # series-cache fast paths that never reach a SearchStarted.
             self._emit(SourceStarted(path=path, source=source.name))
-            outcome = self._lookup_one_source(source)
+            outcome = self._lookup_one_source(source, online)
             applied_any = applied_any or outcome.applied
             satisfied = satisfied or outcome.applied or outcome.claimed
         return applied_any
@@ -1259,17 +1278,23 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         folded into this return value; it only gates the first-wins skip
         below. Reporting "applied" for a claim is what let a failed
         ``--id`` fetch surface as ``written``.
+
+        The lookup policy is read once here and threaded down, so the
+        whole file resolves under one generation even while a sibling
+        ``-j N`` worker is answering a prompt that changes it. The one
+        exception is the prompt loop, which re-reads on purpose so the
+        answer applies to the candidates being asked about.
         """
         if self._online_lookup_already_done():
             return self._online_lookup_won
         self._mark_online_lookup_done()
-        online = self._config.online
+        online = self._session_online()
         path = getattr(self, "_path", None)
         if not online.lookup.enabled:
             return False
         if online.lookup.prompts is not Prompts.NEVER:
             _no_tty_hint.maybe_log(has_callback=self._online_selector is not None)
-        active_sources = self._build_active_online_sources()
+        active_sources = self._build_active_online_sources(online)
         if not active_sources and online.lookup.sources is None:
             logger.warning(
                 "online: --online all requested but no sources are configured "

--- a/comicbox/formats/base/online/session_state.py
+++ b/comicbox/formats/base/online/session_state.py
@@ -1,0 +1,82 @@
+"""
+One owner for the online session's mutable lookup policy.
+
+Two settings change mid-run when a selector answers ``set_policy`` or
+``set_unattended``: ``match`` and ``prompts``. Everything else in
+``OnlineSettings`` is resolved once at config time and never moves.
+
+This module owns that pair for the whole run. Readers take a
+``snapshot()`` (both fields under one lock acquisition, so a concurrent
+writer can't hand out a mixed pair) or an ``overlay()`` of an otherwise
+static ``OnlineSettings``. A box takes exactly one overlay per lookup
+and threads that frozen view down its call chain, so a file resolves
+under a single consistent policy generation even while a sibling
+``-j N`` worker is changing it; the change lands on the next file.
+
+Deliberately a dumb holder: payload validation and the operator-facing
+logging live in ``ComicboxOnlineLookup._apply_session_action``, which
+has the source name for its messages.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, replace
+
+from comicbox.config.online.settings import (
+    MatchMode,
+    OnlineLookupSettings,
+    OnlineSettings,
+    Prompts,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LookupPolicy:
+    """A consistent read of the session's mutable lookup policy."""
+
+    match: MatchMode
+    prompts: Prompts
+
+    @property
+    def unattended(self) -> bool:
+        """Whether comicbox may not prompt."""
+        return self.prompts is Prompts.NEVER
+
+
+class OnlineSessionState:
+    """Thread-safe owner of the two session-mutable lookup settings."""
+
+    def __init__(self, match: MatchMode, prompts: Prompts) -> None:
+        """Seed the policy from resolved config values."""
+        self._lock = threading.Lock()
+        self._match = match
+        self._prompts = prompts
+
+    @classmethod
+    def from_lookup(cls, lookup: OnlineLookupSettings) -> OnlineSessionState:
+        """Seed from a resolved lookup settings block."""
+        return cls(match=lookup.match, prompts=lookup.prompts)
+
+    def snapshot(self) -> LookupPolicy:
+        """Read both fields as one consistent pair."""
+        with self._lock:
+            return LookupPolicy(match=self._match, prompts=self._prompts)
+
+    def set_match(self, match: MatchMode) -> None:
+        """Change the match mode for the rest of the run."""
+        with self._lock:
+            self._match = match
+
+    def set_prompts(self, prompts: Prompts) -> None:
+        """Change the prompting policy for the rest of the run."""
+        with self._lock:
+            self._prompts = prompts
+
+    def overlay(self, online: OnlineSettings) -> OnlineSettings:
+        """Project the live policy onto otherwise static online settings."""
+        with self._lock:
+            match = self._match
+            prompts = self._prompts
+        new_lookup = replace(online.lookup, match=match, prompts=prompts)
+        return replace(online, lookup=new_lookup)

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -38,6 +38,7 @@ from comicbox.events import FileError, PromptDeferred, PromptResolvedFromCache
 # the ComicboxError base.
 from comicbox.exceptions import OnlineConfigurationError, OnlineLookupAbortedError
 from comicbox.formats.base.online.series_cache import filename_series_fingerprint
+from comicbox.formats.base.online.session_state import OnlineSessionState
 
 # Re-exported so batch callers get the run estimator off the same Codex-facing
 # façade as the session it estimates; the implementation lives in
@@ -264,8 +265,11 @@ class OnlineSession:
 
     Construction validates per-source credentials and pre-computes the
     ComicboxSettings layer that each per-file Comicbox instance will see.
-    Mutable state — ``mode``, ``unattended``, the cancel token — lives on
-    the instance and may be updated from any thread.
+    Mutable state — the lookup policy (``mode`` / ``unattended``) and the
+    cancel token — lives on the instance and may be updated from any
+    thread. The policy lives in an ``OnlineSessionState`` shared with
+    every box the session spawns, so a change made at a prompt needs no
+    mirroring back: the box and the session read the same owner.
 
     ``ids`` pins an issue id per source for a single-comic session: a
     pinned source fetches that id directly while the unpinned sources
@@ -299,8 +303,10 @@ class OnlineSession:
         self._validate_ids(self._sources, self._ids)
         self._credentials = credentials or OnlineCredentials()
         self._validate_credentials(self._sources, self._credentials)
-        self._mode: MatchMode = self._validate_mode(mode)
-        self._unattended = unattended
+        self._state = OnlineSessionState(
+            match=self._validate_mode(mode),
+            prompts=Prompts.NEVER if unattended else Prompts.ASK,
+        )
         self._prompt_handler = prompt_handler
         self._on_event = on_event
         self._rematch = rematch
@@ -312,12 +318,14 @@ class OnlineSession:
         # batches plus a behavioral surprise where a config-file edit
         # mid-batch changed settings for the remaining files.
         self._base_settings: ComicboxSettings = get_config()
+        # Nothing in the settings tree varies per file: the mutable
+        # policy lives in _state and each box overlays it for itself.
+        self._settings: ComicboxSettings = self._build_config()
 
         # Cancel token. Set when cancel() is called; checked between files
         # in tag_many() and consulted by the wired retry sleep
         # (_retry_sleep_wait), which aborts an in-flight rate-limit wait.
         self._cancel = threading.Event()
-        self._state_lock = threading.Lock()
 
         # Prompt-dedup cache. Keyed by fingerprint of (source, normalized
         # series, sorted distinct candidate volume_ids); the stored entry
@@ -350,26 +358,27 @@ class OnlineSession:
 
     @property
     def mode(self) -> MatchMode:
-        """Current session mode (read-only; mutate via set_mode())."""
-        with self._state_lock:
-            return self._mode
+        """
+        Current session mode (read-only; mutate via set_mode()).
+
+        May report ``MatchMode.ASK`` even though ``set_mode`` rejects it:
+        a prompt handler answering ``set_policy: "ask"`` can put the
+        session there, since that path has a handler to do the asking.
+        """
+        return self._state.snapshot().match
 
     @property
     def unattended(self) -> bool:
         """Current session unattended flag."""
-        with self._state_lock:
-            return self._unattended
+        return self._state.snapshot().unattended
 
     def set_mode(self, mode: MatchMode) -> None:
         """Change the session mode for subsequent file lookups."""
-        validated = self._validate_mode(mode)
-        with self._state_lock:
-            self._mode = validated
+        self._state.set_match(self._validate_mode(mode))
 
     def set_unattended(self, *, unattended: bool) -> None:
         """Toggle the unattended flag for subsequent file lookups."""
-        with self._state_lock:
-            self._unattended = unattended
+        self._state.set_prompts(Prompts.NEVER if unattended else Prompts.ASK)
 
     def cancel(self) -> None:
         """Stop accepting new files. In-flight lookup runs to completion."""
@@ -536,8 +545,7 @@ class OnlineSession:
     # -- internals ----------------------------------------------------------
 
     def _run_one(self, path: Path) -> tuple[dict[str, Any], bool]:
-        config = self._build_config()
-        with Comicbox(path, config=config) as cb:
+        with Comicbox(path, config=self._settings) as cb:
             # Bridge the selector when we have a handler, when defer
             # mode is on (defer produces no handler call but still needs
             # to intercept the prompt to queue it), or when resolutions
@@ -555,6 +563,7 @@ class OnlineSession:
             if self._series_batching:
                 cb.set_series_cache(self._series_cache)
             cb.set_retry_sleep(self._retry_sleep_wait)
+            cb.set_online_session_state(self._state)
             matched = cb.run_online_lookup()
             payload = cb.to_dict()
         return payload.get("comicbox", {}), matched
@@ -615,46 +624,23 @@ class OnlineSession:
                     "is disabled; cannot resolve an ambiguous match"
                 )
                 raise RuntimeError(msg)
+            policy = self._state.snapshot()
             prompt = OnlinePrompt(
                 path=ctx.file_path,
                 source=ctx.source,
                 profile_summary=_summarise_profile(profile),
                 candidates=cand_tuple,
-                mode=self.mode,
-                unattended=self.unattended,
+                mode=policy.match,
+                unattended=policy.unattended,
             )
             response = handler.request(prompt)
-            self._sync_session_state(response)
+            # No session-state sync here: the box applies set_policy /
+            # set_unattended to the OnlineSessionState this session shares
+            # with it, so the change is already ours.
             self._store_prompt_resolution(fingerprint, response, cand_tuple)
             return (response.action, response.payload)
 
         return _selector
-
-    def _sync_session_state(self, response: PromptResponse) -> None:
-        """
-        Mirror session-level prompt actions into the session's own state.
-
-        The box applies set_policy / set_unattended to its per-file config,
-        but _run_one rebuilds that config for every file from the session's
-        _mode / _unattended — without this sync the handler's decision
-        would silently revert on the next file, despite PromptResponse
-        documenting these as session-level actions.
-        """
-        if response.action == "set_unattended":
-            self.set_unattended(unattended=True)
-            return
-        if response.action != "set_policy" or not isinstance(response.payload, str):
-            return
-        try:
-            mode = MatchMode(response.payload)
-        except ValueError:
-            # Malformed payload: the box logs and declines it; nothing to sync.
-            return
-        if mode is MatchMode.ASK:
-            # The session's set_mode rejects ASK (no built-in CLI prompt);
-            # the box still honors it for the in-flight file.
-            return
-        self.set_mode(mode)
 
     def _defer_prompt(
         self,
@@ -664,14 +650,15 @@ class OnlineSession:
         ctx: SelectorContext,
     ) -> None:
         """Queue this prompt for later resolution and emit PromptDeferred."""
+        policy = self._state.snapshot()
         deferred = DeferredPrompt(
             path=ctx.file_path,
             source=ctx.source,
             fingerprint=fingerprint,
             profile_summary=_summarise_profile(profile),
             candidates=candidates,
-            mode=self.mode,
-            unattended=self.unattended,
+            mode=policy.match,
+            unattended=policy.unattended,
         )
         with self._deferred_lock:
             self._deferred.append(deferred)
@@ -743,17 +730,18 @@ class OnlineSession:
         we need to set (``enabled``, ``sources``, per-source auth dict)
         live on runtime-only fields the CLI namespace parser ignores.
 
-        ``mode`` / ``unattended`` are session-mutable, so the cheap
-        ``replace`` layering stays per-file; the disk read happened once
-        in ``__init__``.
+        Built once in ``__init__``. ``match`` / ``prompts`` are the seed
+        values only: every box overlays the live ``OnlineSessionState``
+        over them, so a mid-run policy change needs no rebuild here.
         """
         base = self._base_settings
+        policy = self._state.snapshot()
         new_lookup = OnlineLookupSettings(
             enabled=True,
             sources=self._sources,
             ids=self._ids,
-            match=self.mode,
-            prompts=Prompts.NEVER if self.unattended else Prompts.ASK,
+            match=policy.match,
+            prompts=policy.prompts,
             rematch=self._rematch,
             first_wins=self._first_wins,
         )

--- a/comicbox/run.py
+++ b/comicbox/run.py
@@ -21,6 +21,7 @@ from comicbox.formats.base.online.series_cache import (
     SeriesCache,
     filename_series_fingerprint,
 )
+from comicbox.formats.base.online.session_state import OnlineSessionState
 from comicbox.logger import init_logging
 
 if TYPE_CHECKING:
@@ -60,6 +61,14 @@ class Runner:
         #: read and write it, and `_maybe_populate_series_cache` needs
         #: `in` / `__setitem__` to stay consistent between them.
         self._series_cache = SeriesCache()
+        #: Batch-wide owner of the two mutable lookup settings. Seeded from
+        #: the config-resolved values; a `set_policy` / `set_unattended`
+        #: answered at any file's prompt applies to the rest of the batch.
+        #: Built here rather than after `_maybe_auto_engage_api_budget`
+        #: because that only rewrites per-source effort, never match or
+        #: prompts — and `run_on_file` is a public entry point that never
+        #: goes through `run()`.
+        self._online_state = OnlineSessionState.from_lookup(self._config.online.lookup)
         init_logging(self._config.general.loglevel)
 
     def _iter_recurse(self, path: Path) -> Iterator[Path]:
@@ -137,6 +146,7 @@ class Runner:
         with Comicbox(path, config=self._config) as car:
             if self._config.online.lookup.enabled:
                 car.set_series_cache(self._series_cache)
+                car.set_online_session_state(self._online_state)
             car.print_file_header()
             car.run()
 

--- a/tests/unit/test_online_selector.py
+++ b/tests/unit/test_online_selector.py
@@ -13,6 +13,7 @@ from comicbox.box.online_lookup import ComicboxOnlineLookup, OnlineLookupAborted
 from comicbox.config.online.settings import MatchMode, Prompts
 from comicbox.formats import MetadataFormats
 from comicbox.formats.base.online.profile import Candidate, CandidateSummary
+from comicbox.formats.base.online.session_state import OnlineSessionState
 from comicbox.formats.sources import MetadataSources
 
 if TYPE_CHECKING:
@@ -165,21 +166,24 @@ def test_manual_id_for_other_source_skipped(patched_metron) -> None:
     assert patched_metron[0].get_calls == []
 
 
-def test_set_unattended_mutates_session_and_skips(patched_metron) -> None:
+def test_set_unattended_changes_session_state_and_skips(patched_metron) -> None:
     def selector(profile, candidates, ctx):
         return ("set_unattended", None)
 
     cb = _build_cb()
-    assert cb._config.online.lookup.prompts is Prompts.ASK
+    state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+    cb.set_online_session_state(state)
     cb.set_online_selector(selector)
     cb.run_online_lookup()
     # Session was switched; the current prompt collapsed to SKIP, so the
     # mock source's get() was never called.
-    assert cb._config.online.lookup.prompts is Prompts.NEVER
+    assert state.snapshot().prompts is Prompts.NEVER
     assert patched_metron[0].get_calls == []
+    # The policy lives in the session state, never in the frozen settings.
+    assert cb._config.online.lookup.prompts is Prompts.ASK
 
 
-def test_set_policy_mutates_session_and_reprompts(patched_metron) -> None:
+def test_set_policy_changes_session_state_and_reprompts(patched_metron) -> None:
     calls: list[str] = []
 
     def selector(profile, candidates, ctx):
@@ -189,14 +193,56 @@ def test_set_policy_mutates_session_and_reprompts(patched_metron) -> None:
         return ("skip", None)
 
     cb = _build_cb()
-    assert cb._config.online.lookup.match is MatchMode.AUTO
+    state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+    cb.set_online_session_state(state)
     cb.set_online_selector(selector)
     cb.run_online_lookup()
-    assert cb._config.online.lookup.match is MatchMode.EAGER
+    assert state.snapshot().match is MatchMode.EAGER
+    assert cb._config.online.lookup.match is MatchMode.AUTO
     # Either the EAGER re-resolution auto-wrote (candidate fetched) or it
     # re-prompted and the second call skipped — both are valid outcomes
     # depending on the mock candidates' final scores.
     assert len(calls) >= 1
+
+
+def test_set_policy_reaches_the_selector_context(patched_metron) -> None:
+    """A selector reading ctx.settings sees the live policy, not the seed."""
+    seen: list[MatchMode] = []
+
+    def selector(profile, candidates, ctx):
+        seen.append(ctx.settings.online.lookup.match)
+        if len(seen) == 1:
+            return ("set_policy", "careful")
+        return ("skip", None)
+
+    cb = _build_cb()
+    cb.set_online_session_state(
+        OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+    )
+    cb.set_online_selector(selector)
+    cb.run_online_lookup()
+    assert seen[0] is MatchMode.AUTO
+    # CAREFUL keeps the two close candidates ambiguous, so the loop asks
+    # again — and the second ask carries the mode just set.
+    assert seen[1:] == [MatchMode.CAREFUL]
+
+
+def test_set_policy_ask_persists(patched_metron) -> None:
+    """`set_policy: ask` sticks; the session has a handler to do the asking."""
+    calls: list[str] = []
+
+    def selector(profile, candidates, ctx):
+        calls.append("call")
+        if len(calls) == 1:
+            return ("set_policy", "ask")
+        return ("skip", None)
+
+    cb = _build_cb()
+    state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+    cb.set_online_session_state(state)
+    cb.set_online_selector(selector)
+    cb.run_online_lookup()
+    assert state.snapshot().match is MatchMode.ASK
 
 
 def test_set_policy_invalid_payload_declines(patched_metron) -> None:
@@ -204,11 +250,49 @@ def test_set_policy_invalid_payload_declines(patched_metron) -> None:
         return ("set_policy", "nonsense")
 
     cb = _build_cb()
+    state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+    cb.set_online_session_state(state)
     cb.set_online_selector(selector)
     cb.run_online_lookup()
     # Bad payload: match unchanged, no candidate accepted.
-    assert cb._config.online.lookup.match is MatchMode.AUTO
+    assert state.snapshot().match is MatchMode.AUTO
     assert patched_metron[0].get_calls == []
+
+
+def test_session_state_carries_across_boxes(patched_metron) -> None:
+    """A policy change on one file is in force for the next one."""
+    state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+
+    def selector(profile, candidates, ctx):
+        return ("set_unattended", None)
+
+    first = _build_cb()
+    first.set_online_session_state(state)
+    first.set_online_selector(selector)
+    first.run_online_lookup()
+
+    # No selector on the second box: without the shared state it would
+    # fall back to the CLI prompt and block on a non-tty.
+    second = _build_cb()
+    second.set_online_session_state(state)
+    second.run_online_lookup()
+    assert second._session_online().lookup.prompts is Prompts.NEVER
+    assert all(src.get_calls == [] for src in patched_metron)
+
+
+def test_standalone_box_gets_its_own_state(patched_metron) -> None:
+    """No injected state: the box seeds a private one from its own config."""
+
+    def selector(profile, candidates, ctx):
+        return ("set_unattended", None)
+
+    first = _build_cb()
+    first.set_online_selector(selector)
+    first.run_online_lookup()
+    assert first._session_online().lookup.prompts is Prompts.NEVER
+
+    second = _build_cb()
+    assert second._session_online().lookup.prompts is Prompts.ASK
 
 
 def test_selector_receives_candidates(patched_metron) -> None:

--- a/tests/unit/test_online_session.py
+++ b/tests/unit/test_online_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from comicbox.box import Comicbox
 from comicbox.config.online.settings import MatchMode, Prompts
 from comicbox.online_session import (
     OnlineConfigurationError,
@@ -123,30 +124,35 @@ def test_mode_propagates_to_match_setting(mode: MatchMode) -> None:
         credentials=VALID_METRON,
         mode=mode,
     )
-    cfg = session._build_config()
-    assert cfg.online.lookup.match is mode
+    assert session._settings.online.lookup.match is mode
 
 
 def test_unattended_maps_to_prompts_never() -> None:
     session = OnlineSession(
         sources={"metron"}, credentials=VALID_METRON, unattended=True
     )
-    cfg = session._build_config()
-    assert cfg.online.lookup.prompts == Prompts.NEVER
+    assert session._settings.online.lookup.prompts == Prompts.NEVER
 
 
-def test_set_mode_changes_subsequent_config() -> None:
+def _live_lookup(session: OnlineSession):
+    """Resolve what a box spawned by this session would look up under now."""
+    return session._state.overlay(session._settings.online).lookup
+
+
+def test_set_mode_changes_subsequent_lookups() -> None:
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    assert session._build_config().online.lookup.match == MatchMode.AUTO
+    assert _live_lookup(session).match == MatchMode.AUTO
     session.set_mode(MatchMode.EAGER)
-    assert session._build_config().online.lookup.match == MatchMode.EAGER
+    assert _live_lookup(session).match == MatchMode.EAGER
 
 
-def test_set_unattended_changes_subsequent_config() -> None:
+def test_set_unattended_changes_subsequent_lookups() -> None:
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    assert session._build_config().online.lookup.prompts == Prompts.ASK
+    assert _live_lookup(session).prompts == Prompts.ASK
     session.set_unattended(unattended=True)
-    assert session._build_config().online.lookup.prompts == Prompts.NEVER
+    assert _live_lookup(session).prompts == Prompts.NEVER
+    session.set_unattended(unattended=False)
+    assert _live_lookup(session).prompts == Prompts.ASK
 
 
 # --- credential propagation ---------------------------------------------------
@@ -230,31 +236,49 @@ def test_retry_sleep_wait_passes_when_not_cancelled() -> None:
 
 
 # --- session-level prompt actions ----------------------------------------------
+#
+# The box applies these to the OnlineSessionState the session shares with
+# it, so these go through the box's real `_apply_session_action` rather
+# than a session-side mirror of it.
+
+
+def _apply_via_box(
+    session: OnlineSession, action: str, payload: int | str | None
+) -> bool:
+    """Run one selector action through the box that the session would spawn."""
+    cb = Comicbox(config=session._settings)
+    cb.set_online_session_state(session._state)
+    return cb._apply_session_action("metron", action, payload)
 
 
 def test_set_policy_via_handler_persists_across_files() -> None:
-    """A handler's set_policy must outlive the in-flight file's config."""
+    """A handler's set_policy must outlive the in-flight file."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    session._sync_session_state(PromptResponse(action="set_policy", payload="eager"))
+    assert _apply_via_box(session, "set_policy", "eager") is True
     assert session.mode is MatchMode.EAGER
-    assert session._build_config().online.lookup.match == MatchMode.EAGER
 
 
 def test_set_unattended_via_handler_persists_across_files() -> None:
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    session._sync_session_state(PromptResponse(action="set_unattended", payload=None))
+    assert _apply_via_box(session, "set_unattended", None) is True
     assert session.unattended is True
-    assert session._build_config().online.lookup.prompts == Prompts.NEVER
 
 
-def test_sync_session_state_ignores_malformed_or_ask_policy() -> None:
-    """Bad payloads and ASK (rejected by set_mode) must not raise or stick."""
+def test_set_policy_ask_persists() -> None:
+    """ASK sticks when a handler asks for it, though set_mode still refuses it."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    session._sync_session_state(PromptResponse(action="set_policy", payload="bogus"))
+    assert _apply_via_box(session, "set_policy", "ask") is True
+    assert session.mode is MatchMode.ASK
+    with pytest.raises(OnlineConfigurationError):
+        session.set_mode(MatchMode.ASK)
+
+
+def test_malformed_set_policy_declines_and_leaves_mode() -> None:
+    """Bad payloads are declined, loudly, and don't move the session."""
+    session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
+    assert _apply_via_box(session, "set_policy", "bogus") is False
     assert session.mode is MatchMode.AUTO
-    session._sync_session_state(PromptResponse(action="set_policy", payload="ask"))
-    assert session.mode is MatchMode.AUTO
-    session._sync_session_state(PromptResponse(action="choose", payload=0))
+    assert _apply_via_box(session, "set_policy", 7) is False
     assert session.mode is MatchMode.AUTO
 
 
@@ -303,6 +327,7 @@ class _FakeBox:
 
     def __init__(self, path, config=None) -> None:
         self.selector = None
+        self.session_state = None
         self.won = type(self).next_won
         type(self).last = self
 
@@ -326,6 +351,9 @@ class _FakeBox:
     def set_retry_sleep(self, sleep) -> None:
         pass
 
+    def set_online_session_state(self, state) -> None:
+        self.session_state = state
+
     def run_online_lookup(self) -> bool:
         return self.won
 
@@ -341,6 +369,13 @@ def fake_box(monkeypatch):
     _FakeBox.last = None
     _FakeBox.next_won = False
     return _FakeBox
+
+
+def test_box_shares_the_session_state(tmp_path, fake_box) -> None:
+    """The box gets the session's own state object, not a copy of it."""
+    session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
+    session.tag(tmp_path / "f.cbz")
+    assert fake_box.last.session_state is session._state
 
 
 def test_unmatched_lookup_yields_matched_false(tmp_path, fake_box) -> None:

--- a/tests/unit/test_online_session_state.py
+++ b/tests/unit/test_online_session_state.py
@@ -1,0 +1,117 @@
+"""Tests for the single owner of the mutable online lookup policy."""
+
+from __future__ import annotations
+
+import threading
+
+from comicbox.config import get_config
+from comicbox.config.online.settings import (
+    MatchMode,
+    OnlineLookupSettings,
+    Prompts,
+)
+from comicbox.formats.base.online.session_state import (
+    LookupPolicy,
+    OnlineSessionState,
+)
+
+
+def _online():
+    return get_config().online
+
+
+def test_from_lookup_seeds_both_fields() -> None:
+    lookup = OnlineLookupSettings(match=MatchMode.EAGER, prompts=Prompts.NEVER)
+    policy = OnlineSessionState.from_lookup(lookup).snapshot()
+    assert policy.match is MatchMode.EAGER
+    assert policy.prompts is Prompts.NEVER
+
+
+def test_unattended_is_derived_from_prompts() -> None:
+    assert LookupPolicy(MatchMode.AUTO, Prompts.NEVER).unattended is True
+    assert LookupPolicy(MatchMode.AUTO, Prompts.ASK).unattended is False
+
+
+def test_setters_move_only_their_own_field() -> None:
+    state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
+    state.set_match(MatchMode.CAREFUL)
+    assert state.snapshot() == LookupPolicy(MatchMode.CAREFUL, Prompts.ASK)
+    state.set_prompts(Prompts.NEVER)
+    assert state.snapshot() == LookupPolicy(MatchMode.CAREFUL, Prompts.NEVER)
+    # Unattended is reversible, unlike the one-way prompt action.
+    state.set_prompts(Prompts.ASK)
+    assert state.snapshot().unattended is False
+
+
+def test_overlay_replaces_the_policy_and_nothing_else() -> None:
+    online = _online()
+    overlaid = OnlineSessionState(match=MatchMode.EAGER, prompts=Prompts.NEVER).overlay(
+        online
+    )
+    assert overlaid.lookup.match is MatchMode.EAGER
+    assert overlaid.lookup.prompts is Prompts.NEVER
+    # Sibling blocks are carried over untouched, not rebuilt.
+    assert overlaid.auth is online.auth
+    # And nothing else moved: overlay the original policy back onto the
+    # result and the whole tree compares equal again.
+    restored = OnlineSessionState.from_lookup(online.lookup).overlay(overlaid)
+    assert restored == online
+
+
+def test_overlay_does_not_mutate_its_input() -> None:
+    online = _online()
+    before = online.lookup
+    OnlineSessionState(match=MatchMode.EAGER, prompts=Prompts.NEVER).overlay(online)
+    assert online.lookup is before
+    assert online.lookup.match is before.match
+
+
+def test_concurrent_readers_and_writers_see_only_written_values() -> None:
+    """
+    Reading while other threads write yields real values, never garbage.
+
+    Both fields come out of one lock acquisition, so a reader can't catch
+    a `set_match` half-applied. What two independent setter calls can't
+    promise is that the *pair* came from one writer — the box makes one
+    change per prompt action, so that's not a case the code produces.
+    """
+    pairs = [
+        (MatchMode.CAREFUL, Prompts.ASK),
+        (MatchMode.EAGER, Prompts.NEVER),
+    ]
+    state = OnlineSessionState(*pairs[0])
+    barrier = threading.Barrier(3)
+    stop = threading.Event()
+    seen: list[LookupPolicy] = []
+    errors: list[BaseException] = []
+
+    def writer(match: MatchMode, prompts: Prompts) -> None:
+        try:
+            barrier.wait()
+            while not stop.is_set():
+                state.set_match(match)
+                state.set_prompts(prompts)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def reader() -> None:
+        try:
+            barrier.wait()
+            seen.extend(state.snapshot() for _ in range(2000))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            stop.set()
+
+    threads = [threading.Thread(target=writer, args=pair) for pair in pairs]
+    threads.append(threading.Thread(target=reader))
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+    assert not errors
+    assert seen
+    written_matches = {match for match, _ in pairs}
+    written_prompts = {prompts for _, prompts in pairs}
+    assert all(policy.match in written_matches for policy in seen)
+    assert all(policy.prompts in written_prompts for policy in seen)

--- a/tests/unit/test_run_parallel.py
+++ b/tests/unit/test_run_parallel.py
@@ -443,10 +443,11 @@ def test_runner_owns_one_series_cache_for_the_batch() -> None:
     assert len(runner._series_cache) == 0
 
 
-def test_series_cache_is_wired_into_each_box(tmp_path: Path) -> None:
-    """Every file of an online batch shares the runner's one cache."""
+def test_batch_collaborators_are_wired_into_each_box(tmp_path: Path) -> None:
+    """Every file of an online batch shares the runner's cache and policy."""
     runner, paths = _online_runner(tmp_path, ["Spider-Man #001 (2018).cbz"])
     seen: list[Any] = []
+    states: list[Any] = []
 
     class _FakeBox:
         def __enter__(self) -> Self:
@@ -458,6 +459,9 @@ def test_series_cache_is_wired_into_each_box(tmp_path: Path) -> None:
         def set_series_cache(self, cache: Any) -> None:
             seen.append(cache)
 
+        def set_online_session_state(self, state: Any) -> None:
+            states.append(state)
+
         def print_file_header(self) -> None:
             return None
 
@@ -467,6 +471,9 @@ def test_series_cache_is_wired_into_each_box(tmp_path: Path) -> None:
     with patch("comicbox.run.Comicbox", lambda *_a, **_kw: _FakeBox()):
         runner.run_on_file(paths[0])
     assert seen == [runner._series_cache]
+    # One owner for the batch: a prompt answered on any file is in force
+    # for the rest of it.
+    assert states == [runner._online_state]
 
 
 def test_online_batch_is_clustered_by_series(tmp_path: Path) -> None:


### PR DESCRIPTION
## Context

The online lookup's two session-mutable settings — match mode and prompt policy — had two independent owners:

- **The box** (`box/online_lookup.py`) mutated the shared *frozen* `ComicboxSettings` in place via `object.__setattr__` under `_PROMPT_LOCK`. In the CLI path every `-j N` worker shares that one settings instance by identity, so the write propagated batch-wide — but every read was unlocked, and a single lookup re-read `self._config.online` at four different points, so one file could resolve partly under the old policy and partly under the new one.
- **`OnlineSession`** kept its own `_mode`/`_unattended` under a second lock, rebuilt settings per file, and mirrored the same two selector actions back in `_sync_session_state` — with divergent validation: it silently dropped `set_policy "ask"` and malformed payloads where the box warned, recorded a declined prompt, and honored ASK.

## Change

`OnlineSessionState` (`formats/base/online/session_state.py`) owns `match` and `prompts` for the run. It follows the `_OutcomeStats` pattern: mutate under lock, snapshot under lock.

- `run_online_lookup` takes **one** `overlay()` per lookup and threads that frozen view down the call chain (4 signatures gain a trailing `online: OnlineSettings`), so a file resolves under a single policy generation. The prompt loop re-overlays deliberately, so an answer still applies to the candidates being asked about.
- `Runner` and `OnlineSession` each share one state with every box they spawn. A standalone `Comicbox` lazily seeds a private one from its own config, so single-file and bulk-write use stay item-local exactly as before.
- Deleted: `_sync_session_state`, `_apply_session_lookup_override`, the per-file config rebuild, and the second lock. `grep -rn "object.__setattr__" comicbox/` is now empty — nothing mutates a settings dataclass.
- `_apply_session_action` took a whole `OnlineSource` to read `.name` off it; narrowed to `source_name: str`.

## Behavior changes

- `set_policy "ask"` now persists in library sessions instead of silently reverting on the next file (unifies on what the CLI path already did). `set_mode()` still rejects ASK as a public-API contract — only a prompt handler, which can do the asking, can put a session there.
- Malformed `set_policy` payloads warn and record a declined prompt in the session path too, instead of being silently ignored.
- A policy change made by one `-j N` worker lands on a sibling's **next** file rather than partway through its current one. Deterministic per-file generations replace the torn reads; the acting box still adopts immediately.

## Verification

- Full suite: 2018 passed, 1 skipped.
- `bin/lint.sh` (ruff, basedpyright, complexipy, radon, codespell, prettier/remark) exits 0; `ty check` passes.
- New `tests/unit/test_online_session_state.py`: overlay round-trip, input immutability, concurrent reader/writer safety.
- New coverage for cross-box propagation, standalone-box isolation, ASK persistence, and the selector seeing the live policy through `ctx.settings`.
- End-to-end through the real `Runner` with a stubbed source: file 1 prompts and answers `set_unattended`, file 2 inherits it and never prompts.

## Out of scope

`_defer_prompts` locking, the dual cancel Events (session `_cancel` vs `retry.py`), the series-batching ordering mirror between `run.py` and `OnlineSession.tag_many`, and the stale `--unattended` string in the no-TTY hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)