### PR TITLE
fix(types): annotate _normalize_metadata's real return type

### DIFF
--- a/comicbox/box/normalize.py
+++ b/comicbox/box/normalize.py
@@ -19,7 +19,10 @@ class ComicboxNormalize(ComicboxLoad):
             self._transform_cache[transform_class] = transform_class(self._path)
         return self._transform_cache[transform_class]
 
-    def _normalize_metadata(self, source: MetadataSources, loaded_data: Any) -> None:
+    def _normalize_metadata(
+        self, source: MetadataSources, loaded_data: Any
+    ) -> MappingProxyType | None:
+        """Normalize one loaded document, or None if it's empty or fails."""
         if not loaded_data.metadata:
             return None
         transform_class = loaded_data.fmt.value.transform_class


### PR DESCRIPTION
## Why

`make ty` reported one warning, which predated the previous PR:

```
warning[redundant-condition]: `None` is always falsy
  --> comicbox/box/normalize.py:43:16
```

`ty` was right. `_normalize_metadata` was declared `-> None` but returns
`transform.to_comicbox(...)`, which is a `MappingProxyType`. Reading only the
annotation, the caller's `if normalized_md:` can never be true, so the entire
normalize step looks like dead code.

The runtime behavior was always correct. That branch is what carries every
normalized document into `_normalized`; the annotation was the only thing wrong.

## Verification

Instrumenting a read of a multi-format CBZ shows the supposedly-dead branch is
the load-bearing one:

```
normalize calls: 6 | returned non-None: 6
merged metadata non-empty: True
```

`make ty` now passes. `make lint`, `make typecheck` and `make fix` are clean,
and `make fix` produced no further changes. Full suite unchanged at 2066 passed,
1 skipped, 15 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)