### PR TITLE
fix(online): classify retry errors per client library

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,9 @@
       GiB. Output is unchanged.
 
 - Fixes
+    - Online lookup retries rate-limit errors whose message mentions an API key
+      instead of misreading them as permanent auth failures. Each metadata
+      source now classifies its own client library's errors.
     - Reading a comic no longer fails when two reprints tie on every sort key up
       to one that only one of them has. A reprint carrying a `volume` with an
       `issue_count` but no `number` used to abort the whole dump with

--- a/comicbox/formats/base/online/retry.py
+++ b/comicbox/formats/base/online/retry.py
@@ -6,12 +6,21 @@ Wraps a callable that talks to an upstream API. Retries transient errors
 upstream's `retry_after` hint when present (mokkari sets this on
 `RateLimitError`). Permanent failures — auth errors and not-found
 responses — are never retried.
+
+Which failure is which is the source's call, not this module's: the
+bound instance's ``classify_retry_exception`` (each source contributes
+one for its own client library; see
+`OnlineSource.classify_retry_exception`) returns a `RetryCategory`.
+Exceptions no classifier claims fall back to a conservative default:
+programmer/config errors (`_NON_RETRIABLE`) raise immediately,
+everything else retries on the generic schedule.
 """
 
 from __future__ import annotations
 
 import re
 import threading
+from enum import Enum, auto
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
@@ -23,6 +32,16 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 T = TypeVar("T")
+
+
+class RetryCategory(Enum):
+    """How a classified exception drives the retry loop."""
+
+    RATE_LIMIT = auto()  # rate-limit schedule + budget; on_rate_limit fires
+    AUTH = auto()  # never retried
+    NOT_FOUND = auto()  # never retried
+    TRANSIENT = auto()  # generic exponential schedule
+
 
 # ComicVine sends the API key as a query param (simyan 3.x), and requests
 # embeds the full URL — key included — in HTTPError/ConnectionError
@@ -177,51 +196,19 @@ def interruptible_sleep(seconds: float) -> None:
         raise OnlineLookupAbortedError(msg)
 
 
-def _is_rate_limit(exc: BaseException) -> bool:
-    if type(exc).__name__ == "RateLimitError":
-        return True
-    # simyan 3.x client-side cap exhaustion surfaces as ServiceError whose
-    # __cause__ is requests' Timeout("Rate limit not cleared within
-    # max_delay=..."). Route it to the rate-limit schedule — the generic
-    # 31s budget can't outlast an hourly cap.
-    return (
-        type(exc).__name__ == "ServiceError"
-        and "rate limit not cleared" in str(exc.__cause__ or "").lower()
-    )
+def _classify(exc: BaseException, args: tuple[Any, ...]) -> RetryCategory | None:
+    """
+    Ask the source instance's per-library classifier, if any.
 
-
-_AUTH_MARKERS = (
-    "auth",
-    "401",
-    "403",
-    "forbidden",
-    # mokkari raises its generic ApiError with the server's message for
-    # bad Metron credentials; simyan's AuthenticationError carries CV's
-    # marker-less "Invalid API Key".
-    "invalid username",
-    "invalid password",
-    "api key",
-)
-
-
-def _is_auth_error(exc: BaseException) -> bool:
-    name = type(exc).__name__
-    if name == "AuthenticationError":
-        # The class name alone is conclusive; the message is whatever the
-        # server sent (CV: "Invalid API Key", no recognizable marker).
-        return True
-    return name == "ApiError" and any(
-        marker in str(exc).lower() for marker in _AUTH_MARKERS
-    )
-
-
-def _is_not_found_error(exc: BaseException) -> bool:
-    """Permanent not-found responses (bad explicit id) — never retriable."""
-    if type(exc).__name__ != "ServiceError":
-        return False
-    if getattr(exc.__cause__, "status_code", None) == 404:  # noqa: PLR2004
-        return True
-    return "not found" in str(exc).lower()
+    ``args[0]`` is the bound source instance at every production call
+    site — the same seam `_resolve_sleep` and `_notify_rate_limit_listener`
+    read. Plain functions and fakes without the method fall back to None,
+    which `_is_retriable` treats conservatively.
+    """
+    if not args:
+        return None
+    classify = getattr(args[0], "classify_retry_exception", None)
+    return classify(exc) if classify is not None else None
 
 
 # Exceptions that signal programmer errors / bad config — NOT retriable. The
@@ -238,16 +225,20 @@ _NON_RETRIABLE: tuple[type[BaseException], ...] = (
 )
 
 
-def _is_retriable(exc: BaseException) -> bool:
+def _is_retriable(exc: BaseException, category: RetryCategory | None) -> bool:
     """
     Return True for transient errors worth retrying.
 
-    Auth errors, not-found responses, and programmer/config errors raise
-    immediately without retry.
+    A classifier's AUTH / NOT_FOUND verdicts are terminal; its RATE_LIMIT
+    and TRANSIENT verdicts are trusted (no vendor exception subclasses
+    the `_NON_RETRIABLE` tuple). Unclaimed exceptions raise immediately
+    when they signal programmer/config errors and retry otherwise.
     """
-    if _is_auth_error(exc) or _is_not_found_error(exc):
+    if category in (RetryCategory.AUTH, RetryCategory.NOT_FOUND):
         return False
-    return not isinstance(exc, _NON_RETRIABLE)
+    if category is None:
+        return not isinstance(exc, _NON_RETRIABLE)
+    return True
 
 
 def _retry_after(exc: BaseException) -> float | None:
@@ -284,6 +275,7 @@ def _delay_for_rate_limit(attempt: int) -> float:
 def _plan_retry(
     exc: BaseException,
     *,
+    category: RetryCategory | None,
     attempt: int,
     rate_limit_attempt: int,
     max_retries: int,
@@ -304,7 +296,7 @@ def _plan_retry(
     shortened delay: waiting out only part of a rate-limit window spends
     an attempt on a request that is still going to be refused.
     """
-    is_rate_limit = _is_rate_limit(exc)
+    is_rate_limit = category is RetryCategory.RATE_LIMIT
     if is_rate_limit:
         if rate_limit_attempt >= _MAX_RATE_LIMIT_RETRIES:
             return None
@@ -328,10 +320,11 @@ def _plan_retry(
     return delay, budget, is_rate_limit
 
 
-def _handle_retry_exception(
+def _handle_retry_exception(  # noqa: PLR0913
     exc: Exception,
     *,
     func_name: str,
+    category: RetryCategory | None,
     attempt: int,
     rate_limit_attempt: int,
     max_retries: int,
@@ -348,10 +341,11 @@ def _handle_retry_exception(
     out of its retry loop. The returned delay feeds back in as
     ``waited`` on the next call.
     """
-    if not _is_retriable(exc):
+    if not _is_retriable(exc, category):
         raise exc
     plan = _plan_retry(
         exc,
+        category=category,
         attempt=attempt,
         rate_limit_attempt=rate_limit_attempt,
         max_retries=max_retries,
@@ -376,18 +370,20 @@ def _notify_rate_limit_listener(
     exc: BaseException,
     args: tuple[Any, ...],
     *,
+    category: RetryCategory | None,
     attempt: int,
     rate_limit_attempt: int,
     max_retries: int,
 ) -> None:
     """Invoke ``instance.on_rate_limit`` for rate-limit failures, if defined."""
-    if not args or not _is_rate_limit(exc):
+    if not args or category is not RetryCategory.RATE_LIMIT:
         return
     instance_cb = getattr(args[0], "on_rate_limit", None)
     if instance_cb is None:
         return
     plan = _plan_retry(
         exc,
+        category=category,
         attempt=attempt,
         rate_limit_attempt=rate_limit_attempt,
         max_retries=max_retries,
@@ -443,9 +439,11 @@ def _run_with_retries(
         except Exception as exc:
             _redact_api_keys(exc)
             last_exc = exc
+            category = _classify(exc, args)
             _notify_rate_limit_listener(
                 exc,
                 args,
+                category=category,
                 attempt=attempt,
                 rate_limit_attempt=rate_limit_attempt,
                 max_retries=max_retries,
@@ -453,6 +451,7 @@ def _run_with_retries(
             slept = _handle_retry_exception(
                 exc,
                 func_name=func.__name__,  # ty: ignore[unresolved-attribute]
+                category=category,
                 attempt=attempt,
                 rate_limit_attempt=rate_limit_attempt,
                 max_retries=max_retries,
@@ -463,7 +462,7 @@ def _run_with_retries(
             if slept is None:
                 break
             waited += slept
-            if _is_rate_limit(exc):
+            if category is RetryCategory.RATE_LIMIT:
                 rate_limit_attempt += 1
             else:
                 attempt += 1

--- a/comicbox/formats/base/online/sources/base.py
+++ b/comicbox/formats/base/online/sources/base.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from comicbox.config.online.settings import OnlineSettings, OnlineSourceCredentials
     from comicbox.formats import MetadataFormats
     from comicbox.formats.base.online.profile import Candidate, ComicProfile
+    from comicbox.formats.base.online.retry import RetryCategory
     from comicbox.formats.sources import MetadataSources
 
 # Cache paths already wiped this process under CacheMode.REFRESH.
@@ -121,6 +122,22 @@ class OnlineSource(ABC):
         precomputed cover hash. The matcher scores them; the lookup mixin
         decides AUTO_WRITE / PROMPT / SKIP / NO_MATCH.
         """
+
+    @staticmethod
+    def classify_retry_exception(exc: BaseException) -> RetryCategory | None:  # noqa: ARG004
+        """
+        Classify one exception from this source's client library.
+
+        Consulted by the with_retry decorator (retry._classify) off the
+        bound instance — the same seam as retry_sleep/on_rate_limit. Each
+        subclass owns its client library's taxonomy: isinstance against
+        the real exception classes, imported inside the method to honor
+        the package-wide lazy-import convention. Return None for
+        exceptions this library did not raise; retry.py then falls back
+        to its conservative default (programmer/config errors raise, the
+        rest retry on the generic schedule).
+        """
+        return None
 
     def lookup_issue(
         self, volume_id: int, issue_number: str | None

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -34,7 +34,7 @@ from comicbox.formats.base.online.profile import (
     CandidateSummary,
     strip_issue_leading_zeros,
 )
-from comicbox.formats.base.online.retry import with_retry
+from comicbox.formats.base.online.retry import RetryCategory, with_retry
 from comicbox.formats.base.online.series_filter import (
     max_calls_for,
     should_keep_volume_name,
@@ -163,6 +163,27 @@ class _SearchBudget:
         return f"search deadline ({_SEARCH_DEADLINE_S:.0f}s) reached"
 
 
+def _classify_service_error(exc: BaseException) -> RetryCategory:
+    """Disambiguate a plain simyan ServiceError by cause and message."""
+    # simyan 3.x client-side cap exhaustion: ServiceError("Service took
+    # too long to respond") whose __cause__ is requests'
+    # Timeout("Rate limit not cleared within max_delay=..."). Only the
+    # cause distinguishes it from a genuine read timeout.
+    if "rate limit not cleared" in str(exc.__cause__ or "").lower():
+        return RetryCategory.RATE_LIMIT
+    cause_response = getattr(exc.__cause__, "response", None)
+    if getattr(cause_response, "status_code", None) == 404:  # noqa: PLR2004
+        return RetryCategory.NOT_FOUND
+    if "not found" in str(exc).lower():  # literal "Resource not found"
+        return RetryCategory.NOT_FOUND
+    # CV serves some errors as HTTP 200 bodies that die in pydantic
+    # validation; a 200-body "Rate Limit Exceeded" (CV status 107)
+    # surfaces here with the offending dict in the message.
+    if "rate limit" in str(exc).lower():
+        return RetryCategory.RATE_LIMIT
+    return RetryCategory.TRANSIENT
+
+
 class ComicVineOnlineSource(OnlineSource):
     """Wraps simyan for the ComicVine API."""
 
@@ -174,6 +195,27 @@ class ComicVineOnlineSource(OnlineSource):
     def is_configured(self) -> bool:
         """ComicVine requires an api_key."""
         return bool(self._credentials.key)
+
+    @override
+    @staticmethod
+    def classify_retry_exception(exc: BaseException) -> RetryCategory | None:
+        """
+        Classify simyan's exceptions.
+
+        simyan encodes HTTP status in its class hierarchy (ServiceError >
+        AuthenticationError on 401, RateLimitError on 429/420), so no
+        message sniffing is needed except where the status can't tell
+        (see `_classify_service_error`).
+        """
+        from simyan.errors import AuthenticationError, RateLimitError, ServiceError
+
+        if isinstance(exc, RateLimitError):  # HTTP 429/420; message may be None
+            return RetryCategory.RATE_LIMIT
+        if isinstance(exc, AuthenticationError):  # raised on HTTP 401 only
+            return RetryCategory.AUTH
+        if isinstance(exc, ServiceError):
+            return _classify_service_error(exc)
+        return None
 
     def _get_session(self) -> Comicvine:
         """

--- a/comicbox/formats/metron_api/online_source.py
+++ b/comicbox/formats/metron_api/online_source.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import math
 import threading
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Final
 
 from loguru import logger
 from typing_extensions import override
@@ -23,7 +23,7 @@ from comicbox.formats.base.online.profile import (
     CandidateSummary,
     strip_issue_leading_zeros,
 )
-from comicbox.formats.base.online.retry import with_retry
+from comicbox.formats.base.online.retry import RetryCategory, with_retry
 from comicbox.formats.base.online.sources.base import (
     OnlineSource,
 )
@@ -94,6 +94,29 @@ def _bi_resource_url(base_issue: Any) -> str:
     return str(url) if url else ""
 
 
+# mokkari collapses non-429 HTTP errors, connection failures, bad JSON,
+# 2xx {"detail": ...} bodies and pydantic failures into one ApiError whose
+# only status signal is text inside repr(HTTPError) — so classifying
+# mokkari genuinely requires message inspection. Rate-limit markers are
+# checked FIRST: a throttle response served with a non-429 status (a CDN
+# 403/420, or a 2xx "Request was throttled" detail body) must retry even
+# when the same message also mentions credentials or an api key. No bare
+# "429" marker — mokkari raises RateLimitError for exactly-429, so a
+# "429" inside ApiError text can only be a URL/id collision. No bare
+# "auth" marker — it substring-matches "author", and ApiError embeds
+# pydantic dumps of comic metadata with creator fields.
+_RATE_LIMIT_MARKERS: Final = ("rate limit", "throttl", "too many requests")
+_AUTH_MARKERS: Final = (
+    "401",
+    "403",
+    "unauthorized",
+    "forbidden",
+    "invalid username",
+    "invalid password",
+    "invalid token",
+)
+
+
 class MetronOnlineSource(OnlineSource):
     """Wraps mokkari for the Metron API."""
 
@@ -106,6 +129,26 @@ class MetronOnlineSource(OnlineSource):
         """Metron accepts an API token (key), or both username and password."""
         credentials = self._credentials
         return bool(credentials.key or (credentials.user and credentials.password))
+
+    @override
+    @staticmethod
+    def classify_retry_exception(exc: BaseException) -> RetryCategory | None:
+        """Classify mokkari's exceptions; see the marker tuples above."""
+        from mokkari.exceptions import ApiError, AuthenticationError, RateLimitError
+
+        if isinstance(exc, RateLimitError):
+            return RetryCategory.RATE_LIMIT
+        if isinstance(exc, AuthenticationError):
+            # Raised only by Session.__init__ for missing local credentials.
+            return RetryCategory.AUTH
+        if isinstance(exc, ApiError):
+            msg = str(exc).lower()
+            if any(marker in msg for marker in _RATE_LIMIT_MARKERS):
+                return RetryCategory.RATE_LIMIT
+            if any(marker in msg for marker in _AUTH_MARKERS):
+                return RetryCategory.AUTH
+            return RetryCategory.TRANSIENT
+        return None
 
     def _get_cache(self) -> Any:
         resolved = self._resolve_response_cache()

--- a/tests/calibration/test_label_metron.py
+++ b/tests/calibration/test_label_metron.py
@@ -269,16 +269,13 @@ def test_label_fixtures_retries_rate_limit_then_succeeds(
 
     Before this fix, Metron's 20/min cap would silently mark CVids as
     "no metron coverage" whenever rate-limiting kicked in (false
-    negative on the calibration ground truth). The retry decorator now
-    catches RateLimitError, honors `retry_after`, and replays.
+    negative on the calibration ground truth). The mokkari Session has
+    no `classify_retry_exception`, so the decorator takes its
+    conservative fallback path: RateLimitError isn't in
+    `_NON_RETRIABLE`, so it's retried, and the `retry_after` server
+    hint is still honored over the generic schedule.
     """
-
-    # Mokkari-shaped exception: the retry decorator keys on the type's
-    # name string "RateLimitError" and on `retry_after`.
-    class RateLimitError(Exception):
-        def __init__(self, retry_after: float) -> None:
-            super().__init__("Rate limit exceeded")
-            self.retry_after = retry_after
+    from mokkari.exceptions import RateLimitError
 
     class _RateLimitedSession:
         def __init__(self) -> None:
@@ -289,7 +286,8 @@ def test_label_fixtures_retries_rate_limit_then_succeeds(
             if self.calls == 1:
                 # Tiny retry_after so the test runs fast — the decorator
                 # honors the server hint over its default schedule.
-                raise RateLimitError(retry_after=0.001)
+                msg = "Rate limit exceeded"
+                raise RateLimitError(msg, retry_after=0.001)
             return [_FakeIssue(500)]
 
     fixtures = [{"file": "/a.cbz", "metron": None, "comicvine": 100}]

--- a/tests/unit/test_comicvine.py
+++ b/tests/unit/test_comicvine.py
@@ -9,6 +9,8 @@ from datetime import timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
+from requests.exceptions import Timeout
+from simyan.errors import AuthenticationError, RateLimitError, ServiceError
 from typing_extensions import override
 
 from comicbox.config.online.settings import (
@@ -22,6 +24,7 @@ from comicbox.config.online.settings import (
     OnlineTuningSettings,
 )
 from comicbox.formats.base.online.profile import ComicProfile
+from comicbox.formats.base.online.retry import RetryCategory
 from comicbox.formats.base.online.series_filter import max_calls_for
 from comicbox.formats.comicvine_api.online_source import (
     ComicVineOnlineSource,
@@ -34,6 +37,23 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import pytest
+
+
+class _HintedRateLimitError(RateLimitError):
+    """
+    Real simyan RateLimitError plus the ``retry_after`` duck attribute.
+
+    simyan sets no such attribute (mokkari does); the decorator's generic
+    hint probe picks it up regardless of library, and a tiny hint keeps
+    the real sleep path fast. The classifier still sees a genuine simyan
+    ``RateLimitError`` instance.
+    """
+
+    def __init__(
+        self, message: str = "Rate limit exceeded", retry_after: float = 0.001
+    ) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 # ------------------------------------------ two-step volume → issues search
@@ -260,11 +280,6 @@ def test_search_retries_volume_search_on_rate_limit(
     vol1 = _FakeBasicVolume(vid=100, name="A")
     issues = {100: [_FakeBasicIssue(iid=5001, number="1", volume_name="A")]}
 
-    class RateLimitError(Exception):
-        def __init__(self, retry_after: float = 0) -> None:
-            super().__init__("Rate limit exceeded")
-            self.retry_after = retry_after
-
     class _RateLimitedCV(_FakeCV):
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
@@ -277,7 +292,7 @@ def test_search_retries_volume_search_on_rate_limit(
                     {"query": query, "max_results": max_results}
                 )
                 self._fail_count += 1
-                raise RateLimitError(retry_after=0.001)
+                raise _HintedRateLimitError
             return super().search_volumes(query, max_results)
 
     fake_cv = _RateLimitedCV(volumes=[vol1], issues_by_volume=issues)
@@ -582,11 +597,6 @@ def test_get_retries_get_volume_on_rate_limit(
         vid=999, name="X-Men", publisher=_FakeGenericEntry(eid=1, name="Marvel")
     )
 
-    class RateLimitError(Exception):
-        def __init__(self, retry_after: float = 0) -> None:
-            super().__init__("Rate limit exceeded")
-            self.retry_after = retry_after
-
     class _RateLimitedGetCV(_FakeCVForGet):
         def __init__(self, *args, **kwargs) -> None:
             super().__init__(*args, **kwargs)
@@ -597,7 +607,7 @@ def test_get_retries_get_volume_on_rate_limit(
             if self._fail_count < 1:
                 self.get_volume_calls.append(volume_id)
                 self._fail_count += 1
-                raise RateLimitError(retry_after=0.001)
+                raise _HintedRateLimitError
             return super().get_volume(volume_id)
 
     fake_cv = _RateLimitedGetCV(issue=issue, volume=volume)
@@ -811,11 +821,6 @@ def test_list_issues_by_volume_retries_on_rate_limit(
     vol = _FakeBasicVolume(vid=100, name="Foo", start_year=2020)
     issue = _FakeBasicIssue(iid=5001, number="1", volume_name="Foo")
 
-    class RateLimitError(Exception):
-        def __init__(self, retry_after: float) -> None:
-            super().__init__("Rate limit exceeded")
-            self.retry_after = retry_after
-
     class _RateLimitedCV(_FakeCV):
         def __init__(self, *args: object, **kwargs: object) -> None:
             super().__init__(*args, **kwargs)  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
@@ -826,7 +831,7 @@ def test_list_issues_by_volume_retries_on_rate_limit(
             if self._fail_count < 1:
                 self.list_issues_calls.append(dict(params or {}))
                 self._fail_count += 1
-                raise RateLimitError(retry_after=0.001)
+                raise _HintedRateLimitError
             return super().list_issues(params, max_results)
 
     fake = _RateLimitedCV(volumes=[vol], issues_by_volume={100: [issue]})
@@ -836,6 +841,102 @@ def test_list_issues_by_volume_retries_on_rate_limit(
     assert [c.issue_id for c in candidates] == [5001]
     # Two list_issues calls: failed + replay.
     assert len(fake.list_issues_calls) == 2
+
+
+# ------------------------------------------- retry-exception classification
+
+
+def test_classify_rate_limit_error_tolerates_none_message() -> None:
+    """Simyan raises RateLimitError on HTTP 429/420; the message may be None."""
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(RateLimitError(None))
+        is RetryCategory.RATE_LIMIT
+    )
+
+
+def test_classify_authentication_error_is_auth() -> None:
+    exc = AuthenticationError("Invalid API Key")
+    assert ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.AUTH
+
+
+def test_classify_client_side_cap_timeout_is_rate_limit() -> None:
+    """
+    Simyan 3.x client-side cap exhaustion is only visible in __cause__.
+
+    The ServiceError message is the generic "Service took too long to
+    respond"; the chained requests Timeout carries the rate-limit text.
+    """
+    exc = ServiceError("Service took too long to respond")
+    exc.__cause__ = Timeout("Rate limit not cleared within max_delay=40.0s")
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.RATE_LIMIT
+    )
+
+
+def test_classify_genuine_read_timeout_is_transient() -> None:
+    """The same ServiceError with a plain read timeout cause stays generic."""
+    exc = ServiceError("Service took too long to respond")
+    exc.__cause__ = Timeout(
+        "HTTPSConnectionPool(host='comicvine.gamespot.com', port=443): Read timed out."
+    )
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.TRANSIENT
+    )
+
+
+def test_classify_resource_not_found() -> None:
+    exc = ServiceError("Resource not found")
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.NOT_FOUND
+    )
+
+
+def test_classify_404_cause_without_not_found_text() -> None:
+    """
+    A 404 is caught by its cause's status even when the message doesn't say so.
+
+    The message branch below only fires on simyan's literal "Resource not
+    found"; this probes `__cause__.response.status_code`, which is where
+    `requests.HTTPError` actually carries the status.
+    """
+    from requests import HTTPError, Response
+
+    response = Response()
+    response.status_code = 404
+    cause = HTTPError(
+        "404 Client Error for url: https://comicvine.gamespot.com/api/",
+        response=response,
+    )
+    exc = ServiceError("404: Unable to parse response as Json")
+    exc.__cause__ = cause
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.NOT_FOUND
+    )
+
+
+def test_classify_server_error_is_transient() -> None:
+    exc = ServiceError("500: {'error': 'Internal Server Error'}")
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.TRANSIENT
+    )
+
+
+def test_classify_cv_status_107_body_is_rate_limit() -> None:
+    """CV serves some rate-limit errors as 200 bodies that die in pydantic."""
+    exc = ServiceError(
+        "1 validation error for VolumeListResponse\n"
+        "  Value error, {'error': 'Rate Limit Exceeded', 'status_code': 107}"
+        " [type=value_error]"
+    )
+    assert (
+        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.RATE_LIMIT
+    )
+
+
+def test_classify_non_simyan_exception_is_unclaimed() -> None:
+    """Anything outside simyan's hierarchy returns None (decorator fallback)."""
+    exc = RuntimeError("connection reset by peer")
+    assert ComicVineOnlineSource.classify_retry_exception(exc) is None
 
 
 # ------------------------------------------------------- client construction

--- a/tests/unit/test_metron_source.py
+++ b/tests/unit/test_metron_source.py
@@ -14,10 +14,16 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from mokkari.exceptions import ApiError, AuthenticationError, RateLimitError
 from typing_extensions import override
 
 from comicbox.config.online.settings import OnlineSettings, OnlineSourceCredentials
 from comicbox.formats.base.online.profile import ComicProfile
+from comicbox.formats.base.online.retry import (
+    _RATE_LIMIT_SCHEDULE,
+    RetryCategory,
+    with_retry,
+)
 from comicbox.formats.metron_api.online_source import MetronOnlineSource
 
 
@@ -216,13 +222,6 @@ def test_search_retries_per_call_on_rate_limit(
         "A": [_FakeBaseIssue(iid=5001, number="1", series_name="A", series_id=100)],
     }
 
-    # mokkari-shaped exception: the retry decorator keys on the type
-    # name string "RateLimitError" and the `retry_after` attribute.
-    class RateLimitError(Exception):
-        def __init__(self, retry_after: float) -> None:
-            super().__init__("Rate limit exceeded")
-            self.retry_after = retry_after
-
     class _RateLimitedMokkari(_FakeMokkari):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)
@@ -234,7 +233,11 @@ def test_search_retries_per_call_on_rate_limit(
                 # Record the failed attempt too so we can assert retry count.
                 self.issues_list_calls.append(dict(params or {}))
                 self._fail_count += 1
-                raise RateLimitError(retry_after=0.001)
+                # Real mokkari exception: `classify_retry_exception` keys on
+                # the type, and the tiny `retry_after` hint keeps the real
+                # sleep path fast.
+                msg = "Rate limit exceeded"
+                raise RateLimitError(msg, retry_after=0.001)
             return super().issues_list(params)
 
     fake = _RateLimitedMokkari(issues_by_key=issues)
@@ -638,3 +641,112 @@ def test_get_session_memoizes_client(monkeypatch: pytest.MonkeyPatch) -> None:
     second = src._get_session()
     assert first is second
     assert builds["n"] == 1
+
+
+# ---------------------------------------------------- retry classification
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        pytest.param(
+            RateLimitError(
+                "Rate limit exceeded: You have reached the 20 requests per "
+                "minute limit. Please wait 30 seconds before making another "
+                "request.",
+                retry_after=0.0,
+            ),
+            RetryCategory.RATE_LIMIT,
+            id="rate-limit-error",
+        ),
+        # mokkari's AuthenticationError takes no arguments; it bakes in its
+        # own "Missing authorization information" message.
+        pytest.param(
+            AuthenticationError(),
+            RetryCategory.AUTH,
+            id="authentication-error",
+        ),
+        pytest.param(
+            ApiError(
+                "HTTP error: HTTPError('401 Client Error: Unauthorized for "
+                "url: https://metron.cloud/api/issue/1/') | Response body: "
+                '{"detail": "Invalid token."}'
+            ),
+            RetryCategory.AUTH,
+            id="api-error-401",
+        ),
+        pytest.param(
+            ApiError("Invalid username/password."),
+            RetryCategory.AUTH,
+            id="api-error-bad-credentials",
+        ),
+        # SPEC-BUG regression: a throttle body served as ApiError must
+        # classify as RATE_LIMIT (rate-limit markers are checked FIRST),
+        # not fall through to AUTH or TRANSIENT.
+        pytest.param(
+            ApiError("Rate limit exceeded for this api key. Expires in 42 seconds."),
+            RetryCategory.RATE_LIMIT,
+            id="api-error-throttle-body",
+        ),
+        pytest.param(
+            ApiError("Connection error: ReadTimeout(ReadTimeoutError(...))"),
+            RetryCategory.TRANSIENT,
+            id="api-error-connection",
+        ),
+        # Pins that the old bare-"auth" marker is gone: an ApiError carrying
+        # a pydantic dump with a creator-ish "authors" field must not
+        # substring-match into AUTH.
+        pytest.param(
+            ApiError(
+                "Validation error: {'name': 'Watchmen #5', 'authors': ['Alan Moore']}"
+            ),
+            RetryCategory.TRANSIENT,
+            id="api-error-authors-field-not-auth",
+        ),
+        # Not a mokkari exception — the classifier declines and the retry
+        # decorator's conservative fallback takes over.
+        pytest.param(
+            LookupError("metron: issue 5 not found"),
+            None,
+            id="non-mokkari-declined",
+        ),
+    ],
+)
+def test_classify_retry_exception(
+    exc: BaseException, expected: RetryCategory | None
+) -> None:
+    assert MetronOnlineSource.classify_retry_exception(exc) is expected
+
+
+def test_with_retry_replays_api_error_throttle_body() -> None:
+    """
+    End-to-end SPEC-BUG regression through the decorator.
+
+    A throttle response surfaced as `ApiError` (no `retry_after` hint)
+    must be classified RATE_LIMIT, sleep the rate-limit schedule's first
+    delay, and replay the call — not raise or use the generic schedule.
+    """
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    class _Stub:
+        classify_retry_exception = staticmethod(
+            MetronOnlineSource.classify_retry_exception
+        )
+        on_rate_limit = None
+        retry_sleep = None
+        name = "metron"
+
+        @with_retry(sleep=sleeps.append)
+        def fetch(self) -> str:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                msg = "Rate limit exceeded for this api key."
+                raise ApiError(msg)
+            return "ok"
+
+    assert _Stub().fetch() == "ok"
+    # The call was replayed: the throttled attempt + the successful one.
+    assert calls["n"] == 2
+    # No retry_after hint on ApiError, so the rate-limit schedule applies.
+    assert sleeps == [_RATE_LIMIT_SCHEDULE[0]]

--- a/tests/unit/test_online_retry.py
+++ b/tests/unit/test_online_retry.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from functools import partial, wraps
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import pytest
 
@@ -10,6 +11,7 @@ from comicbox.exceptions import OnlineLookupAbortedError
 from comicbox.formats.base.online.retry import (
     _MAX_TOTAL_WAIT_S,
     _RATE_LIMIT_SCHEDULE,
+    RetryCategory,
     clear_cancel,
     interruptible_sleep,
     request_cancel,
@@ -19,24 +21,60 @@ from comicbox.formats.base.online.retry import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+T = TypeVar("T")
 
-class _FakeRateLimitError(Exception):
+
+class _RateLimitedError(Exception):
+    """Stands in for a client library's rate-limit error."""
+
     def __init__(
         self, msg: str = "rate limited", retry_after: float | None = None
     ) -> None:
         super().__init__(msg)
-        self.retry_after = retry_after
+        if retry_after is not None:
+            self.retry_after = retry_after
 
 
-# Match what mokkari raises by name (the retry decorator key off the class name).
-_FakeRateLimitError.__name__ = "RateLimitError"
+class _AuthFailedError(Exception):
+    """Stands in for a client library's auth error."""
 
 
-class _FakeAuthError(Exception):
-    pass
+class _NotFoundError(Exception):
+    """Stands in for a client library's permanent not-found response."""
 
 
-_FakeAuthError.__name__ = "AuthenticationError"
+class _StubSource:
+    """The minimal source shape the retry decorator reads off ``args[0]``."""
+
+    name = "stub"
+    on_rate_limit: Any = None
+    retry_sleep: Any = None
+
+    @staticmethod
+    def classify_retry_exception(exc: BaseException) -> RetryCategory | None:
+        if isinstance(exc, _RateLimitedError):
+            return RetryCategory.RATE_LIMIT
+        if isinstance(exc, _AuthFailedError):
+            return RetryCategory.AUTH
+        if isinstance(exc, _NotFoundError):
+            return RetryCategory.NOT_FOUND
+        return None
+
+
+def _stub_retry(
+    source: _StubSource | None = None, **retry_kwargs: Any
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Like ``with_retry``, but bound to a stub source instance as ``args[0]``."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @with_retry(**retry_kwargs)
+        @wraps(func)
+        def method(_self: _StubSource, *args: Any, **kwargs: Any) -> T:
+            return func(*args, **kwargs)
+
+        return partial(method, source if source is not None else _StubSource())
+
+    return decorator
 
 
 def _capture_sleeps() -> tuple[list[float], Callable[[float], None]]:
@@ -94,12 +132,12 @@ def test_rate_limit_retries_use_longer_schedule() -> None:
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(sleep=fake_sleep)
+    @_stub_retry(sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
         if calls < 3:
-            raise _FakeRateLimitError
+            raise _RateLimitedError
         return "ok"
 
     assert fn() == "ok"
@@ -114,12 +152,12 @@ def test_honors_retry_after_hint_over_rate_limit_schedule() -> None:
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(sleep=fake_sleep)
+    @_stub_retry(sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
         if calls < 2:
-            raise _FakeRateLimitError(retry_after=12.5)
+            raise _RateLimitedError(retry_after=12.5)
         return "ok"
 
     fn()
@@ -138,12 +176,12 @@ def test_zero_retry_after_hint_falls_back_to_schedule() -> None:
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(sleep=fake_sleep)
+    @_stub_retry(sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
         if calls < 2:
-            raise _FakeRateLimitError(retry_after=0.0)
+            raise _RateLimitedError(retry_after=0.0)
         return "ok"
 
     fn()
@@ -180,13 +218,13 @@ def test_rate_limit_has_its_own_budget() -> None:
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(max_retries=1, sleep=fake_sleep)
+    @_stub_retry(max_retries=1, sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
-        raise _FakeRateLimitError
+        raise _RateLimitedError
 
-    with pytest.raises(_FakeRateLimitError):
+    with pytest.raises(_RateLimitedError):
         fn()
     # 1 + len(_RATE_LIMIT_SCHEDULE) attempts, with len(schedule) sleeps.
     assert calls == 1 + len(_RATE_LIMIT_SCHEDULE)
@@ -198,54 +236,31 @@ def test_auth_error_does_not_retry() -> None:
     calls = 0
     msg = "401 unauthorized"
 
-    @with_retry(max_retries=5, sleep=fake_sleep)
+    @_stub_retry(max_retries=5, sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
-        raise _FakeAuthError(msg)
+        raise _AuthFailedError(msg)
 
-    with pytest.raises(_FakeAuthError):
+    with pytest.raises(_AuthFailedError):
         fn()
     assert calls == 1
     assert sleeps == []
 
 
-def test_auth_error_terminal_without_message_marker() -> None:
-    """Simyan's AuthenticationError carries CV's marker-less 'Invalid API Key'."""
+def test_not_found_error_does_not_retry() -> None:
+    """A NOT_FOUND verdict is terminal: no replay, no sleeps."""
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
-    msg = "Invalid API Key"
+    msg = "Resource not found"
 
-    @with_retry(max_retries=5, sleep=fake_sleep)
+    @_stub_retry(max_retries=5, sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
-        raise _FakeAuthError(msg)
+        raise _NotFoundError(msg)
 
-    with pytest.raises(_FakeAuthError):
-        fn()
-    assert calls == 1
-    assert sleeps == []
-
-
-def test_api_error_with_credential_message_does_not_retry() -> None:
-    """Mokkari raises generic ApiError with the server's credential message."""
-
-    class _FakeApiError(Exception):
-        pass
-
-    _FakeApiError.__name__ = "ApiError"
-    sleeps, fake_sleep = _capture_sleeps()
-    calls = 0
-    msg = "Invalid username/password."
-
-    @with_retry(max_retries=5, sleep=fake_sleep)
-    def fn() -> str:
-        nonlocal calls
-        calls += 1
-        raise _FakeApiError(msg)
-
-    with pytest.raises(_FakeApiError):
+    with pytest.raises(_NotFoundError):
         fn()
     assert calls == 1
     assert sleeps == []
@@ -264,29 +279,6 @@ def test_lookup_error_does_not_retry() -> None:
         raise LookupError(msg)
 
     with pytest.raises(LookupError):
-        fn()
-    assert calls == 1
-    assert sleeps == []
-
-
-def test_service_error_not_found_does_not_retry() -> None:
-    """Simyan maps upstream 404s to ServiceError('Resource not found')."""
-
-    class _FakeServiceError(Exception):
-        pass
-
-    _FakeServiceError.__name__ = "ServiceError"
-    sleeps, fake_sleep = _capture_sleeps()
-    calls = 0
-    msg = "Resource not found"
-
-    @with_retry(max_retries=5, sleep=fake_sleep)
-    def fn() -> str:
-        nonlocal calls
-        calls += 1
-        raise _FakeServiceError(msg)
-
-    with pytest.raises(_FakeServiceError):
         fn()
     assert calls == 1
     assert sleeps == []
@@ -405,7 +397,7 @@ def test_mixed_failures_track_budgets_independently() -> None:
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(max_retries=3, sleep=fake_sleep)
+    @_stub_retry(max_retries=3, sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
@@ -413,7 +405,7 @@ def test_mixed_failures_track_budgets_independently() -> None:
             msg = "transient"
             raise RuntimeError(msg)  # generic attempt 0
         if calls == 2:
-            raise _FakeRateLimitError  # rate-limit attempt 0
+            raise _RateLimitedError  # rate-limit attempt 0
         if calls == 3:
             msg = "transient"
             raise RuntimeError(msg)  # generic attempt 1
@@ -433,15 +425,23 @@ def test_simyan_client_cap_timeout_uses_rate_limit_schedule() -> None:
     Timeout("Rate limit not cleared within max_delay=...") and simyan
     wraps it in ServiceError("Service took too long to respond"). That is
     a rate-limit condition — the generic 31s budget can't outlast an
-    hourly cap. Uses the real simyan/requests classes to pin the shape.
+    hourly cap. Uses the real simyan/requests classes AND the real
+    ComicVine classifier to pin the shape end-to-end.
     """
     from requests.exceptions import Timeout
     from simyan.errors import ServiceError
 
+    from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
+
+    class _ComicVineStub(_StubSource):
+        classify_retry_exception = staticmethod(
+            ComicVineOnlineSource.classify_retry_exception
+        )
+
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(max_retries=5, sleep=fake_sleep)
+    @_stub_retry(source=_ComicVineStub(), max_retries=5, sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
@@ -460,10 +460,17 @@ def test_genuine_timeout_stays_on_generic_schedule() -> None:
     from requests.exceptions import Timeout
     from simyan.errors import ServiceError
 
+    from comicbox.formats.comicvine_api.online_source import ComicVineOnlineSource
+
+    class _ComicVineStub(_StubSource):
+        classify_retry_exception = staticmethod(
+            ComicVineOnlineSource.classify_retry_exception
+        )
+
     sleeps, fake_sleep = _capture_sleeps()
     calls = 0
 
-    @with_retry(max_retries=5, sleep=fake_sleep)
+    @_stub_retry(source=_ComicVineStub(), max_retries=5, sleep=fake_sleep)
     def fn() -> str:
         nonlocal calls
         calls += 1
@@ -545,11 +552,11 @@ def test_total_wait_ceiling_stops_a_server_hint_loop() -> None:
     """
     sleeps, fake_sleep = _capture_sleeps()
 
-    @with_retry(max_retries=1, sleep=fake_sleep)
+    @_stub_retry(max_retries=1, sleep=fake_sleep)
     def fn() -> str:
-        raise _FakeRateLimitError(retry_after=3600.0)
+        raise _RateLimitedError(retry_after=3600.0)
 
-    with pytest.raises(_FakeRateLimitError):
+    with pytest.raises(_RateLimitedError):
         fn()
     assert sum(sleeps) <= _MAX_TOTAL_WAIT_S
     # One 3600s hint exactly fills the ceiling; a second would breach it.
@@ -560,11 +567,11 @@ def test_total_wait_ceiling_is_configurable_per_call() -> None:
     """A tighter ceiling ends the loop sooner, without truncating a delay."""
     sleeps, fake_sleep = _capture_sleeps()
 
-    @with_retry(max_retries=1, sleep=fake_sleep, max_wait_s=100.0)
+    @_stub_retry(max_retries=1, sleep=fake_sleep, max_wait_s=100.0)
     def fn() -> str:
-        raise _FakeRateLimitError
+        raise _RateLimitedError
 
-    with pytest.raises(_FakeRateLimitError):
+    with pytest.raises(_RateLimitedError):
         fn()
     # 30 + 60 = 90 fits; the next scheduled delay (120) would breach 100,
     # so the loop ends rather than sleeping a shortened, useless wait.
@@ -595,11 +602,11 @@ def test_default_sleep_is_interruptible() -> None:
     """
     calls = 0
 
-    @with_retry(max_retries=3)
+    @_stub_retry(max_retries=3)
     def fn() -> str:
         nonlocal calls
         calls += 1
-        raise _FakeRateLimitError
+        raise _RateLimitedError
 
     request_cancel()
     try:
@@ -621,17 +628,16 @@ def test_instance_retry_sleep_still_overrides_the_new_default() -> None:
     """OnlineSession's per-instance cancellable sleep keeps winning."""
     sleeps, fake_sleep = _capture_sleeps()
 
-    class _Source:
+    class _Source(_StubSource):
         retry_sleep = staticmethod(fake_sleep)
-        on_rate_limit = None
 
         @with_retry(max_retries=2)
         def fetch(self) -> str:
-            raise _FakeRateLimitError
+            raise _RateLimitedError
 
     request_cancel()
     try:
-        with pytest.raises(_FakeRateLimitError):
+        with pytest.raises(_RateLimitedError):
             _Source().fetch()
     finally:
         clear_cancel()

--- a/tests/unit/test_rate_limits.py
+++ b/tests/unit/test_rate_limits.py
@@ -516,18 +516,20 @@ def test_partial_rate_limit_override() -> None:
 # ----------------------------------------------------- with_retry retry_after
 
 
+class _StubMetronSource:
+    """Minimal instance seam for `with_retry`: real Metron classifier, no session."""
+
+    classify_retry_exception = staticmethod(MetronOnlineSource.classify_retry_exception)
+    on_rate_limit = None
+    retry_sleep = None
+    name = "metron"
+
+
 def test_with_retry_honors_long_retry_after() -> None:
     """A server hint of 300s is honored, not capped at our 60s schedule."""
+    from mokkari.exceptions import RateLimitError
+
     from comicbox.formats.base.online.retry import with_retry
-
-    # mokkari-style RateLimitError with retry_after attribute.
-    class FakeRateLimitError(Exception):
-        def __init__(self, retry_after: float) -> None:
-            super().__init__(f"retry after {retry_after}")
-            self.retry_after = retry_after
-
-    # Override the type-name check by naming the class accordingly.
-    FakeRateLimitError.__name__ = "RateLimitError"
 
     sleeps: list[float] = []
     call_count = {"n": 0}
@@ -535,41 +537,40 @@ def test_with_retry_honors_long_retry_after() -> None:
     def fake_sleep(s: float) -> None:
         sleeps.append(s)
 
-    @with_retry(max_retries=2, sleep=fake_sleep)
-    def flaky() -> str:
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise FakeRateLimitError(retry_after=300.0)
-        return "ok"
+    class Stub(_StubMetronSource):
+        @with_retry(max_retries=2, sleep=fake_sleep)
+        def flaky(self) -> str:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                msg = "retry after 300.0"
+                raise RateLimitError(msg, retry_after=300.0)
+            return "ok"
 
-    result = flaky()
+    result = Stub().flaky()
     assert result == "ok"
     assert sleeps == [300.0]  # exact server hint, NOT clamped to 60s
 
 
 def test_with_retry_clamps_excessive_retry_after() -> None:
     """A wildly-large hint (e.g. 1 day) is clamped to the 1-hour ceiling."""
+    from mokkari.exceptions import RateLimitError
+
     from comicbox.formats.base.online.retry import with_retry
-
-    class FakeRateLimitError(Exception):
-        def __init__(self) -> None:
-            super().__init__("nope")
-            self.retry_after = 86_400.0  # 1 day
-
-    FakeRateLimitError.__name__ = "RateLimitError"
 
     sleeps: list[float] = []
 
     def fake_sleep(s: float) -> None:
         sleeps.append(s)
 
-    @with_retry(max_retries=1, sleep=fake_sleep)
-    def flaky() -> str:
-        if not sleeps:
-            raise FakeRateLimitError
-        return "ok"
+    class Stub(_StubMetronSource):
+        @with_retry(max_retries=1, sleep=fake_sleep)
+        def flaky(self) -> str:
+            if not sleeps:
+                msg = "nope"
+                raise RateLimitError(msg, retry_after=86_400.0)  # 1 day
+            return "ok"
 
-    flaky()
+    Stub().flaky()
     assert sleeps == [3600.0]  # clamped to 1-hour ceiling
 
 


### PR DESCRIPTION
## What

Replaces the shared, string-matching retry classifier in `comicbox/formats/base/online/retry.py` with per-library classifiers that each online source contributes for its own client library.

`retry.py` gains a `RetryCategory` enum (`RATE_LIMIT` / `AUTH` / `NOT_FOUND` / `TRANSIENT`) and resolves the source's `classify_retry_exception` off `args[0]` — the same instance seam already used for `retry_sleep` and `on_rate_limit`. It no longer knows anything about mokkari or simyan.

## Why

Errors were classified by `type(exc).__name__` plus message substrings, shared across two libraries with different taxonomies. Both define a `RateLimitError`; only mokkari defines `ApiError`. The shared auth marker list contained `"api key"`, so a transient mokkari `ApiError` reading `"rate limit exceeded for this api key"` was classified as a permanent auth failure and never retried.

## How each source classifies

- **Metron / mokkari** still inspects messages, because mokkari genuinely requires it: non-429 HTTP errors, connection failures, bad JSON, `{"detail": ...}` bodies and pydantic failures all collapse into one `ApiError` whose only status signal is text inside `repr(HTTPError)`. Rate-limit markers are now checked **first**, so a throttle response served with a non-429 status (a CDN 403/420, or a 2xx "Request was throttled" body) retries even when the same message mentions credentials.
- **ComicVine / simyan** needs almost none: its class hierarchy already encodes HTTP status (`AuthenticationError` on 401, `RateLimitError` on 429/420). Message inspection survives only where status can't tell — the client-side rate cap (distinguished by `__cause__`) and CV's errors-served-as-200-bodies.

## Deliberate behavior changes

1. A mokkari `ApiError` with rate-limit wording — including "…for this api key" — now retries on the rate-limit schedule. This is the reported bug.
2. The `"api key"` and bare `"auth"` markers are dropped. `"api key"` never fired for simyan (the library it was added for, which has no `ApiError`) and only ever misread Metron messages; bare `"auth"` substring-matches `"author"`, a real hazard since `ApiError` embeds pydantic dumps of comic metadata with creator fields.
3. A CV rate limit served as a 200 body (status 107, surfacing as a pydantic `ServiceError`) now routes to the rate-limit schedule instead of the generic 31s budget.
4. simyan 404s are additionally detected via `__cause__.response.status_code`. The old probe read `__cause__.status_code`, which `requests.HTTPError` does not have — it was dead code, and only the message branch ever worked.

Kept as-is: simyan `AuthenticationError` stays conclusively `AUTH` even if its 401 body mentions rate limits (401 is auth by protocol); mokkari 404s stay `TRANSIENT`, as before.

## Preserved

mokkari `retry_after` hints (including the `<=0` means no-hint rule), the simyan client-cap route to the rate-limit schedule, not-found and programmer errors never retried, API-key redaction, `on_rate_limit` notification, and cancel/sleep wiring. Unclaimed exceptions fall back to exactly today's behavior: `_NON_RETRIABLE` raises immediately, everything else retries on the generic schedule.

## Reviewer notes

- **Test fakes changed shape.** Exceptions with a spoofed `__name__` no longer classify as anything, by design. Tests now construct real `mokkari.exceptions` / `simyan.errors` instances. Every sleep-list and call-count assertion was carried over verbatim; the conversion added classifier unit tests per library plus an end-to-end regression asserting the reported message is replayed on `_RATE_LIMIT_SCHEDULE[0]`.
- **`tests/calibration/label_metron.py`** decorates a free function whose `args[0]` is a mokkari `Session`, not a source, so it has no classifier and now uses the fallback path. A real `RateLimitError` is still retried and its `retry_after` hint still honored — just on the generic budget. Acceptable for a calibration script; a one-line attribute assignment would restore schedule fidelity if wanted.
- Two coverage gaps found by an adversarial review pass were closed with mutation-verified tests: `NOT_FOUND` terminality end-to-end, and the 404-via-`__cause__.response.status_code` branch.

## Verification

`make fix`, `make lint` (incl. basedpyright), `make ty`, and the full suite: **2022 passed, 1 skipped** (the skip is a pre-existing unrelated one in `test_online_matcher.py`).