### PR TITLE
feat(online): let an embedder supply the session's base settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,10 @@
     - Web urls in the Notes field are read into `urls`.
     - Online API: new `SourceStarted` event, and `rate_limit_status()` now
       covers Comic Vine as well as Metron.
+    - `OnlineSession` accepts a `config`, the settings it layers its tagging
+      preferences over. An embedder that already holds configured settings —
+      naming its own cache directory or effort — hands them over instead of
+      exporting environment variables for the settings loader to find.
 
 - Fixes
     - Two silent data losses: an XML tag carrying an attribute, like

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -274,6 +274,14 @@ class OnlineSession:
     ``ids`` pins an issue id per source for a single-comic session: a
     pinned source fetches that id directly while the unpinned sources
     search, so one run can mix id retrieval and search and merge both.
+
+    ``config`` supplies the settings the session layers its tagging
+    preferences over. An embedder that already holds configured
+    ``ComicboxSettings`` — naming its own cache directory or effort,
+    neither of which an ``OnlineSession`` keyword covers — passes them
+    here instead of exporting environment variables for the settings
+    loader to find. Omitted, the session reads config files and the
+    environment itself.
     """
 
     def __init__(  # noqa: PLR0913
@@ -290,6 +298,7 @@ class OnlineSession:
         first_wins: bool = True,
         defer_prompts: bool = False,
         series_batching: bool = True,
+        config: ComicboxSettings | None = None,
     ) -> None:
         """Validate inputs, build per-session state. See class docstring."""
         # Order is run priority: the first source runs first and, under
@@ -316,8 +325,12 @@ class OnlineSession:
         # Read config files / env exactly once per session. _build_config
         # used to call get_config() per file — wasted disk I/O on big
         # batches plus a behavioral surprise where a config-file edit
-        # mid-batch changed settings for the remaining files.
-        self._base_settings: ComicboxSettings = get_config()
+        # mid-batch changed settings for the remaining files. A caller
+        # that passes its own settings skips the read entirely: they are
+        # already the answer this would have gone looking for.
+        self._base_settings: ComicboxSettings = (
+            config if config is not None else get_config()
+        )
         # Nothing in the settings tree varies per file: the mutable
         # policy lives in _state and each box overlays it for itself.
         self._settings: ComicboxSettings = self._build_config()

--- a/tasks/codex-5-upstream-followups.md
+++ b/tasks/codex-5-upstream-followups.md
@@ -1,0 +1,161 @@
+# Comicbox 5.0 — Upstream Follow-ups Found While Adopting It in Codex
+
+**Audience:** an agent working in [comicbox](https://github.com/ajslater/comicbox).
+This document is self-contained: it does not assume you saw the codex
+conversation or PRs. It is the return leg of `tasks/codex-v3-handoff.md`.
+
+**Status:** one item is already implemented on the branch
+`online-session-config-hook` and needs merging before the 5.0 release. The rest
+are observations codex worked around; each says what codex did instead, so
+nothing here is blocking.
+
+## Context
+
+Codex was migrated to comicbox 5.0.0 (schema v3.0) over three commits on its
+`comicbox-5` branch. The migration is straightforward and the v3 design holds
+up well in practice. What follows is only the friction: places where codex had
+to reach around an API, accept a lossy round trip, or duplicate something
+comicbox already knows.
+
+The codex side is on branch `comicbox-5`, pinned to `comicbox[pdf]~=5.0.0`.
+
+---
+
+## 1. `OnlineSession` could not be given settings (DONE, needs merge)
+
+**Branch:** `online-session-config-hook`, commit `33a369a`.
+
+`OnlineSession.__init__` read its base `ComicboxSettings` from `get_config()`
+(`comicbox/online_session.py:320`). Every other comicbox entry point lets a
+caller pass settings in, but this one did not, so an embedder holding
+configured settings had no way to hand them over.
+
+That mattered to codex twice:
+
+- **Cache directory.** Codex keeps comicbox's online sqlite caches under its
+  own `/config` volume, because comicbox's platformdirs default is thrown away
+  when a Docker container is recreated. It travelled as
+  `COMICBOX_ONLINE_CACHE_DIR`, which 5.0 stops reading — correctly, since env
+  vars now nest with `__`. Codex could have switched to
+  `COMICBOX_ONLINE__CACHE__DIR`, but that puts the setting back on a name
+  comicbox is free to rename again.
+- **Effort.** `Effort` has no `OnlineSession` keyword, so an embedder wanting
+  anything but the default has only the environment to reach it through.
+
+The fix adds a `config` keyword. Passing it also skips the config-file and
+environment read, which is pure waste when the caller's settings are already
+the answer that read would find. Tests are in
+`tests/unit/test_online_session.py`; `NEWS.md`'s 5.0.0 Features section has an
+entry.
+
+**Action:** merge before releasing 5.0.0. Codex's `comicbox-5` branch depends
+on it — `session_manager.py` passes `config=COMICBOX_ONLINE_CONFIG`.
+
+---
+
+## 2. The run estimator still models unbounded Comic Vine fan-out
+
+`comicbox/online_estimate.py:117` `requests_per_comic()` keys Comic Vine's cost
+off `MatchMode` alone. Since 5.0 bounds Comic Vine's per-candidate fan-out by
+default and `Effort.THOROUGH` restores the unbounded search, the estimate no
+longer describes what a default run actually costs.
+
+Codex surfaces this estimate directly: the online-tag launcher shows a
+projected duration before a scan and a live countdown during it
+(`codex/librarian/onlinetag/estimate.py`, `codex/choices/onlinetag.py`). Under
+the new default those numbers read high, and under `thorough` they read low.
+
+**Suggested shape:** `requests_per_comic(source, mode, effort)` and
+`estimate_run(..., effort=...)`, with `COMICVINE_REQUESTS_BY_MODE` becoming a
+mode-by-effort table. Codex would pass the admin's configured effort, which it
+already threads into the session.
+
+---
+
+## 3. The credit primary flag reaches no format codex writes
+
+`credits.<person>.roles.<role>.primary` persists to ComicBookInfo only
+(`comicbox/formats/comicbox/schema/__init__.py:150` marks it "CBI ONLY"; the
+only writer is `comicbox/formats/comic_book_info/transform/credits.py:145`).
+MetronInfo v1.1's schema has `primary` attributes on `URL` and `ID` but none on
+a credit, and ComicInfo has no notion of one.
+
+Codex writes ComicInfo and MetronInfo. It reads the flag, stores it on the
+person-and-role pairing, and shows primaries first in the metadata panel — but
+it deliberately ships **no editor control**, because a control whose value
+could never be written back would be a lie. The flag survives only as long as
+nothing rewrites the file.
+
+**Not obviously actionable** — it is a limitation of the format specs, not of
+comicbox. Worth knowing that the field is, in practice, read-only for the two
+formats most tools use. If MetronInfo ever gains the attribute, codex's field
+support map derives itself from the transforms and the control would light up
+on its own.
+
+---
+
+## 4. Metron publishes no URL for several id types
+
+`IDENTIFIER_PARTS_MAP[IdSources.METRON]`
+(`comicbox/identifiers/identifiers.py:238`) notes that genre, location,
+reprint, role, story and tag have no public web page, so `unparse_url` returns
+`""` for them.
+
+That is correct, and codex now derives its `Identifier.url` column through
+`get_identifier_url` and stores the empty string. Two observations:
+
+- An id on one of a series' `alternative_names` is a **series** id, but where
+  it sits no longer implies that. Codex has to inject `id_type: series` when it
+  folds those names in among its reprints, or the derived link is empty. If
+  comicbox stated the type on those identifiers itself — the way it does for a
+  top-level id that isn't an issue — the positional rule would carry through
+  and no consumer would need to know this.
+- `reprint` as an id type can never build a Metron URL, so any identifier
+  comicbox files under it is linkless by construction.
+
+---
+
+## 5. `MergeMode` note — no action, just confirmation
+
+The `MergeMode` docstring (`comicbox/config/settings.py:81`) is the clearest
+statement of the tradeoff and it is accurate: `update` replaces top-level keys
+wholesale and drops siblings, while `replace` recurses into dicts and replaces
+only the leaves.
+
+Codex writes with `update`, so a patch that carried only
+`series.alternative_names` would drop the series' `name`. Codex compensates by
+sending the whole series object it knows about. Switching codex to `replace`
+for these writes would be the cleaner fix and is a codex-side decision;
+recorded here only so the next person does not read the compensation as a
+comicbox bug.
+
+---
+
+## Things that worked well, for what it's worth
+
+- **The new skip warning earned its keep immediately.** Two codex test fixtures
+  had been malformed for as long as they had existed — a null team value that
+  voided the entire `teams` field, and a credit role's identifier keyed by
+  `key` instead of by its source. 4.8.7 dropped both as silently as an absent
+  tag. 5.0 named them, and both were repaired.
+- **Deriving links from keys rather than storing them** removed a whole class
+  of disagreement. Codex kept its url column and now fills it through
+  `get_identifier_url`, which also fixed a latent mismatch: the column stores
+  `""` for a linkless type, and the aggregate now carries `""` too rather than
+  `None`.
+- **`id_type` on a top-level identifier** let codex file a stated series or
+  volume id correctly instead of assuming every comic-level id was an issue id.
+- **Splitting manga from reading direction** was clean to adopt. The two facts
+  land in two columns and two editor fields, and the format support map derives
+  which format can store which without anything hand-written.
+
+## Where the codex work lives
+
+| Branch | Commit | What |
+|---|---|---|
+| `comicbox-5` | `1f1c593` | Moved and renamed APIs, derived identifier urls, v3 fixtures |
+| `comicbox-5` | `07188d9` | Identifier type vocabulary bridge, reprint name fallback |
+| `comicbox-5` | `0db3cf0` | manga, manga_volume, urls, Credit.primary, Reprint.alternative_name |
+
+Remaining codex phases: online extras (effort setting, Comic Vine rate-limit
+display), the one-time re-read migration, and docs.

--- a/tests/unit/test_online_session.py
+++ b/tests/unit/test_online_session.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+from pathlib import Path
+
 import pytest
 
 from comicbox.box import Comicbox
-from comicbox.config.online.settings import MatchMode, Prompts
+from comicbox.config import get_config
+from comicbox.config.online.settings import Effort, MatchMode, Prompts
 from comicbox.online_session import (
     OnlineConfigurationError,
     OnlineCredentials,
@@ -184,6 +188,39 @@ def test_only_enabled_sources_appear_in_auth() -> None:
     cfg = session._build_config()
     assert "metron" in cfg.online.auth.sources
     assert "comicvine" not in cfg.online.auth.sources
+
+
+def test_supplied_config_is_the_base_the_session_layers_over() -> None:
+    """Settings an embedder passes in survive into every per-file config."""
+    base = get_config()
+    cache = replace(base.online.cache, dir=Path("/tmp/codex-cache"))
+    tuning = replace(base.online.tuning, effort=Effort.THOROUGH)
+    supplied = replace(base, online=replace(base.online, cache=cache, tuning=tuning))
+
+    session = OnlineSession(
+        sources={"metron"}, credentials=VALID_METRON, config=supplied
+    )
+
+    cfg = session._build_config()
+    assert cfg.online.cache.dir == Path("/tmp/codex-cache")
+    assert cfg.online.tuning.effort is Effort.THOROUGH
+    # The session's own preferences still win over what it was handed.
+    assert cfg.online.lookup.sources == ("metron",)
+    assert cfg.online.lookup.enabled is True
+
+
+def test_supplied_config_skips_the_settings_read(monkeypatch) -> None:
+    """A caller with settings in hand pays no config-file or env read."""
+
+    def _fail() -> None:
+        msg = "get_config() should not be called when config= is supplied"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("comicbox.online_session.get_config", _fail)
+    session = OnlineSession(
+        sources={"metron"}, credentials=VALID_METRON, config=get_config()
+    )
+    assert session._build_config().online.lookup.sources == ("metron",)
 
 
 # --- cancellation -------------------------------------------------------------


### PR DESCRIPTION
`OnlineSession.__init__` read its base `ComicboxSettings` from `get_config()`. Every other comicbox entry point lets a caller pass settings in, but this one did not, so an embedder holding configured settings had no way to hand them over.

That mattered to codex twice. It keeps comicbox's online sqlite caches under its own `/config` volume, because the platformdirs default is thrown away when a Docker container is recreated; and `Effort` has no `OnlineSession` keyword, so an embedder wanting anything but the default had only the environment to reach it through. Both travelled as environment variables on names comicbox is free to rename.

The new `config` keyword is the settings the session layers its tagging preferences over. Passing it also skips the config-file and environment read, which is pure waste when the caller's settings are already the answer that read would find.

Codex's `comicbox-5` branch depends on this: its `session_manager.py` passes `config=COMICBOX_ONLINE_CONFIG`. It needs to land before 5.0.0 ships.

The follow-up doc this branch also adds, `tasks/codex-5-upstream-followups.md`, is the return leg of `tasks/codex-v3-handoff.md`: everything codex had to reach around while adopting 5.0. The remaining actionable items are a stacked PR.

## Verification

CI's lint/test job is skipped on a `develop` PR (it gates on `main` or a `pre-release` head), so this ran locally on macOS:

- `make fix` — no diff
- `make lint` — all checks passed, 0 errors, 0 warnings, 0 notes
- `make ty` — all checks passed
- `make test` — 2068 passed, 1 skipped, 15 warnings (warning count unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)