### PR TITLE
Adopt simyan 4.0.0: typed Comic Vine errors, simpler cache policy, per-pool rate-limit budget

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,8 +42,12 @@
     - Web urls in the Notes field are read into `urls`.
     - New `SourceStarted` online event, emitted once per source that actually
       runs, including on the fast paths `SearchStarted` never covered.
+    - `OnlineSession.rate_limit_status()` now reports Comic Vine's remaining
+      hourly budget for each endpoint it has used, not just Metron's.
 
 - Fixes
+    - An invalid Comic Vine API key now fails immediately instead of retrying
+      for half a minute first. A malformed Comic Vine search fails at once too.
     - Online tagging reports a match only when metadata was really applied. A
       failed `--id` fetch or stored-id refresh counted the comic as tagged and
       rewrote it with its own metadata.
@@ -119,6 +123,8 @@
       of calls per comic — `--effort thorough` restores the unbounded search —
       and rate-limit waits are interruptible, so Ctrl-C is no longer ignored for
       minutes.
+    - Cached Comic Vine responses live for the configured `online.cache.ttl`
+      instead of expiring early when Comic Vine's own cache headers said so.
     - Comicbox starts about a third faster and building a `Comicbox` is about
       forty times cheaper: schemas, the CLI help tables and the config files are
       built once instead of on every import or instance. As with

--- a/comicbox/config/online/settings.py
+++ b/comicbox/config/online/settings.py
@@ -174,7 +174,7 @@ class OnlineSourceLimits:
     # are accepted but ignored with a warning at client build.
     per_minute: int | None = None
     per_day: int | None = None
-    # Historical ComicVine overrides. simyan 3.x builds its rate limiter
+    # Historical ComicVine overrides. simyan builds its rate limiter
     # internally (1/sec, 200/hr) with no injection point; these are
     # accepted but ignored with a warning at client build.
     per_second: int | None = None

--- a/comicbox/formats/base/online/rate_limits.py
+++ b/comicbox/formats/base/online/rate_limits.py
@@ -4,11 +4,11 @@ Rate limits for online sources, for citation / audit.
 Neither upstream library takes a local override anymore: mokkari>=4.0.1
 tracks Metron's actual per-user limits from the `X-RateLimit-*` response
 headers instead of a fixed local bucket (see `MetronOnlineSource`'s
-`_warn_ignored_rate_limit_overrides`), and simyan 3.x builds its ComicVine
+`_warn_ignored_rate_limit_overrides`), and simyan builds its ComicVine
 limiter internally with no injection point at all. This module exists so
 the numbers are visible in our codebase (rather than hidden in transitive
-dependencies) and can be cited / audited, and so `online_estimate` has a
-stable constant to derive its pacing math from.
+dependencies) and can be cited / audited, and so the two consumers below
+have a stable constant to work from.
 
 Sources:
 - Metron: 20 req/min burst, fixed for every user. The daily sustained
@@ -28,8 +28,10 @@ from typing import Final
 # this stays a citable constant. There is no equivalent constant for the
 # daily sustained limit anymore — see the module docstring.
 METRON_DEFAULT_PER_MINUTE: Final[int] = 20
-# simyan 3.x enforces these internally (hardcoded literals, no importable
-# constant). Kept for citation; `online_estimate` derives its pacing math
-# from the hourly cap.
+# simyan enforces these internally (hardcoded literals, no importable
+# constant), so these are the only place the numbers appear by name.
+# Two consumers read the hourly cap: `online_estimate` derives its pacing
+# math from it, and the ComicVine source subtracts spent bucket rows from
+# it to report a remaining budget.
 COMICVINE_DEFAULT_PER_SECOND: Final[int] = 1
 COMICVINE_DEFAULT_PER_HOUR: Final[int] = 200

--- a/comicbox/formats/base/online/retry.py
+++ b/comicbox/formats/base/online/retry.py
@@ -4,8 +4,8 @@ Exponential-backoff retry decorator for online API calls.
 Wraps a callable that talks to an upstream API. Retries transient errors
 (rate-limit, 5xx) with exponential backoff up to `max_retries`. Honors the
 upstream's `retry_after` hint when present (mokkari sets this on
-`RateLimitError`). Permanent failures — auth errors and not-found
-responses — are never retried.
+`RateLimitError`). Permanent failures — auth errors, not-found responses,
+and requests the upstream rejected as malformed — are never retried.
 
 Which failure is which is the source's call, not this module's: the
 bound instance's ``classify_retry_exception`` (each source contributes
@@ -44,9 +44,9 @@ class RetryCategory(Enum):
     TRANSIENT = auto()  # generic exponential schedule
 
 
-# ComicVine sends the API key as a query param (simyan 3.x), and requests
-# embeds the full URL — key included — in HTTPError/ConnectionError
-# messages that ride along as ``__cause__`` of every simyan error.
+# ComicVine sends the API key as a query param, and requests embeds the
+# full URL — key included — in HTTPError/ConnectionError messages that
+# ride along as ``__cause__`` of every simyan error.
 _API_KEY_RE: Final = re.compile(r"(api_key=)[^&\s'\"]+")
 
 

--- a/comicbox/formats/base/online/retry.py
+++ b/comicbox/formats/base/online/retry.py
@@ -40,6 +40,7 @@ class RetryCategory(Enum):
     RATE_LIMIT = auto()  # rate-limit schedule + budget; on_rate_limit fires
     AUTH = auto()  # never retried
     NOT_FOUND = auto()  # never retried
+    INVALID = auto()  # never retried; malformed request, a bug on our side
     TRANSIENT = auto()  # generic exponential schedule
 
 
@@ -229,12 +230,23 @@ def _is_retriable(exc: BaseException, category: RetryCategory | None) -> bool:
     """
     Return True for transient errors worth retrying.
 
-    A classifier's AUTH / NOT_FOUND verdicts are terminal; its RATE_LIMIT
-    and TRANSIENT verdicts are trusted (no vendor exception subclasses
-    the `_NON_RETRIABLE` tuple). Unclaimed exceptions raise immediately
-    when they signal programmer/config errors and retry otherwise.
+    A classifier's AUTH / NOT_FOUND / INVALID verdicts are terminal; its
+    RATE_LIMIT and TRANSIENT verdicts are trusted (no vendor exception
+    subclasses the `_NON_RETRIABLE` tuple). Unclaimed exceptions raise
+    immediately when they signal programmer/config errors and retry
+    otherwise.
+
+    INVALID is the classified twin of `_NON_RETRIABLE`: the upstream
+    rejected the request itself, so replaying it verbatim can only fail
+    the same way. It exists because some libraries report a malformed
+    request as a generic service error rather than as a distinct
+    exception class, leaving the message as the only signal.
     """
-    if category in (RetryCategory.AUTH, RetryCategory.NOT_FOUND):
+    if category in (
+        RetryCategory.AUTH,
+        RetryCategory.NOT_FOUND,
+        RetryCategory.INVALID,
+    ):
         return False
     if category is None:
         return not isinstance(exc, _NON_RETRIABLE)

--- a/comicbox/formats/base/online/sources/base.py
+++ b/comicbox/formats/base/online/sources/base.py
@@ -53,6 +53,25 @@ def refresh_cache_unlink_once(cache_path: Path) -> None:
         logger.debug(f"refresh-cache: removed {cache_path}")
 
 
+def resolve_cache_db_path(
+    cache_dir: Path | None, name: str, suffix: str = "cache", *, create: bool = True
+) -> Path:
+    """
+    Resolve a source's cache sqlite path.
+
+    Honours an explicit ``online.cache_dir``; otherwise uses the
+    platformdirs user cache path for comicbox. ``create=False`` skips
+    making the parent directory, for read-only callers (a budget
+    readout) that must not have side effects.
+    """
+    if cache_dir is None:
+        cache_dir = user_cache_path("comicbox") / "online"
+    cache_dir = Path(cache_dir).expanduser()
+    if create:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{name}_{suffix}.sqlite"
+
+
 class OnlineSource(ABC):
     """
     Contract every online provider must implement.
@@ -236,14 +255,8 @@ class OnlineSource(ABC):
 
     def cache_db_path(self, suffix: str = "cache") -> Path:
         """
-        Resolve the cache sqlite path for this source.
+        Resolve the cache sqlite path for this source, creating its parent.
 
-        Honours `online.cache_dir` when set; otherwise uses the platformdirs
-        user cache path for comicbox. Creates the parent directory.
+        See `resolve_cache_db_path`, which read-only callers share.
         """
-        cache_dir = self._settings.cache.dir
-        if cache_dir is None:
-            cache_dir = user_cache_path("comicbox") / "online"
-        cache_dir = Path(cache_dir).expanduser()
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        return cache_dir / f"{self.name}_{suffix}.sqlite"
+        return resolve_cache_db_path(self._settings.cache.dir, self.name, suffix)

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -165,6 +165,24 @@ class _SearchBudget:
         return f"search deadline ({_SEARCH_DEADLINE_S:.0f}s) reached"
 
 
+# Comic Vine reports application-level failures as an HTTP 200 whose body
+# carries a non-1 `status_code`. simyan raises the typed
+# AuthenticationError (CV 100 "Invalid API Key") and RateLimitError (CV
+# 107 "Rate Limit Exceeded") for the two it recognizes, and a plain
+# ServiceError carrying the body's `error` string for everything else —
+# so for those the message is the only signal. Matched as lower-cased
+# substrings; first hit wins.
+_CV_BODY_ERRORS: Final[tuple[tuple[str, RetryCategory], ...]] = (
+    # CV 101, plus simyan's own wording for an HTTP 404.
+    ("object not found", RetryCategory.NOT_FOUND),
+    ("resource not found", RetryCategory.NOT_FOUND),
+    # CV 102 / 104: comicbox sent a malformed url or filter expression.
+    # That is our bug, not a server hiccup, so replaying it verbatim can
+    # only fail the same way — fail fast and let the traceback show.
+    ("error in url format", RetryCategory.INVALID),
+    ("filter error", RetryCategory.INVALID),
+)
+
 # What each HTTP status means once recovered from a plain ServiceError.
 # simyan raises dedicated classes for 401 and 429/420 when it can parse
 # the error body; these are the same statuses arriving down the
@@ -202,9 +220,27 @@ def _service_error_status(exc: BaseException) -> int | None:
     return int(match.group(1)) if match else None
 
 
+def _classify_body_error(message: str) -> RetryCategory | None:
+    """Match a Comic Vine body `error` string; None when unrecognized."""
+    lowered = message.lower()
+    for phrase, category in _CV_BODY_ERRORS:
+        if phrase in lowered:
+            return category
+    return None
+
+
 def _classify_service_error(exc: BaseException) -> RetryCategory:
-    """Disambiguate a plain simyan ServiceError by cause, status and message."""
-    # simyan 3.x client-side cap exhaustion: ServiceError("Service took
+    """
+    Disambiguate a plain simyan ServiceError by cause, status and message.
+
+    Three signals, in order of reliability: the chained cause (the only
+    thing that distinguishes a client-side rate-limit wait from a real
+    read timeout), the HTTP status, and finally Comic Vine's body `error`
+    string. Anything unrecognized is treated as transient — the
+    conservative choice, since retrying a permanent failure only costs
+    time while giving up on a transient one loses the lookup.
+    """
+    # Client-side rate-limit cap exhaustion: ServiceError("Service took
     # too long to respond") whose __cause__ is requests'
     # Timeout("Rate limit not cleared within max_delay=..."). Only the
     # cause distinguishes it from a genuine read timeout.
@@ -213,14 +249,7 @@ def _classify_service_error(exc: BaseException) -> RetryCategory:
     status = _service_error_status(exc)
     if status is not None:
         return _STATUS_CATEGORIES.get(status, RetryCategory.TRANSIENT)
-    if "not found" in str(exc).lower():  # literal "Resource not found"
-        return RetryCategory.NOT_FOUND
-    # CV serves some errors as HTTP 200 bodies that die in pydantic
-    # validation; a 200-body "Rate Limit Exceeded" (CV status 107)
-    # surfaces here with the offending dict in the message.
-    if "rate limit" in str(exc).lower():
-        return RetryCategory.RATE_LIMIT
-    return RetryCategory.TRANSIENT
+    return _classify_body_error(str(exc)) or RetryCategory.TRANSIENT
 
 
 class ComicVineOnlineSource(OnlineSource):
@@ -241,16 +270,20 @@ class ComicVineOnlineSource(OnlineSource):
         """
         Classify simyan's exceptions.
 
-        simyan encodes HTTP status in its class hierarchy (ServiceError >
-        AuthenticationError on 401, RateLimitError on 429/420), so no
-        message sniffing is needed except where the status can't tell
-        (see `_classify_service_error`).
+        simyan encodes the failure in its class hierarchy (ServiceError >
+        AuthenticationError on HTTP 401 and Comic Vine body status 100,
+        RateLimitError on HTTP 429/420 and body status 107), so the two
+        cases worth retrying differently arrive already typed. The
+        remaining ServiceErrors need `_classify_service_error`.
+
+        RateLimitError and AuthenticationError both subclass
+        ServiceError, so they must be tested before it.
         """
         from simyan.errors import AuthenticationError, RateLimitError, ServiceError
 
-        if isinstance(exc, RateLimitError):  # HTTP 429/420; message may be None
+        if isinstance(exc, RateLimitError):  # 429/420 or body 107; msg may be None
             return RetryCategory.RATE_LIMIT
-        if isinstance(exc, AuthenticationError):  # raised on HTTP 401 only
+        if isinstance(exc, AuthenticationError):  # HTTP 401 or body status 100
             return RetryCategory.AUTH
         if isinstance(exc, ServiceError):
             return _classify_service_error(exc)
@@ -321,36 +354,31 @@ class ComicVineOnlineSource(OnlineSource):
         if self._credentials.url:
             kwargs["base_url"] = self._credentials.url
         client = Comicvine(**kwargs)
-        if resolved is None:  # CacheMode.OFF
-            self._disable_response_cache(client)
-        else:
+        if resolved is not None:
             self._maintain_cache(client, cache_path)
         return client
 
     @staticmethod
     def _cache_expiry(resolved: tuple[Path, timedelta] | None) -> Any:
-        """Map comicbox's resolved cache mode/ttl onto simyan's `cache_expiry`."""
+        """
+        Map comicbox's resolved cache mode/ttl onto simyan's `cache_expiry`.
+
+        `DO_NOT_CACHE` is the whole of CacheMode.OFF: simyan no longer
+        passes `cache_control`, so a response's own cache headers cannot
+        re-derive an expiry and get themselves written anyway, and
+        requests_cache counts "disabled by expiration" against reads and
+        writes alike. Under simyan 3.x this needed a private reach-in to
+        set `session.settings.disabled`.
+
+        A zero ttl means "keep forever" rather than "expire instantly" —
+        `NEVER_EXPIRE`, since OFF already covers not caching.
+        """
         from requests_cache import DO_NOT_CACHE, NEVER_EXPIRE
 
         if resolved is None:  # CacheMode.OFF
             return DO_NOT_CACHE
         _, ttl = resolved
         return ttl if ttl.total_seconds() > 0 else NEVER_EXPIRE
-
-    def _disable_response_cache(self, client: Comicvine) -> None:
-        """
-        Make CacheMode.OFF mean no cache reads AND no cache writes.
-
-        `DO_NOT_CACHE` alone skips reads, but simyan enables
-        `cache_control`, which lets a response carrying explicit cache
-        headers re-derive an expiry and get written anyway. The settings
-        flag turns the session into a plain requests one. Best-effort
-        private reach-in; `DO_NOT_CACHE` remains as the fallback signal.
-        """
-        try:
-            client._session.settings.disabled = True  # noqa: SLF001
-        except Exception as exc:
-            logger.debug(f"online {self.name}: cache disable skipped: {exc}")
 
     def _warn_ignored_rate_limit_overrides(self) -> None:
         from comicbox.config.online.settings import resolve_rate_limit

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -36,6 +36,7 @@ from comicbox.formats.base.online.profile import (
     CandidateSummary,
     strip_issue_leading_zeros,
 )
+from comicbox.formats.base.online.rate_limits import COMICVINE_DEFAULT_PER_HOUR
 from comicbox.formats.base.online.retry import RetryCategory, with_retry
 from comicbox.formats.base.online.series_filter import (
     max_calls_for,
@@ -43,6 +44,7 @@ from comicbox.formats.base.online.series_filter import (
 )
 from comicbox.formats.base.online.sources.base import (
     OnlineSource,
+    resolve_cache_db_path,
 )
 from comicbox.formats.base.online.transform_helpers import split_aliases
 from comicbox.formats.base.online.warn_once import warn_once
@@ -55,6 +57,7 @@ if TYPE_CHECKING:
 
     from simyan.comicvine import Comicvine
 
+    from comicbox.config.online.settings import OnlineSettings
     from comicbox.formats.base.online.profile import ComicProfile
 
 # Cache files already housekept this process. Keyed by cache PATH, not by
@@ -71,6 +74,10 @@ _maintenance_lock = threading.Lock()
 # batch behind one pathological comic. The volume discovery calls
 # themselves are outside it: they are the search, not the fan-out.
 _SEARCH_DEADLINE_S = 45.0
+
+# Comic Vine's cap is per hour, so its sliding window is an hour wide.
+# In milliseconds to match pyrate-limiter's `item_timestamp` stamps.
+_RATE_LIMIT_WINDOW_MS: Final[int] = 3600 * 1000
 
 # Clients are shared process-wide across the credential set that built
 # them (see `_get_session`), keyed by (api_key, base_url). Sources are
@@ -105,6 +112,96 @@ def reset_shared_sessions() -> None:
     """
     with _session_cache_lock:
         _session_cache.clear()
+
+
+def _bucket_window(conn: sqlite3.Connection, table: str, now_ms: int) -> dict[str, Any]:
+    """Summarize one bucket table as a `limit`/`remaining`/`reset_epoch` window."""
+    window_start = now_ms - _RATE_LIMIT_WINDOW_MS
+    # Quoted, not parameterized: sqlite takes no placeholder for an
+    # identifier. The name comes from sqlite_master filtered to our own
+    # `bucket_%` prefix, so it is never caller-supplied.
+    row = conn.execute(
+        f'SELECT COUNT(*), MIN(item_timestamp) FROM "{table}" '  # noqa: S608
+        "WHERE item_timestamp >= ?",
+        (window_start,),
+    ).fetchone()
+    used, oldest = (row[0] or 0), row[1]
+    # A sliding window frees its next slot when the oldest request in it
+    # ages out, so that — not the top of the hour — is the reset instant.
+    reset_epoch = (
+        (oldest + _RATE_LIMIT_WINDOW_MS) / 1000 if oldest is not None else None
+    )
+    return {
+        "limit": COMICVINE_DEFAULT_PER_HOUR,
+        "remaining": max(0, COMICVINE_DEFAULT_PER_HOUR - used),
+        "reset_epoch": reset_epoch,
+    }
+
+
+def _read_rate_limit_buckets(path: Path) -> dict[str, dict[str, Any]]:
+    """
+    Read each rate-limit pool's remaining hourly budget from its bucket file.
+
+    simyan builds its limiter internally and exposes no budget to read,
+    but requests-ratelimiter persists one pyrate-limiter ``SQLiteBucket``
+    table per endpoint pool (``bucket_issues``, ``bucket_search``, …),
+    each row one request stamped in epoch milliseconds. Counting the rows
+    still inside the hour window is therefore an exact read of what
+    Comic Vine's 200-per-resource-per-hour cap has left.
+
+    Opened read-only so a live limiter's connection is never disturbed,
+    and so this cannot create the file. Best-effort: a missing, locked or
+    unexpected database reports ``{}`` rather than failing a caller who
+    only asked for a status. Reads the file rather than the in-process
+    client on purpose — the budget outlives the process that spent it,
+    so a fresh run can show it before issuing any request.
+    """
+    if not path.exists():
+        return {}
+    windows: dict[str, dict[str, Any]] = {}
+    now_ms = int(time.time() * 1000)
+    try:
+        with closing(
+            sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=1.0)
+        ) as conn:
+            tables = [
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name LIKE 'bucket_%'"
+                )
+            ]
+            for table in tables:
+                pool = table.removeprefix("bucket_")
+                windows[pool] = _bucket_window(conn, table, now_ms)
+    except sqlite3.Error as exc:
+        logger.debug(f"online comicvine: rate-limit status unavailable: {exc}")
+        return {}
+    return windows
+
+
+def shared_client_rate_limit_status(
+    settings: OnlineSettings,
+) -> dict[str, dict[str, Any]]:
+    """
+    Comic Vine's remaining hourly budget, one window per endpoint pool.
+
+    Comic Vine rate-limits per resource, so there is no single number to
+    report: `{"issues": {...}, "search": {...}}`, each window carrying
+    `limit` / `remaining` / `reset_epoch` exactly as Metron's do. A pool
+    absent from the result has never been used.
+
+    Returns ``{}`` when the bucket file does not exist yet or cannot be
+    read. Needs no client and no credentials — only where the cache
+    lives — so it is safe to call before a session has issued a request.
+    """
+    path = resolve_cache_db_path(
+        settings.cache.dir,
+        ComicVineOnlineSource.name,
+        "rate_limit",
+        create=False,
+    )
+    return _read_rate_limit_buckets(path)
 
 
 def _drop_v2_cache_table(cache_path: Path) -> None:

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -1,13 +1,25 @@
 """
 ComicVine API source via simyan.
 
-Wraps simyan's `Comicvine` client. simyan 3.x manages its own response
-cache (requests_cache; `api_key` stripped from cache keys) and rate
-limiting (1/sec, 200/hr in per-endpoint buckets) with a *bounded*
-blocking wait (`max_delay = timeout * 2`); waits past that bound surface
-as errors that comicbox's logged, cancellable retry layer handles. We
-point the cache and rate-limit bucket files into comicbox's cache dir
-via `online.cache_dir` / `cache_ttl`.
+Wraps simyan's `Comicvine` client. simyan manages its own response cache
+(requests_cache; `api_key` stripped from cache keys) and rate limiting
+(1/sec, 200/hr in per-endpoint buckets) with a *bounded* blocking wait
+(`max_delay = timeout * 2`); waits past that bound surface as errors that
+comicbox's logged, cancellable retry layer handles. We point the cache
+and rate-limit bucket files into comicbox's cache dir via
+`online.cache_dir` / `cache_ttl`.
+
+Both of those sqlite files are also read directly here, for things
+simyan offers no accessor for: `_maintain_cache` purges expired response
+rows (requests_cache never does so on its own), and
+`shared_client_rate_limit_status` counts rate-limit bucket rows to report
+what each endpoint pool has left of its hourly budget.
+
+Comic Vine reports application-level failures as an HTTP 200 whose body
+carries a non-1 `status_code`. simyan 4.0 turns those into its own typed
+exceptions rather than letting them fail validation downstream, so
+`classify_retry_exception` reads the class first and the message only for
+what the class cannot say.
 
 ComicVine candidates do *not* arrive with a precomputed cover hash, so
 the matcher's hashing path downloads the candidate's `image.thumbnail`
@@ -86,7 +98,7 @@ _RATE_LIMIT_WINDOW_MS: Final[int] = 3600 * 1000
 # batch paid for a fresh `Comicvine`: a new requests session (no
 # connection reuse across files), a new requests_cache sqlite handle, a
 # new ratelimit-bucket file handle, and a re-run of the cache
-# maintenance path. simyan 3.x keeps its rate-limit state in a sqlite
+# maintenance path. simyan keeps its rate-limit state in a sqlite
 # bucket file rather than in memory, so sharing is about connection and
 # handle reuse rather than about rate-limit visibility — that part
 # already worked across instances.
@@ -208,7 +220,7 @@ def _drop_v2_cache_table(cache_path: Path) -> None:
     """
     Drop simyan v2's `queries` table from the shared cache file.
 
-    simyan 3.x (requests_cache) creates its own tables alongside; the old
+    simyan's requests_cache creates its own tables alongside; the old
     blob rows would otherwise sit as dead weight forever. A no-op once
     dropped. Best-effort — a locked/busy db just skips until next build.
     """
@@ -487,7 +499,7 @@ class ComicVineOnlineSource(OnlineSource):
             warn_once(
                 f"{self.name}:rate-limit-override",
                 f"online {self.name}: rate_limit.per_second/per_hour "
-                "overrides are ignored — simyan 3.x manages ComicVine "
+                "overrides are ignored — simyan manages ComicVine "
                 "rates internally (1/sec, 200/hr)",
             )
 

--- a/comicbox/online_estimate.py
+++ b/comicbox/online_estimate.py
@@ -24,7 +24,7 @@ costs are summed.
 
 Wall-clock paces each source at its sustained throughput: Metron's
 per-minute cap binds a bounded run directly. Comic Vine limits **per
-resource pool** — 200/hour for each endpoint (simyan 3.x keeps a separate
+resource pool** — 200/hour for each endpoint (simyan keeps a separate
 bucket per endpoint, mirroring CV's documented "200 requests per resource
 per hour") — so a run is bound by its busiest single pool, not by the
 request total: discovery and the final fetches land in different pools
@@ -85,7 +85,7 @@ COMICVINE_REQUESTS_BY_MODE: Final = MappingProxyType(
 )
 
 # How many of one comic's Comic Vine requests land in its BUSIEST resource
-# pool. CV rate-limits per resource, and simyan 3.x enforces that client-side
+# pool. CV rate-limits per resource, and simyan enforces that client-side
 # with a separate bucket per endpoint (search / volumes / issues / get_issue /
 # get_volume), so wall-clock is bound by the fullest single pool rather than
 # the request total. Discovery and the final issue/volume fetches each land

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -471,18 +471,35 @@ class OnlineSession:
         """
         Snapshot of each enabled source's current rate-limit budget.
 
-        Metron entries carry the live per-account state mokkari>=4 tracks
-        from ``X-RateLimit-*`` response headers, as JSON-safe windows::
+        Every entry maps a window name to a JSON-safe
+        ``limit`` / ``remaining`` / ``reset_epoch`` triple, so one
+        renderer handles both sources; only the window names differ,
+        because the two services meter differently.
+
+        Metron carries the live per-account state mokkari>=4 tracks from
+        ``X-RateLimit-*`` response headers::
 
             {"burst": {"limit": 20, "remaining": 19, "reset_epoch": ...},
              "sustained": {"limit": 5000, "remaining": 4987, "reset_epoch": ...}}
 
         The sustained (daily) limit varies by Metron OpenCollective donor
-        tier, so it is only discoverable from these headers. A source
-        reports ``{}`` until it has data: for Metron that means no request
-        has gone out yet in this process (no shared session, or no header
-        seen). Comic Vine always reports ``{}`` — simyan builds its
-        limiter internally and exposes no budget to read.
+        tier, so it is only discoverable from these headers.
+
+        Comic Vine meters per resource, so it reports one window per
+        endpoint pool it has actually used::
+
+            {"issues": {"limit": 200, "remaining": 197, "reset_epoch": ...},
+             "search": {"limit": 200, "remaining": 199, "reset_epoch": ...}}
+
+        Its numbers are read from the rate-limit bucket file rather than
+        from a live client, so they survive across runs and are available
+        before this session issues a request. ``reset_epoch`` is when the
+        window's oldest request ages out and frees the next slot.
+
+        A source reports ``{}`` until it has data: for Metron that means
+        no request has gone out yet in this process (no shared session,
+        or no header seen); for Comic Vine, that no bucket file exists
+        yet or it could not be read.
         """
         statuses: dict[str, dict[str, Any]] = {name: {} for name in self._sources}
         if "metron" in statuses:
@@ -497,6 +514,14 @@ class OnlineSession:
             )
             if status is not None:
                 statuses["metron"] = _rate_limit_windows(status)
+        if "comicvine" in statuses:
+            from comicbox.formats.comicvine_api.online_source import (
+                shared_client_rate_limit_status,
+            )
+
+            statuses["comicvine"] = shared_client_rate_limit_status(
+                self._settings.online
+            )
         return statuses
 
     # -- per-file tagging ---------------------------------------------------

--- a/tasks/simyan-4-plan.md
+++ b/tasks/simyan-4-plan.md
@@ -1,0 +1,225 @@
+# simyan 4.0.0 adoption plan
+
+**Status:** plan only, awaiting go-ahead. Branch for the work: `simyan-4` off
+`develop`; PR against `develop`. No version bump — NEWS lines go under the
+existing `v5.0.0` section.
+
+## Where we are
+
+- `pyproject.toml` already requires `simyan>=4.0.0,<5` and `uv.lock` resolves
+  4.0.0 (commit `fbcaa26`, 2026-09-03). That commit touched only the lock files.
+- Under 4.0.0 the 111 tests in `test_comicvine.py`, `test_comicvine_client.py`,
+  `test_online_abort_propagation.py` and `test_rich_transforms.py` pass
+  unchanged. Nothing is broken.
+- The code, comments, warnings and test names still describe simyan 3.x
+  behaviour, and two pieces of defensive code exist only because of 3.x quirks
+  that 4.0.0 removed.
+
+## What changed, 3.1.0 → 4.0.0
+
+Verified by diffing the installed 4.0.0 wheel against a downloaded 3.1.0
+(`git diff --no-index`), and by the GitHub release notes for tag `4.0.0`.
+
+| #   | Change                                                                                                                                                                                                                                                                                                       | Effect on comicbox                                                                                                                                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `_request` now inspects the JSON body. `status_code != 1` raises `AuthenticationError` (CV 100 "Invalid API Key"), `RateLimitError` (CV 107 "Rate Limit Exceeded"), else `ServiceError(body["error"])` (101 "Object Not Found", 102 "Error in URL Format", 104 "Filter Error"). Raised before pydantic runs. | Under 3.x these HTTP-200 error bodies died inside pydantic as a `ServiceError` wrapping a `ValidationError`. Comicbox sniffed "rate limit" in that message to catch 107; an invalid key was classified TRANSIENT and retried five times (~31 s) before failing.                                           |
+| 2   | `cache_control=cache_expiry != NEVER_EXPIRE` dropped from the session constructor.                                                                                                                                                                                                                           | Comic Vine's response cache headers no longer override `cache_expiry`; comicbox's `online.cache.ttl` now fully governs. `DO_NOT_CACHE` alone skips reads **and** writes (requests-cache 1.3.3 `update_from_response`, "disabled by expiration" criterion). The `settings.disabled` reach-in is redundant. |
+| 3   | `ComicvineResource` enum removed; `simyan.resources` module with a `Resource` dataclass and `ISSUE`, `VOLUME`, … constants added.                                                                                                                                                                            | Unused by comicbox.                                                                                                                                                                                                                                                                                       |
+| 4   | Deprecated generic `search()` removed.                                                                                                                                                                                                                                                                       | Comicbox has used `search_volumes()` since 3.1.0.                                                                                                                                                                                                                                                         |
+| 5   | `BasicCreator.date_of_death` is a `TimezonedDate`.                                                                                                                                                                                                                                                           | Comicbox never fetches creators.                                                                                                                                                                                                                                                                          |
+| 6   | Endpoint strings now come from `Resource` with a trailing slash.                                                                                                                                                                                                                                             | Resulting URLs are byte-identical to 3.x, so existing `comicvine_cache.sqlite` rows stay valid. Bucket names (`search`, `volumes`, `issues`, `get_issue`, `get_volume`) are unchanged.                                                                                                                    |
+| 7   | Unchanged: 1/s and 200/h per-bucket limits, `max_delay = 2 × timeout = 40 s`, the `Timeout("Rate limit not cleared within max_delay=…")` cause, `ignored_parameters=["api_key"]`, `Issue`/`Volume` schemas, the pagination helpers.                                                                          | Retry cause-sniffing, api-key redaction, the transform and the estimator constants all still apply.                                                                                                                                                                                                       |
+
+Dependency floors moved to pydantic ≥ 2.13, requests-cache ≥ 1.3,
+requests-ratelimiter ≥ 0.10, requests ≥ 2.34. Already satisfied by `uv.lock`.
+
+## Findings that shape the plan
+
+### A. Error classification has dead and mis-tuned branches
+
+`_classify_service_error` in `comicbox/formats/comicvine_api/online_source.py`:
+
+- The final `"rate limit" in str(exc).lower()` fallback is dead: 107 now arrives
+  as a typed `RateLimitError`.
+- "Object Not Found" (CV 101) already lands on NOT_FOUND through the literal
+  `"not found"` check, but the comment claims the only literal is "Resource not
+  found".
+- "Error in URL Format" / "Filter Error" (CV 102/104) become `ServiceError` →
+  TRANSIENT → five retries. They are programmer errors and should raise
+  immediately, like the `_NON_RETRIABLE` tuple in `retry.py`.
+- The `Timeout("Rate limit not cleared…")` cause sniff and
+  `_service_error_status` (HTTPError path) are still the only signal for their
+  cases and stay.
+
+### B. Cache OFF no longer needs a private reach-in
+
+`_disable_response_cache` sets `client._session.settings.disabled = True`
+because 3.x's `cache_control=True` let header-driven expiry write anyway. With
+`cache_control` gone, `cache_expiry=DO_NOT_CACHE` is sufficient.
+
+### C. Hidden 2× pagination cost (pre-existing; fix belongs upstream)
+
+Measured with a fake `_request` transport against the installed 4.0.0:
+
+| Call                                                   | Results | HTTP requests |
+| ------------------------------------------------------ | ------- | ------------- |
+| `list_issues(filter=volume+issue_number)`              | 2       | **2**         |
+| `list_issues(...)`                                     | 0       | 1             |
+| `list_volumes(filter=name+start_year, max_results=20)` | 3       | **2**         |
+| `search_volumes(max_results=20)`                       | 7       | **2**         |
+| `search_volumes(max_results=20)`                       | 50      | **2**         |
+| `search_volumes(max_results=5)`                        | 50      | 1             |
+
+Cause: `Comicvine._offset` loops until it receives an empty page rather than
+stopping when a page is short (or when
+`offset + limit >= number_of_total_results`, which every CV response carries).
+`_search` never sends `limit`, so CV's `/search/` default page size of 10 forces
+a second page for `max_results=20`. The same code is in 3.1.0; this is not a
+regression, but every fan-out `list_issues` call spends **two** of the 200/h
+`issues` budget, and `api_call_counts` / `online_estimate.py` under-count by
+about 2×. Nothing comicbox can pass (`max_results`, `limit`) stops a short page
+early, and overriding `_offset` is private surface. Fix it in simyan.
+
+### D. A Comic Vine budget readout is now cheap and dependency-free
+
+`comicvine_rate_limit.sqlite` holds one table per bucket (`bucket_issues`,
+`bucket_search`, …) with `item_timestamp` in ms since the epoch; the rates are
+(1 per 1000 ms, 200 per 3 600 000 ms). Verified by driving the real `Comicvine`
+limiter on a tmp path. `remaining = 200 − COUNT(item_timestamp
+
+> = now − 3600
+> s)`per pool, read-only, no simyan or pyrate-limiter internals.`OnlineSession.rate_limit_status()`currently returns`{}`
+> for Comic Vine and NEWS 4.x says "simyan exposes no budget to read" — the
+> sqlite file _is_ the budget.
+
+## Phases
+
+### Phase 1 — Adopt the 4.0 error contract
+
+Files: `comicbox/formats/comicvine_api/online_source.py`,
+`comicbox/formats/base/online/retry.py`, `tests/unit/test_comicvine_client.py`.
+
+- [ ] Delete the `"rate limit"` message fallback in `_classify_service_error`;
+      rewrite its docstring around "body-status errors arrive typed".
+- [ ] Replace the single `"not found"` literal with a small `_CV_BODY_ERRORS`
+      `MappingProxyType` keyed on the lower-cased body messages 4.0 surfaces
+      verbatim: `object not found` → NOT_FOUND, `resource not found` → NOT_FOUND
+      (simyan's own 404 text), `error in url format` / `filter error` → INVALID.
+- [ ] Add `RetryCategory.INVALID` ("never retried; programmer/config error") and
+      treat it like AUTH/NOT_FOUND in `_is_retriable`. Three lines.
+- [ ] Tests: drop `test_classify_cv_status_107_body_is_rate_limit`; parametrize
+      the typed cases (`RateLimitError("Rate Limit Exceeded")`,
+      `RateLimitError(None)`, `AuthenticationError("Invalid API Key")`,
+      `ServiceError("Object Not Found")`, `ServiceError("Filter Error")`); add
+      one `with_retry` integration test proving a 200-body `AuthenticationError`
+      makes exactly one call.
+- [ ] NEWS (Fixes): "An invalid Comic Vine API key fails at once instead of
+      retrying for half a minute."
+
+### Phase 2 — Cache policy simplification
+
+Files: `online_source.py`, `tests/unit/test_comicvine_client.py`.
+
+- [ ] Remove `_disable_response_cache` and its call in `_build_session`; update
+      `_cache_expiry`'s docstring.
+- [ ] `test_build_session_cache_off_uses_do_not_cache`: drop the
+      `settings.disabled is True` assertion; the
+      `cache_expiry ==     DO_NOT_CACHE` and `cache_path` assertions remain the
+      contract.
+- [ ] NEWS (Performance): "Comic Vine responses now stay cached for
+      `online.cache.ttl` instead of following the server's cache headers."
+- [ ] Keep `_drop_v2_cache_table` (eight lines, once per process, harmless);
+      revisit at the next major.
+
+### Phase 3 — Upstream pagination fix, then a floor bump
+
+- [ ] Open an issue + PR on `Metron-Project/Simyan` (under your account): 1.
+      `_offset`: return when `len(page) < limit` or when
+      `offset + limit >= number_of_total_results`. 2. `_paginate`: same, via
+      `number_of_page_results` / `number_of_total_results`. 3. `_search`: send
+      `limit=min(100, max_results)` so `search_volumes(max_results=20)` is one
+      request. 4. Doc nit: the `Comicvine` docstring still says "Response
+      cache-headers take precedence", which 4.0 made false. Attach the
+      fake-transport table from Finding C as the reproduction.
+- [ ] When it ships: `simyan>=4.1.0,<5` (or whatever the tag is), `uv lock`,
+      NEWS (Dev): "Require simyan ≥ 4.1.0."
+- [ ] Re-run the fake-transport probe to confirm one request per short page.
+- [ ] If comicbox 5.0.0 ships before the upstream fix, re-derive
+      `COMICVINE_REQUESTS_BY_MODE` and `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE`
+      in `comicbox/online_estimate.py` with the 2× list cost so Codex's estimate
+      is honest, and note the reason in the module docstring. Revert when the
+      floor bumps.
+- [ ] No interim client-side workaround: shrinking `_MAX_VOLUMES_PER_SEARCH` to
+      10 would save the second `/search/` page but changes calibrated recall,
+      and nothing else can stop a short page early.
+
+### Phase 4 — Comic Vine budget in `rate_limit_status()`
+
+Files: `online_source.py`, `comicbox/online_session.py`,
+`comicbox/formats/base/online/rate_limits.py`, new test.
+
+- [ ] Add `shared_client_rate_limit_status(key, url)` next to
+      `reset_shared_sessions`, mirroring Metron's
+      `shared_session_rate_limit_status`. Store the ratelimit path in the
+      `_session_cache` tuple at build time. Open the file read-only
+      (`file:…?mode=ro` URI), list `bucket_%` tables, and for each report
+      `{"limit": COMICVINE_DEFAULT_PER_HOUR, "remaining": limit − n,     "reset_epoch": oldest_in_window_ms / 1000 + 3600}`.
+      Best-effort: any sqlite error or a missing file yields `{}`.
+- [ ] Wire `"comicvine"` into `OnlineSession.rate_limit_status()` and rewrite
+      its docstring (per-pool windows keyed by bucket name, each in the same
+      `limit / remaining / reset_epoch` shape as Metron's windows so a renderer
+      can reuse it).
+- [ ] Test: build a real `Comicvine` on `tmp_path`, call
+      `client._session.limiter.try_acquire("issues")` three times (public
+      pyrate-limiter API), assert `remaining == 197` for `issues` and no entry
+      for untouched pools. This pins the sqlite layout assumption.
+- [ ] NEWS (Features): "`OnlineSession.rate_limit_status()` now reports Comic
+      Vine's per-endpoint hourly budget."
+- [ ] Flag for Codex: a per-pool dict rather than Metron's fixed burst/sustained
+      pair. Paired release; no shim.
+
+### Phase 5 — Retire "simyan 3.x" wording and stale rationale
+
+- [ ] `online_source.py`: module docstring, `_session_cache` comment,
+      `_warn_ignored_rate_limit_overrides` message ("simyan 3.x manages" →
+      "simyan manages"), `_maintain_cache` and `_classify_service_error`
+      comments.
+- [ ] `rate_limits.py`, `config/online/settings.py` (`OnlineSourceLimits`),
+      `retry.py` comments, `online_estimate.py` docstring, `vacuum.py`
+      docstring, `online_session.py` (rewritten in Phase 4).
+- [ ] Tests: rename `test_build_session_passes_v3_kwargs` →
+      `test_build_session_passes_simyan_kwargs`; `_FakeComicvine` docstring;
+      `test_classify_client_side_cap_timeout_is_rate_limit` docstring.
+- [ ] After landing, update the memory note
+      `project_simyan_version_bump_review.md`.
+
+### Phase 6 — Verify and ship
+
+- [ ] `make fix`, `make lint`, `make ty`, `make test` — run unpiped, fix every
+      warning that surfaces.
+- [ ] `make complexity` stays green (`online_source.py` is 984 lines; Phase 1
+      and 2 shrink it, Phase 4 adds ~60 lines).
+- [ ] Optional live smoke with a real key using the warm-cache method in the
+      calibration notes: one `--online` lookup, confirm the new
+      `rate_limit_status()` entry moves.
+- [ ] Commit per phase; PR `simyan-4` → `develop`.
+
+## Out of scope
+
+- Using `simyan.resources` generics: every comicbox call is already a public
+  typed wrapper (`search_volumes`, `list_volumes`, `list_issues`, `get_issue`,
+  `get_volume`).
+- Passing `timeout`: the 20 s default and the derived 40 s client-side
+  rate-limit wait interact with comicbox's retry schedule as designed.
+- Restoring `per_second` / `per_hour` config overrides: still no injection point
+  in 4.0; the warn-and-ignore stays.
+
+## Open questions
+
+1. Phase 1: add `RetryCategory.INVALID` for CV 102/104 (recommended, three
+   lines), or leave them TRANSIENT as today?
+2. Phase 4: per-pool dict for Comic Vine, or collapse to the busiest pool as a
+   single `sustained` window to match Metron's shape exactly? Depends on what
+   Codex's renderer wants.
+3. Phase 3: file the simyan issue/PR now, before the comicbox work, so the floor
+   bump can ride the same release?

--- a/tasks/simyan-4-plan.md
+++ b/tasks/simyan-4-plan.md
@@ -1,18 +1,26 @@
 # simyan 4.0.0 adoption plan
 
-**Status:** plan only, awaiting go-ahead. Branch for the work: `simyan-4` off
-`develop`; PR against `develop`. No version bump — NEWS lines go under the
-existing `v5.0.0` section.
+**Status:** phases 1, 2, 4, 5 and 6 landed on branch `simyan-4` (off `develop`,
+2026-09-03). Phase 3 is filed upstream and blocked on a simyan release. No
+version bump — NEWS lines went under the existing `v5.0.0` section.
 
-## Where we are
+Decisions taken (the three questions this plan originally left open):
 
-- `pyproject.toml` already requires `simyan>=4.0.0,<5` and `uv.lock` resolves
+1. `RetryCategory.INVALID` was added, for Comic Vine 102/104.
+2. Comic Vine's budget reports a **per-pool dict**, one window per endpoint,
+   sharing Metron's `limit` / `remaining` / `reset_epoch` shape.
+3. The upstream issue was filed first:
+   [Simyan#309](https://github.com/Metron-Project/Simyan/issues/309).
+
+## Where we started
+
+- `pyproject.toml` already required `simyan>=4.0.0,<5` and `uv.lock` resolved
   4.0.0 (commit `fbcaa26`, 2026-09-03). That commit touched only the lock files.
 - Under 4.0.0 the 111 tests in `test_comicvine.py`, `test_comicvine_client.py`,
-  `test_online_abort_propagation.py` and `test_rich_transforms.py` pass
-  unchanged. Nothing is broken.
-- The code, comments, warnings and test names still describe simyan 3.x
-  behaviour, and two pieces of defensive code exist only because of 3.x quirks
+  `test_online_abort_propagation.py` and `test_rich_transforms.py` passed
+  unchanged. Nothing was broken.
+- But the code, comments, warnings and test names still described simyan 3.x
+  behaviour, and two pieces of defensive code existed only because of 3.x quirks
   that 4.0.0 removed.
 
 ## What changed, 3.1.0 → 4.0.0
@@ -20,42 +28,73 @@ existing `v5.0.0` section.
 Verified by diffing the installed 4.0.0 wheel against a downloaded 3.1.0
 (`git diff --no-index`), and by the GitHub release notes for tag `4.0.0`.
 
-| #   | Change                                                                                                                                                                                                                                                                                                       | Effect on comicbox                                                                                                                                                                                                                                                                                        |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `_request` now inspects the JSON body. `status_code != 1` raises `AuthenticationError` (CV 100 "Invalid API Key"), `RateLimitError` (CV 107 "Rate Limit Exceeded"), else `ServiceError(body["error"])` (101 "Object Not Found", 102 "Error in URL Format", 104 "Filter Error"). Raised before pydantic runs. | Under 3.x these HTTP-200 error bodies died inside pydantic as a `ServiceError` wrapping a `ValidationError`. Comicbox sniffed "rate limit" in that message to catch 107; an invalid key was classified TRANSIENT and retried five times (~31 s) before failing.                                           |
-| 2   | `cache_control=cache_expiry != NEVER_EXPIRE` dropped from the session constructor.                                                                                                                                                                                                                           | Comic Vine's response cache headers no longer override `cache_expiry`; comicbox's `online.cache.ttl` now fully governs. `DO_NOT_CACHE` alone skips reads **and** writes (requests-cache 1.3.3 `update_from_response`, "disabled by expiration" criterion). The `settings.disabled` reach-in is redundant. |
-| 3   | `ComicvineResource` enum removed; `simyan.resources` module with a `Resource` dataclass and `ISSUE`, `VOLUME`, … constants added.                                                                                                                                                                            | Unused by comicbox.                                                                                                                                                                                                                                                                                       |
-| 4   | Deprecated generic `search()` removed.                                                                                                                                                                                                                                                                       | Comicbox has used `search_volumes()` since 3.1.0.                                                                                                                                                                                                                                                         |
-| 5   | `BasicCreator.date_of_death` is a `TimezonedDate`.                                                                                                                                                                                                                                                           | Comicbox never fetches creators.                                                                                                                                                                                                                                                                          |
-| 6   | Endpoint strings now come from `Resource` with a trailing slash.                                                                                                                                                                                                                                             | Resulting URLs are byte-identical to 3.x, so existing `comicvine_cache.sqlite` rows stay valid. Bucket names (`search`, `volumes`, `issues`, `get_issue`, `get_volume`) are unchanged.                                                                                                                    |
-| 7   | Unchanged: 1/s and 200/h per-bucket limits, `max_delay = 2 × timeout = 40 s`, the `Timeout("Rate limit not cleared within max_delay=…")` cause, `ignored_parameters=["api_key"]`, `Issue`/`Volume` schemas, the pagination helpers.                                                                          | Retry cause-sniffing, api-key redaction, the transform and the estimator constants all still apply.                                                                                                                                                                                                       |
+**1. `_request` now inspects the JSON body.** A `status_code != 1` raises
+`AuthenticationError` (CV 100 "Invalid API Key"), `RateLimitError` (CV 107 "Rate
+Limit Exceeded"), else `ServiceError(body["error"])` (101 "Object Not Found",
+102 "Error in URL Format", 104 "Filter Error"). Raised before pydantic runs.
+Under 3.x these HTTP-200 error bodies died inside pydantic as a `ServiceError`
+wrapping a `ValidationError`; comicbox sniffed "rate limit" in that message to
+catch 107, and an invalid key was classified TRANSIENT and retried five times
+(~31 s) before failing.
+
+**2. `cache_control=cache_expiry != NEVER_EXPIRE` dropped** from the session
+constructor. Comic Vine's response cache headers no longer override
+`cache_expiry`, so comicbox's `online.cache.ttl` now fully governs.
+`DO_NOT_CACHE` alone skips reads **and** writes (requests-cache 1.3.3
+`update_from_response`, "disabled by expiration" criterion), which made the
+`settings.disabled` reach-in redundant.
+
+**3. `ComicvineResource` enum removed**, replaced by a `simyan.resources` module
+with a `Resource` dataclass and `ISSUE`, `VOLUME`, … constants. Unused by
+comicbox.
+
+**4. Deprecated generic `search()` removed.** Comicbox has used
+`search_volumes()` since 3.1.0.
+
+**5. `BasicCreator.date_of_death` is a `TimezonedDate`.** Comicbox never fetches
+creators.
+
+**6. Endpoint strings now come from `Resource`** with a trailing slash. The
+resulting URLs are byte-identical to 3.x, so existing `comicvine_cache.sqlite`
+rows stay valid, and bucket names (`search`, `volumes`, `issues`, `get_issue`,
+`get_volume`) are unchanged.
+
+**7. Unchanged:** the 1/s and 200/h per-bucket limits,
+`max_delay = 2 × timeout = 40 s`, the
+`Timeout("Rate limit not cleared within max_delay=…")` cause,
+`ignored_parameters=["api_key"]`, the `Issue` / `Volume` schemas, and the
+pagination helpers. So retry cause-sniffing, api-key redaction, the transform
+and the estimator constants all still apply.
 
 Dependency floors moved to pydantic ≥ 2.13, requests-cache ≥ 1.3,
 requests-ratelimiter ≥ 0.10, requests ≥ 2.34. Already satisfied by `uv.lock`.
 
-## Findings that shape the plan
+## Findings that shaped the plan
 
-### A. Error classification has dead and mis-tuned branches
+### A. Error classification had dead and mis-tuned branches
 
-`_classify_service_error` in `comicbox/formats/comicvine_api/online_source.py`:
+In `_classify_service_error`
+(`comicbox/formats/comicvine_api/online_source.py`):
 
-- The final `"rate limit" in str(exc).lower()` fallback is dead: 107 now arrives
-  as a typed `RateLimitError`.
-- "Object Not Found" (CV 101) already lands on NOT_FOUND through the literal
-  `"not found"` check, but the comment claims the only literal is "Resource not
-  found".
-- "Error in URL Format" / "Filter Error" (CV 102/104) become `ServiceError` →
+- The final `"rate limit" in str(exc).lower()` fallback was dead: 107 now
+  arrives as a typed `RateLimitError`.
+- "Object Not Found" (CV 101) already landed on NOT_FOUND through the literal
+  `"not found"` check, but the comment claimed the only literal was "Resource
+  not found".
+- "Error in URL Format" / "Filter Error" (CV 102/104) became `ServiceError` →
   TRANSIENT → five retries. They are programmer errors and should raise
   immediately, like the `_NON_RETRIABLE` tuple in `retry.py`.
 - The `Timeout("Rate limit not cleared…")` cause sniff and
   `_service_error_status` (HTTPError path) are still the only signal for their
-  cases and stay.
+  cases, and stay.
 
 ### B. Cache OFF no longer needs a private reach-in
 
-`_disable_response_cache` sets `client._session.settings.disabled = True`
-because 3.x's `cache_control=True` let header-driven expiry write anyway. With
-`cache_control` gone, `cache_expiry=DO_NOT_CACHE` is sufficient.
+`_disable_response_cache` set `client._session.settings.disabled = True` because
+3.x's `cache_control=True` let header-driven expiry write anyway. With
+`cache_control` gone, `cache_expiry=DO_NOT_CACHE` is sufficient. Confirmed
+against the real client with a fake transport returning
+`Cache-Control: max-age=3600`: zero rows written.
 
 ### C. Hidden 2× pagination cost (pre-existing; fix belongs upstream)
 
@@ -68,141 +107,141 @@ Measured with a fake `_request` transport against the installed 4.0.0:
 | `list_volumes(filter=name+start_year, max_results=20)` | 3       | **2**         |
 | `search_volumes(max_results=20)`                       | 7       | **2**         |
 | `search_volumes(max_results=20)`                       | 50      | **2**         |
-| `search_volumes(max_results=5)`                        | 50      | 1             |
+| `list_issues(filter=volume)` whole volume              | 43      | **2**         |
 
 Cause: `Comicvine._offset` loops until it receives an empty page rather than
-stopping when a page is short (or when
-`offset + limit >= number_of_total_results`, which every CV response carries).
-`_search` never sends `limit`, so CV's `/search/` default page size of 10 forces
-a second page for `max_results=20`. The same code is in 3.1.0; this is not a
-regression, but every fan-out `list_issues` call spends **two** of the 200/h
-`issues` budget, and `api_call_counts` / `online_estimate.py` under-count by
-about 2×. Nothing comicbox can pass (`max_results`, `limit`) stops a short page
-early, and overriding `_offset` is private surface. Fix it in simyan.
+stopping when a page is short, or when `offset + limit` reaches
+`number_of_total_results`, which every Comic Vine response carries. The same
+code is in 3.1.0, so this is not a regression, but every fan-out `list_issues`
+call spends **two** of the 200/h `issues` budget, and `api_call_counts` /
+`online_estimate.py` under-count by about 2×. Nothing comicbox can pass
+(`max_results`, `limit`) stops a short page early, and overriding `_offset` is
+private surface. Fix it in simyan.
 
-### D. A Comic Vine budget readout is now cheap and dependency-free
+**Correction to this plan's first draft:** sending `limit=min(100, max_results)`
+on `/search/` is _not_ a valid fix. Comic Vine caps that endpoint's `limit` at
+10, so `search_volumes(max_results=20)` genuinely needs two pages. Only the
+short-page exit helps there, and it does: the 7-total row drops to one request.
+
+### D. A Comic Vine budget readout is cheap and dependency-free
 
 `comicvine_rate_limit.sqlite` holds one table per bucket (`bucket_issues`,
-`bucket_search`, …) with `item_timestamp` in ms since the epoch; the rates are
-(1 per 1000 ms, 200 per 3 600 000 ms). Verified by driving the real `Comicvine`
-limiter on a tmp path. `remaining = 200 − COUNT(item_timestamp
-
-> = now − 3600
-> s)`per pool, read-only, no simyan or pyrate-limiter internals.`OnlineSession.rate_limit_status()`currently returns`{}`
-> for Comic Vine and NEWS 4.x says "simyan exposes no budget to read" — the
-> sqlite file _is_ the budget.
+`bucket_search`, …) with `item_timestamp` in milliseconds since the epoch, at
+rates of 1 per 1000 ms and 200 per 3,600,000 ms. Verified by driving the real
+`Comicvine` limiter on a tmp path. Per pool, `remaining` is 200 minus the rows
+whose `item_timestamp` falls inside the last 3600 s — read-only, with no simyan
+or pyrate-limiter internals. `OnlineSession.rate_limit_status()` returned `{}`
+for Comic Vine, and NEWS 4.x said "simyan exposes no budget to read", but the
+sqlite file _is_ the budget.
 
 ## Phases
 
-### Phase 1 — Adopt the 4.0 error contract
+### Phase 1 — Adopt the 4.0 error contract ✅
 
 Files: `comicbox/formats/comicvine_api/online_source.py`,
 `comicbox/formats/base/online/retry.py`, `tests/unit/test_comicvine_client.py`.
 
-- [ ] Delete the `"rate limit"` message fallback in `_classify_service_error`;
+- [x] Delete the `"rate limit"` message fallback in `_classify_service_error`;
       rewrite its docstring around "body-status errors arrive typed".
-- [ ] Replace the single `"not found"` literal with a small `_CV_BODY_ERRORS`
-      `MappingProxyType` keyed on the lower-cased body messages 4.0 surfaces
-      verbatim: `object not found` → NOT_FOUND, `resource not found` → NOT_FOUND
-      (simyan's own 404 text), `error in url format` / `filter error` → INVALID.
-- [ ] Add `RetryCategory.INVALID` ("never retried; programmer/config error") and
-      treat it like AUTH/NOT_FOUND in `_is_retriable`. Three lines.
-- [ ] Tests: drop `test_classify_cv_status_107_body_is_rate_limit`; parametrize
-      the typed cases (`RateLimitError("Rate Limit Exceeded")`,
-      `RateLimitError(None)`, `AuthenticationError("Invalid API Key")`,
-      `ServiceError("Object Not Found")`, `ServiceError("Filter Error")`); add
-      one `with_retry` integration test proving a 200-body `AuthenticationError`
-      makes exactly one call.
-- [ ] NEWS (Fixes): "An invalid Comic Vine API key fails at once instead of
-      retrying for half a minute."
+- [x] Replace the two ad-hoc message checks with a `_CV_BODY_ERRORS` table keyed
+      on the lower-cased body messages 4.0 surfaces verbatim: `object not found`
+      → NOT_FOUND, `resource not found` → NOT_FOUND (simyan's own 404 text),
+      `error in url format` / `filter error` → INVALID.
+- [x] Add `RetryCategory.INVALID` and treat it like AUTH/NOT_FOUND in
+      `_is_retriable`.
+- [x] Tests: drop `test_classify_cv_status_107_body_is_rate_limit`; parametrize
+      the typed cases; assert every terminal classification is called exactly
+      once through `with_retry`.
+- [x] NEWS (Fixes): an invalid Comic Vine API key fails at once.
 
-### Phase 2 — Cache policy simplification
+### Phase 2 — Cache policy simplification ✅
 
-Files: `online_source.py`, `tests/unit/test_comicvine_client.py`.
-
-- [ ] Remove `_disable_response_cache` and its call in `_build_session`; update
-      `_cache_expiry`'s docstring.
-- [ ] `test_build_session_cache_off_uses_do_not_cache`: drop the
-      `settings.disabled is True` assertion; the
-      `cache_expiry ==     DO_NOT_CACHE` and `cache_path` assertions remain the
-      contract.
-- [ ] NEWS (Performance): "Comic Vine responses now stay cached for
-      `online.cache.ttl` instead of following the server's cache headers."
-- [ ] Keep `_drop_v2_cache_table` (eight lines, once per process, harmless);
+- [x] Remove `_disable_response_cache` and its call in `_build_session`;
+      document why `DO_NOT_CACHE` is now sufficient in `_cache_expiry`.
+- [x] `test_build_session_cache_off_uses_do_not_cache`: drop the
+      `settings.disabled` assertion; `cache_expiry == DO_NOT_CACHE` and
+      `cache_path` remain the contract.
+- [x] NEWS (Performance): cached responses honor `online.cache.ttl`.
+- [x] Keep `_drop_v2_cache_table` (eight lines, once per process, harmless);
       revisit at the next major.
 
-### Phase 3 — Upstream pagination fix, then a floor bump
+### Phase 3 — Upstream pagination fix, then a floor bump ⛔ blocked upstream
 
-- [ ] Open an issue + PR on `Metron-Project/Simyan` (under your account): 1.
-      `_offset`: return when `len(page) < limit` or when
-      `offset + limit >= number_of_total_results`. 2. `_paginate`: same, via
-      `number_of_page_results` / `number_of_total_results`. 3. `_search`: send
-      `limit=min(100, max_results)` so `search_volumes(max_results=20)` is one
-      request. 4. Doc nit: the `Comicvine` docstring still says "Response
-      cache-headers take precedence", which 4.0 made false. Attach the
-      fake-transport table from Finding C as the reproduction.
+Filed as [Simyan#309](https://github.com/Metron-Project/Simyan/issues/309) with
+the fake-transport reproduction, a verified before/after table, and the patch
+for both loops. The fix was tested locally by binding the patched methods
+per-instance: every returned result set is identical and the request count drops
+by one in each non-boundary case, including a full 100-item page — which only
+the `number_of_total_results` check catches, not the short-page test.
+
+- [x] Open the issue, including the doc nit that the `Comicvine` docstring still
+      promises "Response cache-headers take precedence" after 4.0 dropped
+      `cache_control`, and that both loops mutate the caller's `params` dict.
+- [ ] Offer the PR if the maintainer approves the approach.
 - [ ] When it ships: `simyan>=4.1.0,<5` (or whatever the tag is), `uv lock`,
       NEWS (Dev): "Require simyan ≥ 4.1.0."
 - [ ] Re-run the fake-transport probe to confirm one request per short page.
-- [ ] If comicbox 5.0.0 ships before the upstream fix, re-derive
-      `COMICVINE_REQUESTS_BY_MODE` and `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE`
-      in `comicbox/online_estimate.py` with the 2× list cost so Codex's estimate
-      is honest, and note the reason in the module docstring. Revert when the
-      floor bumps.
+- [ ] Decide then whether to re-derive `COMICVINE_REQUESTS_BY_MODE` and
+      `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE` in `comicbox/online_estimate.py`
+      with the 2× list cost. Deliberately not done now: those numbers are a
+      projection shown to an operator before a run, and doubling them to
+      describe a bug we are fixing upstream would make them wrong again as soon
+      as the floor bumps. Revisit only if comicbox 5.0.0 ships first.
 - [ ] No interim client-side workaround: shrinking `_MAX_VOLUMES_PER_SEARCH` to
       10 would save the second `/search/` page but changes calibrated recall,
       and nothing else can stop a short page early.
 
-### Phase 4 — Comic Vine budget in `rate_limit_status()`
+### Phase 4 — Comic Vine budget in `rate_limit_status()` ✅
 
-Files: `online_source.py`, `comicbox/online_session.py`,
-`comicbox/formats/base/online/rate_limits.py`, new test.
-
-- [ ] Add `shared_client_rate_limit_status(key, url)` next to
-      `reset_shared_sessions`, mirroring Metron's
-      `shared_session_rate_limit_status`. Store the ratelimit path in the
-      `_session_cache` tuple at build time. Open the file read-only
-      (`file:…?mode=ro` URI), list `bucket_%` tables, and for each report
-      `{"limit": COMICVINE_DEFAULT_PER_HOUR, "remaining": limit − n,     "reset_epoch": oldest_in_window_ms / 1000 + 3600}`.
-      Best-effort: any sqlite error or a missing file yields `{}`.
-- [ ] Wire `"comicvine"` into `OnlineSession.rate_limit_status()` and rewrite
-      its docstring (per-pool windows keyed by bucket name, each in the same
-      `limit / remaining / reset_epoch` shape as Metron's windows so a renderer
-      can reuse it).
-- [ ] Test: build a real `Comicvine` on `tmp_path`, call
-      `client._session.limiter.try_acquire("issues")` three times (public
-      pyrate-limiter API), assert `remaining == 197` for `issues` and no entry
-      for untouched pools. This pins the sqlite layout assumption.
-- [ ] NEWS (Features): "`OnlineSession.rate_limit_status()` now reports Comic
-      Vine's per-endpoint hourly budget."
+- [x] Add `shared_client_rate_limit_status(settings)` beside
+      `reset_shared_sessions`. It opens the bucket file read-only
+      (`file:…?mode=ro`), lists `bucket_%` tables, and reports `limit` /
+      `remaining` / `reset_epoch` per pool. Best-effort: a missing or unreadable
+      file yields `{}`. It takes settings rather than credentials because the
+      path depends only on the cache dir — so it works before a session has
+      issued any request, and the budget survives across runs.
+- [x] Wire `"comicvine"` into `OnlineSession.rate_limit_status()` and rewrite
+      its docstring: per-pool windows keyed by bucket name, in the same shape as
+      Metron's, so one renderer handles both.
+- [x] Test: drive the real limiter through pyrate-limiter's public `try_acquire`
+      and assert the numbers. This pins the sqlite layout, so a future change to
+      table naming or timestamp units fails loudly instead of silently reading
+      as a full budget.
+- [x] NEWS (Features): `rate_limit_status()` reports Comic Vine's per-endpoint
+      hourly budget.
+- [x] Split `resolve_cache_db_path` out of `OnlineSource.cache_db_path` so a
+      read-only caller can skip the `mkdir`.
 - [ ] Flag for Codex: a per-pool dict rather than Metron's fixed burst/sustained
       pair. Paired release; no shim.
 
-### Phase 5 — Retire "simyan 3.x" wording and stale rationale
+### Phase 5 — Retire "simyan 3.x" wording and stale rationale ✅
 
-- [ ] `online_source.py`: module docstring, `_session_cache` comment,
-      `_warn_ignored_rate_limit_overrides` message ("simyan 3.x manages" →
-      "simyan manages"), `_maintain_cache` and `_classify_service_error`
-      comments.
-- [ ] `rate_limits.py`, `config/online/settings.py` (`OnlineSourceLimits`),
-      `retry.py` comments, `online_estimate.py` docstring, `vacuum.py`
-      docstring, `online_session.py` (rewritten in Phase 4).
-- [ ] Tests: rename `test_build_session_passes_v3_kwargs` →
-      `test_build_session_passes_simyan_kwargs`; `_FakeComicvine` docstring;
-      `test_classify_client_side_cap_timeout_is_rate_limit` docstring.
+- [x] `online_source.py`: module docstring (now also describes the two direct
+      sqlite reads and 4.0's typed body errors), `_session_cache` comment,
+      `_warn_ignored_rate_limit_overrides` message, `_maintain_cache` and
+      `_classify_service_error` comments.
+- [x] `rate_limits.py` (now records the hourly cap's second consumer),
+      `config/online/settings.py`, `retry.py`, `online_estimate.py`,
+      `online_session.py`.
+- [x] Tests: rename `test_build_session_passes_v3_kwargs`; `_FakeComicvine` and
+      cap-timeout docstrings; `test_online_estimate.py`, `test_rate_limits.py`,
+      `test_online_retry.py` comments.
+- [x] References to simyan **v2** stay: those name a version whose artifacts the
+      code really does still clean up.
 - [ ] After landing, update the memory note
       `project_simyan_version_bump_review.md`.
 
-### Phase 6 — Verify and ship
+### Phase 6 — Verify and ship ✅
 
-- [ ] `make fix`, `make lint`, `make ty`, `make test` — run unpiped, fix every
-      warning that surfaces.
-- [ ] `make complexity` stays green (`online_source.py` is 984 lines; Phase 1
-      and 2 shrink it, Phase 4 adds ~60 lines).
+- [x] `make fix`, `make lint`, `make ty`, `make typecheck` — all clean.
+- [x] `make complexity` green.
+- [x] `make test`: 2061 passed, 1 skipped (2048 on `fbcaa26`), warning count
+      unchanged at 15.
 - [ ] Optional live smoke with a real key using the warm-cache method in the
       calibration notes: one `--online` lookup, confirm the new
       `rate_limit_status()` entry moves.
-- [ ] Commit per phase; PR `simyan-4` → `develop`.
+- [x] Commit per phase.
+- [ ] PR `simyan-4` → `develop`.
 
 ## Out of scope
 
@@ -214,12 +253,24 @@ Files: `online_source.py`, `comicbox/online_session.py`,
 - Restoring `per_second` / `per_hour` config overrides: still no injection point
   in 4.0; the warn-and-ignore stays.
 
-## Open questions
+## Outcome
 
-1. Phase 1: add `RetryCategory.INVALID` for CV 102/104 (recommended, three
-   lines), or leave them TRANSIENT as today?
-2. Phase 4: per-pool dict for Comic Vine, or collapse to the busiest pool as a
-   single `sustained` window to match Metron's shape exactly? Depends on what
-   Codex's renderer wants.
-3. Phase 3: file the simyan issue/PR now, before the comicbox work, so the floor
-   bump can ride the same release?
+Landed in five commits on `simyan-4`. Two things surfaced that were not in the
+original plan:
+
+- **The test suite was never isolated from the real online cache dir.**
+  `online.cache.dir` defaults to the platformdirs user cache, which holds live
+  response and rate-limit sqlite files. Phase 4's budget read made this visible
+  by returning this machine's actual Comic Vine pools inside a unit test. The
+  hermetic env fixture now pins the directory into `tmp_path`, so no test can
+  read or corrupt real cached data.
+- **Closing a simyan client does not release its sqlite handles.**
+  requests-ratelimiter's `HostBucketFactory` stores buckets in its own `buckets`
+  dict, which pyrate-limiter's `BucketFactory.close()` does not iterate, so
+  `session.close()` stops the leaker but leaves the bucket connections open —
+  measured, 2 of 4 released. This is the cause of the `unclosed database`
+  ResourceWarnings that already existed on `develop` (10 on `fbcaa26`).
+  `tests/util/online_client.py` closes them explicitly so the new tests add
+  none. **Not fixed broadly:** the pre-existing warnings come from other tests
+  building real clients, and a general fix belongs either upstream in
+  requests-ratelimiter or in a shared fixture, which is a separate change.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,12 @@ def _hermetic_comicbox_env(  # pyright: ignore[reportUnusedFunction]
     """
     Strip ``COMICBOX_*`` env vars and isolate confuse from user config.
 
+    Also pins the online cache directory into ``tmp_path``. Left unset it
+    resolves to the developer's real platformdirs cache, which holds live
+    response and rate-limit sqlite files from actual tagging runs — so a
+    test reading either would depend on that machine's history, and one
+    writing either would corrupt it.
+
     Also clears the online sources' process-wide client caches on the way
     out. Both Metron and Comic Vine memoize their upstream client by
     credential set at module scope so a batch reuses one connection pool;
@@ -82,6 +88,7 @@ def _hermetic_comicbox_env(  # pyright: ignore[reportUnusedFunction]
         if key.startswith("COMICBOX"):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("COMICBOXDIR", str(tmp_path))
+    monkeypatch.setenv("COMICBOX_ONLINE__CACHE__DIR", str(tmp_path / "online-cache"))
     yield
     _reset_shared_online_sessions()
 

--- a/tests/unit/test_comicvine_client.py
+++ b/tests/unit/test_comicvine_client.py
@@ -21,7 +21,7 @@ from comicbox.config.online.settings import (
     OnlineSourceTuning,
     OnlineTuningSettings,
 )
-from comicbox.formats.base.online.retry import RetryCategory
+from comicbox.formats.base.online.retry import RetryCategory, with_retry
 from comicbox.formats.comicvine_api.online_source import (
     ComicVineOnlineSource,
     reset_shared_sessions,
@@ -32,22 +32,42 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_classify_rate_limit_error_tolerates_none_message() -> None:
-    """Simyan raises RateLimitError on HTTP 429/420; the message may be None."""
-    assert (
-        ComicVineOnlineSource.classify_retry_exception(RateLimitError(None))
-        is RetryCategory.RATE_LIMIT
-    )
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        # Typed by simyan from the HTTP status...
+        (RateLimitError(None), RetryCategory.RATE_LIMIT),
+        (AuthenticationError("Invalid API Key"), RetryCategory.AUTH),
+        # ...and from Comic Vine's HTTP-200 body `status_code` (107, 100).
+        (RateLimitError("Rate Limit Exceeded"), RetryCategory.RATE_LIMIT),
+        # Body errors simyan leaves as a plain ServiceError: CV 101, 102, 104.
+        (ServiceError("Object Not Found"), RetryCategory.NOT_FOUND),
+        (ServiceError("Error in URL Format"), RetryCategory.INVALID),
+        (ServiceError("Filter Error"), RetryCategory.INVALID),
+        # simyan's own wording for an HTTP 404.
+        (ServiceError("Resource not found"), RetryCategory.NOT_FOUND),
+        # Unrecognized bodies stay retriable rather than failing a lookup.
+        (ServiceError("Something new upstream"), RetryCategory.TRANSIENT),
+        (ServiceError(None), RetryCategory.TRANSIENT),
+    ],
+)
+def test_classify_by_exception_type_and_body_message(
+    exc: BaseException, expected: RetryCategory
+) -> None:
+    """
+    Simyan 4 types the two retry-relevant failures; the rest read as messages.
 
-
-def test_classify_authentication_error_is_auth() -> None:
-    exc = AuthenticationError("Invalid API Key")
-    assert ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.AUTH
+    RateLimitError on HTTP 429/420 and CV body status 107,
+    AuthenticationError on HTTP 401 and body status 100. Comic Vine's
+    other body errors arrive as a bare ServiceError carrying only the
+    body's `error` string, so the message is the only signal left.
+    """
+    assert ComicVineOnlineSource.classify_retry_exception(exc) is expected
 
 
 def test_classify_client_side_cap_timeout_is_rate_limit() -> None:
     """
-    Simyan 3.x client-side cap exhaustion is only visible in __cause__.
+    Client-side rate-limit cap exhaustion is only visible in __cause__.
 
     The ServiceError message is the generic "Service took too long to
     respond"; the chained requests Timeout carries the rate-limit text.
@@ -70,11 +90,38 @@ def test_classify_genuine_read_timeout_is_transient() -> None:
     )
 
 
-def test_classify_resource_not_found() -> None:
-    exc = ServiceError("Resource not found")
-    assert (
-        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.NOT_FOUND
-    )
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # CV 102/104: comicbox built a bad url or filter expression.
+        # Replaying it verbatim can only fail identically, which is the
+        # point of INVALID over TRANSIENT.
+        ServiceError("Filter Error"),
+        ServiceError("Error in URL Format"),
+        # CV 100 / HTTP 401: burning the generic 5-attempt budget on a
+        # key that will never work just delays the failure ~31s.
+        AuthenticationError("Invalid API Key"),
+        # CV 101 / HTTP 404.
+        ServiceError("Object Not Found"),
+    ],
+)
+def test_terminal_failures_are_called_exactly_once(exc: BaseException) -> None:
+    """A terminal classification must not be replayed by the retry loop."""
+    calls = {"n": 0}
+
+    class _Source:
+        classify_retry_exception = staticmethod(
+            ComicVineOnlineSource.classify_retry_exception
+        )
+
+        @with_retry()
+        def call(self) -> None:
+            calls["n"] += 1
+            raise exc
+
+    with pytest.raises(type(exc)):
+        _Source().call()
+    assert calls["n"] == 1
 
 
 def _unparseable_body_error(status: int) -> ServiceError:
@@ -142,18 +189,6 @@ def test_classify_server_error_is_transient() -> None:
     )
 
 
-def test_classify_cv_status_107_body_is_rate_limit() -> None:
-    """CV serves some rate-limit errors as 200 bodies that die in pydantic."""
-    exc = ServiceError(
-        "1 validation error for VolumeListResponse\n"
-        "  Value error, {'error': 'Rate Limit Exceeded', 'status_code': 107}"
-        " [type=value_error]"
-    )
-    assert (
-        ComicVineOnlineSource.classify_retry_exception(exc) is RetryCategory.RATE_LIMIT
-    )
-
-
 def test_classify_non_simyan_exception_is_unclaimed() -> None:
     """Anything outside simyan's hierarchy returns None (decorator fallback)."""
     exc = RuntimeError("connection reset by peer")
@@ -164,14 +199,13 @@ def test_classify_non_simyan_exception_is_unclaimed() -> None:
 
 
 class _FakeComicvine:
-    """Captures simyan v3 constructor kwargs; stands in for the client."""
+    """Captures simyan constructor kwargs; stands in for the client."""
 
     def __init__(self, **kwargs: object) -> None:
         self.kwargs = kwargs
         self.cache_deletes: list[dict] = []
         self._session = SimpleNamespace(
             cache=SimpleNamespace(delete=lambda **kw: self.cache_deletes.append(kw)),
-            settings=SimpleNamespace(disabled=False),
         )
 
 
@@ -215,7 +249,7 @@ def test_get_session_memoizes_client(monkeypatch: pytest.MonkeyPatch) -> None:
     assert builds["n"] == 1
 
 
-def test_build_session_passes_v3_kwargs(
+def test_build_session_passes_simyan_kwargs(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Cache and rate-limit files land in comicbox's cache dir, ttl → expiry."""
@@ -236,16 +270,19 @@ def test_build_session_passes_v3_kwargs(
 def test_build_session_cache_off_uses_do_not_cache(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """OFF pins cache_path (never ~/.cache/simyan) and disables the session cache."""
+    """
+    OFF pins cache_path (never ~/.cache/simyan) and passes DO_NOT_CACHE.
+
+    That flag is the whole of OFF now: simyan stopped passing
+    `cache_control`, so no response can talk its way back into the cache
+    on its own headers. See `_cache_expiry`.
+    """
     from requests_cache import DO_NOT_CACHE
 
     settings = _make_cache_settings(tmp_path, mode=CacheMode.OFF)
     client = _build_with_fake(monkeypatch, settings)
     assert client.kwargs["cache_expiry"] == DO_NOT_CACHE
     assert client.kwargs["cache_path"] == tmp_path / "comicvine_cache.sqlite"
-    # DO_NOT_CACHE alone still allows header-driven writes; the settings
-    # flag makes OFF mean no reads AND no writes.
-    assert client._session.settings.disabled is True
 
 
 def test_build_session_zero_ttl_never_expires(
@@ -299,7 +336,7 @@ def test_get_session_warns_on_ignored_rate_limit_override(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """
-    CV per_second/per_hour overrides can't flow into simyan 3.x — warn.
+    CV per_second/per_hour overrides can't flow into simyan — warn.
 
     Driven through `_get_session`, not `_build_session`: the warning
     deliberately fires on every source that carries the ignored config,

--- a/tests/unit/test_comicvine_client.py
+++ b/tests/unit/test_comicvine_client.py
@@ -7,7 +7,7 @@ import time
 from contextlib import closing
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 from requests.exceptions import Timeout
@@ -28,6 +28,7 @@ from comicbox.formats.comicvine_api.online_source import (
     reset_shared_sessions,
 )
 from comicbox.version import USER_AGENT
+from tests.util.online_client import comicvine_client, spend
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -434,19 +435,6 @@ def test_get_session_warns_when_reused_with_different_cache_settings(
 # ------------------------------------------------------- rate-limit status
 
 
-def _spend(client: Any, pool: str, times: int) -> None:
-    """
-    Claim `times` slots in a limiter pool via pyrate-limiter's public API.
-
-    `client._session` is simyan's private session, typed Any here for
-    the same reason the source module does: it is deliberately not part
-    of simyan's public surface.
-    """
-    limiter = client._session.limiter
-    for _ in range(times):
-        limiter.try_acquire(pool, weight=1, blocking=True, timeout=5)
-
-
 def test_rate_limit_status_reads_per_pool_budget(tmp_path: Path) -> None:
     """
     Comic Vine's remaining budget is readable per endpoint pool.
@@ -456,24 +444,17 @@ def test_rate_limit_status_reads_per_pool_budget(tmp_path: Path) -> None:
     pyrate-limiter changes the table naming or the timestamp units, the
     numbers here stop matching rather than silently reading as full.
     """
-    from simyan.comicvine import Comicvine
-
     from comicbox.formats.base.online.rate_limits import COMICVINE_DEFAULT_PER_HOUR
     from comicbox.formats.comicvine_api.online_source import (
         shared_client_rate_limit_status,
     )
 
-    client = Comicvine(
-        api_key="k",
-        cache_path=tmp_path / "comicvine_cache.sqlite",
-        ratelimit_path=tmp_path / "comicvine_rate_limit.sqlite",
-    )
-    _spend(client, "issues", 3)
-    _spend(client, "search", 1)
-
-    status = shared_client_rate_limit_status(
-        OnlineSettings(cache=OnlineCacheSettings(dir=tmp_path))
-    )
+    with comicvine_client(tmp_path) as client:
+        spend(client, "issues", 3)
+        spend(client, "search", 1)
+        status = shared_client_rate_limit_status(
+            OnlineSettings(cache=OnlineCacheSettings(dir=tmp_path))
+        )
 
     assert status["issues"]["remaining"] == COMICVINE_DEFAULT_PER_HOUR - 3
     assert status["issues"]["limit"] == COMICVINE_DEFAULT_PER_HOUR

--- a/tests/unit/test_comicvine_client.py
+++ b/tests/unit/test_comicvine_client.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from contextlib import closing
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from requests.exceptions import Timeout
@@ -428,3 +429,82 @@ def test_get_session_warns_when_reused_with_different_cache_settings(
         loguru_logger.remove(handler_id)
         reset_shared_sessions()
     assert any("ignored in favor of" in message for message in messages)
+
+
+# ------------------------------------------------------- rate-limit status
+
+
+def _spend(client: Any, pool: str, times: int) -> None:
+    """
+    Claim `times` slots in a limiter pool via pyrate-limiter's public API.
+
+    `client._session` is simyan's private session, typed Any here for
+    the same reason the source module does: it is deliberately not part
+    of simyan's public surface.
+    """
+    limiter = client._session.limiter
+    for _ in range(times):
+        limiter.try_acquire(pool, weight=1, blocking=True, timeout=5)
+
+
+def test_rate_limit_status_reads_per_pool_budget(tmp_path: Path) -> None:
+    """
+    Comic Vine's remaining budget is readable per endpoint pool.
+
+    simyan exposes no budget accessor, but requests-ratelimiter persists
+    one bucket table per pool. This test pins that layout: if a future
+    pyrate-limiter changes the table naming or the timestamp units, the
+    numbers here stop matching rather than silently reading as full.
+    """
+    from simyan.comicvine import Comicvine
+
+    from comicbox.formats.base.online.rate_limits import COMICVINE_DEFAULT_PER_HOUR
+    from comicbox.formats.comicvine_api.online_source import (
+        shared_client_rate_limit_status,
+    )
+
+    client = Comicvine(
+        api_key="k",
+        cache_path=tmp_path / "comicvine_cache.sqlite",
+        ratelimit_path=tmp_path / "comicvine_rate_limit.sqlite",
+    )
+    _spend(client, "issues", 3)
+    _spend(client, "search", 1)
+
+    status = shared_client_rate_limit_status(
+        OnlineSettings(cache=OnlineCacheSettings(dir=tmp_path))
+    )
+
+    assert status["issues"]["remaining"] == COMICVINE_DEFAULT_PER_HOUR - 3
+    assert status["issues"]["limit"] == COMICVINE_DEFAULT_PER_HOUR
+    assert status["search"]["remaining"] == COMICVINE_DEFAULT_PER_HOUR - 1
+    # An untouched pool has no table, so it is absent rather than full.
+    assert "volumes" not in status
+    # reset_epoch is when the oldest in-window request ages out: an hour
+    # out, give or take the time this test took.
+    assert status["issues"]["reset_epoch"] == pytest.approx(time.time() + 3600, abs=60)
+
+
+def test_rate_limit_status_empty_without_bucket_file(tmp_path: Path) -> None:
+    """No requests yet means no file; report {} rather than a full budget."""
+    from comicbox.formats.comicvine_api.online_source import (
+        shared_client_rate_limit_status,
+    )
+
+    status = shared_client_rate_limit_status(
+        OnlineSettings(cache=OnlineCacheSettings(dir=tmp_path))
+    )
+    assert status == {}
+
+
+def test_rate_limit_status_does_not_create_the_cache_dir(tmp_path: Path) -> None:
+    """A status read must have no side effects on the filesystem."""
+    from comicbox.formats.comicvine_api.online_source import (
+        shared_client_rate_limit_status,
+    )
+
+    missing = tmp_path / "not-yet"
+    shared_client_rate_limit_status(
+        OnlineSettings(cache=OnlineCacheSettings(dir=missing))
+    )
+    assert not missing.exists()

--- a/tests/unit/test_online_estimate.py
+++ b/tests/unit/test_online_estimate.py
@@ -61,7 +61,7 @@ def test_comicvine_requests_scale_with_mode() -> None:
 
 def test_comicvine_pacing_binds_on_busiest_pool_not_total() -> None:
     """
-    Simyan 3.x paces per resource pool (CV's per-resource limit).
+    Simyan paces per resource pool (CV's per-resource limit).
 
     Auto costs more requests than eager, but the extras land in different
     pools, so both sustain the same pace.

--- a/tests/unit/test_online_retry.py
+++ b/tests/unit/test_online_retry.py
@@ -487,7 +487,7 @@ def test_mixed_failures_track_budgets_independently() -> None:
 
 def test_simyan_client_cap_timeout_uses_rate_limit_schedule() -> None:
     """
-    Simyan 3.x client-side cap exhaustion routes to the rate-limit schedule.
+    Simyan's client-side cap exhaustion routes to the rate-limit schedule.
 
     When the bounded in-limiter wait expires, requests_ratelimiter raises
     Timeout("Rate limit not cleared within max_delay=...") and simyan
@@ -558,7 +558,7 @@ def test_api_key_redacted_from_exception_chain() -> None:
     """
     The retry boundary scrubs `api_key=` values from chained messages.
 
-    simyan 3.x sends the ComicVine key as a query param; requests embeds
+    simyan sends the ComicVine key as a query param; requests embeds
     the full URL in the HTTPError that becomes `__cause__` of every
     simyan error. A full-traceback log of that chain must not print the
     key. Uses the real simyan/requests classes to pin the shape.

--- a/tests/unit/test_rate_limits.py
+++ b/tests/unit/test_rate_limits.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from argparse import Namespace
 from dataclasses import replace
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 import pytest
 from mokkari.session import RateLimitStatus, RateLimitWindow
@@ -30,6 +31,10 @@ from comicbox.formats.metron_api.online_source import (
     shared_session_rate_limit_status,
 )
 from comicbox.online_session import OnlineCredentials, OnlineSession
+from tests.util.online_client import comicvine_client, spend
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_documented_defaults_match_upstream() -> None:
@@ -46,7 +51,7 @@ def test_documented_defaults_match_upstream() -> None:
     needs a manual look.
     """
     assert METRON_DEFAULT_PER_MINUTE == 20
-    # simyan 3.x hardcodes its rates as literals in Comicvine.__init__ with
+    # simyan hardcodes its rates as literals in Comicvine.__init__ with
     # no importable constant; pin the documented numbers it ships with.
     assert COMICVINE_DEFAULT_PER_SECOND == 1
     assert COMICVINE_DEFAULT_PER_HOUR == 200
@@ -294,11 +299,32 @@ def test_online_session_rate_limit_status_skips_blank_window() -> None:
     }
 
 
-def test_online_session_rate_limit_status_comicvine_always_empty() -> None:
-    """Simyan exposes no budget to read; comic vine stays {} even mid-run."""
+def test_online_session_rate_limit_status_comicvine_empty_before_any_request() -> None:
+    """
+    Comic Vine reports {} until its rate-limit bucket file exists.
+
+    Nothing has spent budget in this session, so there is no file to read
+    and no pool to report — distinct from reporting a full budget, which
+    would be a guess.
+    """
     _seed_shared_session(RateLimitStatus(burst=RateLimitWindow(limit=20, remaining=19)))
     session = _make_online_session(sources=("comicvine", "metron"))
     assert session.rate_limit_status()["comicvine"] == {}
+
+
+def test_online_session_rate_limit_status_comicvine_reports_spent_pools(
+    tmp_path: Path,
+) -> None:
+    """Once a pool has spent budget, the session surfaces what it has left."""
+    # The hermetic env fixture pins the online cache dir here, so this is
+    # the same directory the session under test will read.
+    with comicvine_client(tmp_path / "online-cache") as client:
+        spend(client, "issues", 2)
+        status = _make_online_session(sources=("comicvine",)).rate_limit_status()
+
+    assert status["comicvine"]["issues"]["remaining"] == (
+        COMICVINE_DEFAULT_PER_HOUR - 2
+    )
 
 
 def test_metron_rate_limit_override_warns_and_is_ignored(

--- a/tests/util/online_client.py
+++ b/tests/util/online_client.py
@@ -1,0 +1,57 @@
+"""Lifecycle helpers for real upstream API clients built in tests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+
+def close_comicvine_client(client: Any) -> None:
+    """
+    Release every sqlite connection a simyan `Comicvine` opened.
+
+    `session.close()` alone leaves the rate-limit buckets open:
+    requests-ratelimiter's `HostBucketFactory` keeps its buckets in its
+    own `buckets` dict, which pyrate-limiter's `BucketFactory.close()`
+    does not iterate, so it closes the leaker but not the bucket
+    connections. Closing them here keeps tests from leaking sqlite
+    handles and emitting ResourceWarnings.
+    """
+    session = client._session
+    factory = session.limiter.bucket_factory
+    session.close()
+    for bucket in list(getattr(factory, "buckets", {}).values()):
+        bucket.close()
+
+
+@contextmanager
+def comicvine_client(cache_dir: Path, api_key: str = "k") -> Generator[Any]:
+    """
+    Yield a real `Comicvine` pointed at `cache_dir`, fully closed on exit.
+
+    Its file names match what `ComicVineOnlineSource` would choose, so a
+    status read against the same directory finds them.
+    """
+    from simyan.comicvine import Comicvine
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    client = Comicvine(
+        api_key=api_key,
+        cache_path=cache_dir / "comicvine_cache.sqlite",
+        ratelimit_path=cache_dir / "comicvine_rate_limit.sqlite",
+    )
+    try:
+        yield client
+    finally:
+        close_comicvine_client(client)
+
+
+def spend(client: Any, pool: str, times: int) -> None:
+    """Claim `times` slots in a limiter pool via pyrate-limiter's public API."""
+    limiter = client._session.limiter
+    for _ in range(times):
+        limiter.try_acquire(pool, weight=1, blocking=True, timeout=5)


### PR DESCRIPTION
Adopts simyan 4.0.0. The dependency bump itself already landed in fbcaa26;
every ComicVine test passed unmodified under 4.0.0, so nothing here is
repair. This is taking advantage of what changed and retiring code written
around 3.x quirks.

Plan, findings and outcome: `tasks/simyan-4-plan.md`.

## What 4.0.0 changed, and what comicbox does about it

Verified by diffing the installed 4.0.0 wheel against a downloaded 3.1.0.

**Comic Vine's HTTP-200 error bodies are now typed exceptions.** A body
`status_code` of 100 raises `AuthenticationError` and 107 raises
`RateLimitError`, instead of dying inside pydantic. Two pieces of comicbox
code existed only to cope with the old behavior:

- The `"rate limit"` message sniff in `_classify_service_error` was dead
  code, since 107 now arrives typed.
- An invalid API key used to classify as TRANSIENT and burn all five generic
  retries (~31s) before failing. It is now AUTH, so it fails on the first
  call.

The two ad-hoc message checks are replaced by an explicit table of Comic
Vine's body `error` strings. New `RetryCategory.INVALID` covers CV 102 and
104 (malformed url / filter): those mean comicbox built a bad request, so
replaying it verbatim can only fail the same way. It is terminal, the
classified twin of `retry.py`'s `_NON_RETRIABLE` tuple.

**`cache_control` is gone from simyan's session.** A response's own cache
headers can no longer talk their way back into the cache, so the private
`session.settings.disabled` reach-in for `CacheMode.OFF` is redundant:
`DO_NOT_CACHE` alone now skips reads and writes alike. Verified against the
real client with a fake transport returning `Cache-Control: max-age=3600` —
zero rows written. Side effect worth noting: cached responses now live for
the configured `online.cache.ttl` instead of expiring early when Comic Vine
said so.

## New: Comic Vine's rate-limit budget

`rate_limit_status()` returned `{}` for Comic Vine because simyan builds its
limiter internally and exposes no accessor. The budget is readable anyway:
requests-ratelimiter persists one pyrate-limiter `SQLiteBucket` table per
endpoint pool, one row per request stamped in epoch milliseconds. Counting
the rows still inside the hour window is an exact read of what Comic Vine's
200-per-resource-per-hour cap has left.

Comic Vine meters per resource, so it reports one window per pool it has
used rather than Metron's fixed burst/sustained pair:

```
{"issues": {"limit": 200, "remaining": 197, "reset_epoch": ...},
 "search": {"limit": 200, "remaining": 199, "reset_epoch": ...}}
```

Both sources now map a window name to the same
`limit` / `remaining` / `reset_epoch` triple, so one renderer handles
either. Read from the file rather than a live client, so the budget survives
across runs and is available before a session issues its first request, and
opened read-only so it cannot disturb a live limiter or create the file.

**Note for codex:** this is a per-pool dict, not Metron's fixed pair. Paired
release, no shim.

## Two things the plan did not anticipate

**The test suite was never isolated from the real online cache dir.**
`online.cache.dir` defaults to the platformdirs user cache, which holds live
response and rate-limit sqlite files from real tagging runs. The budget read
made this visible by returning this machine's actual Comic Vine pools inside
a unit test. Any test reading those files depended on the machine's history,
and any test writing them would corrupt real cached data. The hermetic env
fixture now pins the directory into `tmp_path`.

**Closing a simyan client does not release its sqlite handles.**
requests-ratelimiter's `HostBucketFactory` keeps its buckets in its own
`buckets` dict, which pyrate-limiter's `BucketFactory.close()` does not
iterate, so the leaker is stopped but the bucket connections stay open
(measured: `session.close()` releases 2 of 4). This is the cause of the
`unclosed database` ResourceWarnings that **already exist on develop** — 10
of them on fbcaa26. `tests/util/online_client.py` closes them explicitly so
the new tests add none.

*Not fixed broadly, deliberately.* The pre-existing warnings come from other
tests building real clients, and a general fix belongs either upstream in
requests-ratelimiter or in a shared fixture. Happy to do it as a follow-up if
you want it.

## Filed upstream, not worked around here

simyan's `_offset` / `_paginate` loop until they receive an *empty* page
rather than stopping on a *short* one, so every result set that does not land
on a page boundary spends an extra request. A volume-scoped issue lookup
returning 2 issues costs 2 requests against the 200/hr `issues` pool; a
43-issue volume that fits in one 100-item page also costs 2. The same code is
in 3.1.0, so this is not a regression, but it means `api_call_counts` and
`online_estimate.py` under-count by roughly 2x.

Filed with a reproduction and a tested patch as
Metron-Project/Simyan#309. Nothing comicbox can pass stops a short page
early, and overriding `_offset` is private surface, so there is no
workaround in this PR.

`online_estimate.py`'s constants are deliberately left alone. They are a
projection shown to an operator before a run, and doubling them to describe a
bug we are fixing upstream would make them wrong again as soon as the floor
bumps. Revisit if 5.0.0 ships before the simyan fix.

## Verification

`make fix`, `make lint`, `make ty`, `make typecheck` and `make complexity`
are all clean.

`make test`: **2061 passed, 1 skipped** — up from 2048 on fbcaa26, with the
warning count unchanged at 15.

No version bump: NEWS entries went under the existing `v5.0.0` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
