### PR TITLE
feat(online): key the run estimate off effort; link MetronInfo alternative-name and reprint ids

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,10 @@
     - Web urls in the Notes field are read into `urls`.
     - Online API: new `SourceStarted` event, and `rate_limit_status()` now
       covers Comic Vine as well as Metron.
+    - `OnlineSession` accepts a `config`, the settings it layers its tagging
+      preferences over. An embedder that already holds configured settings —
+      naming its own cache directory or effort — hands them over instead of
+      exporting environment variables for the settings loader to find.
 
 - Fixes
     - Two silent data losses: an XML tag carrying an attribute, like

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
       `--online --write … --rename` no longer names the file from stale data.
     - A comic that can't be read no longer ends the batch, and `comicbox` exits
       non-zero whenever any file failed.
+    - MetronInfo alternative name ids link to their series, and reprint ids to
+      the issue they reprint, instead of to pages that don't exist.
     - Many smaller repairs to credit roles, tag coverage, identifiers, urls and
       odd data that used to cost a whole comic. Metadata comicbox skips is now
       named in a warning instead of dropped silently.

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,13 +22,16 @@
       `merge_mode` instead of `mode`, and `WriteMode` is now `MergeMode`.
     - Environment variables nest with `__`, and every config key can be set that
       way: `COMICBOX_ONLINE__AUTH__METRON__KEY`. Old flat names warn.
+    - `estimate_run()` and `requests_per_comic()` take an `effort` instead of a
+      match mode, which never changed what a search costs.
 
 - Features
     - New `--merge-mode` chooses how supplied metadata merges into a comic's
       existing tags: `additive` (the default), `replace` or `update`.
     - Web urls in the Notes field are read into `urls`.
-    - Online API: new `SourceStarted` event, and `rate_limit_status()` now
-      covers Comic Vine as well as Metron.
+    - Online API: new `SourceStarted` event, `Effort` is exported alongside
+      `MatchMode`, and `rate_limit_status()` now covers Comic Vine as well as
+      Metron.
     - `OnlineSession` accepts a `config`, the settings it layers its tagging
       preferences over. An embedder that already holds configured settings —
       naming its own cache directory or effort — hands them over instead of

--- a/comicbox/formats/base/online/series_filter.py
+++ b/comicbox/formats/base/online/series_filter.py
@@ -33,9 +33,9 @@ matcher's `s_series`; the matcher gets to be permissive because it sees
 the full candidate. The pre-filter has to decide before any API call
 goes out.
 
-Driven by the `Effort` resolved per-source. See
-`tasks/online-tagging/06-api-budget-spec.md` for the threshold rationale
-(Phase B picks the real numbers; Phase A ships with the lever dormant).
+Driven by the `Effort` resolved per-source. The thresholds below are
+calibrated against the fixture set, not placeholders; each carries the
+measurement that chose it.
 """
 
 from __future__ import annotations

--- a/comicbox/formats/comicbox/schema/identifiers.py
+++ b/comicbox/formats/comicbox/schema/identifiers.py
@@ -20,7 +20,9 @@ class IdentifierSchema(BaseSubSchema):  # Comet, CIX, CT, Metron
     differs from the type implied by where the identifier sits — every id
     under ``series`` is a series id, so it says nothing. A hand-tagged key
     like ``series:178012`` written at the issue level is the case that needs
-    it, since the type decides which url the key builds.
+    it, since the type decides which url the key builds. So is a container
+    that is a name rather than the thing named: a series alternative name
+    implies nothing about its own id, so that id states ``series``.
     """
 
     key = StringField()

--- a/comicbox/formats/comicvine_api/online_source.py
+++ b/comicbox/formats/comicvine_api/online_source.py
@@ -964,10 +964,10 @@ class ComicVineOnlineSource(OnlineSource):
             query=f"series={profile.series!r}",
         )
 
-        # Pre-call filter threshold from the resolved effort. At the
-        # `balanced` default this resolves to 0.0 (filter is a no-op), so
-        # Phase A behaviour is identical to today's. Phase B calibration
-        # picks the real values for `minimal` (currently 0.7 placeholder).
+        # Pre-call filter threshold from the resolved effort. The values
+        # are calibrated and live in `series_filter.threshold_for`: at the
+        # `balanced` default the filter drops obvious mismatches before
+        # they cost a call, and `thorough` turns it off.
         name_threshold = self._effort_name_threshold()
 
         budget = self._new_search_budget()

--- a/comicbox/formats/metron_info/transform/identifier_attribute.py
+++ b/comicbox/formats/metron_info/transform/identifier_attribute.py
@@ -6,16 +6,30 @@ from loguru import logger
 
 from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY
 from comicbox.formats.metron_info.transform.const import DEFAULT_ID_SOURCE_STR
-from comicbox.identifiers import ID_KEY_KEY
+from comicbox.identifiers import DEFAULT_ID_TYPE, ID_KEY_KEY
 from comicbox.identifiers.identifiers import create_identifier
 
 ID_ATTRIBUTE = "@id"
 
 
 def metron_id_attribute_to_cb(
-    id_type: str, metron_obj: Mapping | str, comicbox_obj: dict, id_source_str: str
+    id_type: str,
+    metron_obj: Mapping | str,
+    comicbox_obj: dict,
+    id_source_str: str,
+    *,
+    implied: bool = True,
 ) -> None:
-    """Create a metron tag identifier from a metron identifier attribute."""
+    """
+    Create a metron tag identifier from a metron identifier attribute.
+
+    The attribute names no type of its own, so ``id_type`` is the type the
+    tag it hangs on means. Usually that tag IS the thing the id names, and
+    the type is left implied. ``implied=False`` is for a tag that is a name
+    rather than the thing: an AlternativeName is not a series, so nothing
+    about where its id sits says the id names one, and the type has to be
+    stated the way a top level id states a type that isn't an issue.
+    """
     try:
         if not (
             isinstance(metron_obj, Mapping) and (id_key := metron_obj.get(ID_ATTRIBUTE))
@@ -26,8 +40,8 @@ def metron_id_attribute_to_cb(
             # Mapping.get is untyped here; metron @id attributes arrive as
             # str from xmltodict but int from API dicts — coerce.
             str(id_key),
-            # The attribute names no type of its own; the tag it hangs on does.
-            positional_id_type=id_type,
+            id_type=id_type,
+            positional_id_type=id_type if implied else DEFAULT_ID_TYPE,
             default_id_source_str=DEFAULT_ID_SOURCE_STR,
         )
         comicbox_obj[IDENTIFIERS_KEY] = {id_source_str: comicbox_identifier}

--- a/comicbox/formats/metron_info/transform/reprints.py
+++ b/comicbox/formats/metron_info/transform/reprints.py
@@ -46,8 +46,10 @@ def _reprint_to_cb(
     comicbox_reprint: dict[str, Any] = {}
     if name := get_cdata(metron_reprint):
         comicbox_reprint[NAME_KEY] = str(name)
+        # A Reprint's id is the reprinted issue's metron id, which is what
+        # the online api transform files it as too.
         metron_id_attribute_to_cb(
-            "reprint", metron_reprint, comicbox_reprint, primary_id_source
+            "issue", metron_reprint, comicbox_reprint, primary_id_source
         )
     return comicbox_reprint
 
@@ -111,8 +113,14 @@ def _alternative_name_to_cb(
         return comicbox_alternative_name
     if lang := metron_alternative_name.get(LANG_ATTR):
         comicbox_alternative_name[LANGUAGE_KEY] = lang
+    # An alternative name is a name, not a series, so its id says which
+    # series it names instead of leaving the type to its position.
     metron_id_attribute_to_cb(
-        "series", metron_alternative_name, comicbox_alternative_name, primary_id_source
+        "series",
+        metron_alternative_name,
+        comicbox_alternative_name,
+        primary_id_source,
+        implied=False,
     )
     return comicbox_alternative_name
 

--- a/comicbox/online_estimate.py
+++ b/comicbox/online_estimate.py
@@ -11,11 +11,15 @@ The model is deliberately simple. Per comic, each source costs a
 characteristic number of API requests:
 
 - Metron resolves an issue with a single ``issues_list`` search plus the
-  final issue fetch — a flat count that match mode does not change (see
-  v4.0.5 / PR #143; no series-discovery step since series ids land
-  directly on issue-list results).
-- Comic Vine's fuzzy volume→issue path does more verification the tighter
-  the match mode, so its request count scales with mode.
+  final issue fetch — a flat count (see v4.0.5 / PR #143; no
+  series-discovery step since series ids land directly on issue-list
+  results). Metron does not fan out, so effort does not move it.
+- Comic Vine discovers volumes, asks each surviving candidate for its
+  issues, then fetches the issue it accepts. Only the middle step varies:
+  ``Effort`` decides how many candidates are worth a call.
+
+Match mode is not an input. It decides how a verdict is applied, never how
+many requests a search spends.
 
 Under first-match-wins a comic stops at the first source that answers, so
 the run is billed the costliest single selected source; merging all sources
@@ -27,10 +31,17 @@ per-minute cap binds a bounded run directly. Comic Vine limits **per
 resource pool** — 200/hour for each endpoint (simyan keeps a separate
 bucket per endpoint, mirroring CV's documented "200 requests per resource
 per hour") — so a run is bound by its busiest single pool, not by the
-request total: discovery and the final fetches land in different pools
+request total: discovery and the final fetches each land in their own pool
 while the per-volume issue lookups stack in one. first-match-wins means a
 comic isn't done until the binding source answers, so the slowest source
 sets the pace; merging pays every source per comic, so their paces sum.
+
+The projection prices a cold search for every comic. A real run batches by
+series, where one search answers for the whole series and the issues after
+it cost about one issue-list call each, so a library finishes ahead of this
+number. Comic Vine also spends about 2x what these counts say, from simyan
+paginating a short page; that correction waits on the upstream fix (see
+``tasks/simyan-4-plan.md``).
 """
 
 from __future__ import annotations
@@ -39,7 +50,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Final
 
-from comicbox.config.online.settings import MatchMode
+from comicbox.config.online.settings import Effort
 from comicbox.formats.base.online.rate_limits import (
     COMICVINE_DEFAULT_PER_HOUR,
     METRON_DEFAULT_PER_MINUTE,
@@ -49,8 +60,9 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 __all__ = (
-    "COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE",
-    "COMICVINE_REQUESTS_BY_MODE",
+    "COMICVINE_DISCOVERY_REQUESTS",
+    "COMICVINE_FETCH_REQUESTS",
+    "COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT",
     "DEFAULT_RATE_PER_MINUTE",
     "DEFAULT_REQUESTS_PER_COMIC",
     "METRON_REQUESTS_PER_COMIC",
@@ -63,8 +75,8 @@ __all__ = (
 # Sustained requests/minute used to pace a bounded run. Metron's per-minute
 # cap binds directly. Comic Vine's entry is the 200/hour cap of ONE resource
 # pool spread over the minute (rather than its 1/second burst) — see
-# ``COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE`` for how a run draws on it.
-# Derived from ``rate_limits`` so both move together.
+# ``_seconds_per_comic`` for how a run draws on it. Derived from
+# ``rate_limits`` so both move together.
 SOURCE_RATE_PER_MINUTE: Final = MappingProxyType(
     {
         "metron": METRON_DEFAULT_PER_MINUTE,
@@ -72,34 +84,36 @@ SOURCE_RATE_PER_MINUTE: Final = MappingProxyType(
     }
 )
 
-# API requests one comic costs, per source. Metron's search + issue fetch
-# is a flat count match mode does not change; Comic Vine's scales with
-# match mode.
+# API requests one comic costs against Metron: the search and the issue
+# fetch. Metron has no fan-out to throttle, so effort does not move it.
 METRON_REQUESTS_PER_COMIC: Final[int] = 2
-COMICVINE_REQUESTS_BY_MODE: Final = MappingProxyType(
+
+# Comic Vine's cold search, in three parts. Discovery is one
+# ``search_volumes``, plus one narrowed ``list_volumes`` when the comic
+# names a year. The issue it accepts then costs a ``get_issue`` and a
+# ``get_volume``. Each of those four lands in its own resource pool.
+COMICVINE_DISCOVERY_REQUESTS: Final[int] = 2
+COMICVINE_FETCH_REQUESTS: Final[int] = 2
+
+# The middle part, and the only one effort moves: how many surviving volume
+# candidates are worth an issue-list call. They all stack in one pool, which
+# makes this number the pace of a Comic Vine run as well as the bulk of its
+# cost. Anchored to a measured cold search — mean 3.48 ``list_issues`` calls
+# with the name filter off — scaled by the call reductions ``series_filter``
+# records for each threshold (balanced -18%, minimal -60.5%) and rounded.
+# Thorough rounds up so the unbounded search stays above balanced's filtered
+# one. The measurement is in
+# ``tasks/online-tagging/calibration-notes/2026-09-08-estimator-cold-search-cost.md``.
+COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT: Final = MappingProxyType(
     {
-        MatchMode.EAGER.value: 2,
-        MatchMode.AUTO.value: 3,
-        MatchMode.CAREFUL.value: 5,
+        Effort.MINIMAL.value: 1,
+        Effort.BALANCED.value: 3,
+        Effort.THOROUGH.value: 4,
     }
 )
 
-# How many of one comic's Comic Vine requests land in its BUSIEST resource
-# pool. CV rate-limits per resource, and simyan enforces that client-side
-# with a separate bucket per endpoint (search / volumes / issues / get_issue /
-# get_volume), so wall-clock is bound by the fullest single pool rather than
-# the request total. Discovery and the final issue/volume fetches each land
-# in their own pool; the per-volume ``issues`` lookups stack in one, and
-# careful mode verifies more volumes there.
-COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE: Final = MappingProxyType(
-    {
-        MatchMode.EAGER.value: 1,
-        MatchMode.AUTO.value: 1,
-        MatchMode.CAREFUL.value: 2,
-    }
-)
-
-# Fallbacks for an unrecognized source / match mode.
+# Fallbacks for an unrecognized source. An unrecognized effort is priced as
+# ``balanced``, the shipped default.
 DEFAULT_REQUESTS_PER_COMIC: Final[int] = 3
 DEFAULT_RATE_PER_MINUTE: Final[int] = 10
 
@@ -114,56 +128,81 @@ class RunEstimate:
     """Projected wall-clock duration in seconds."""
 
 
-def requests_per_comic(source: str, mode: str) -> int:
-    """Return the API requests one comic costs against ``source`` under ``mode``."""
+def _comicvine_issue_list_requests(effort: str) -> int:
+    """Return the issue-list calls one Comic Vine search spends at ``effort``."""
+    return COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT.get(
+        effort, COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT[Effort.BALANCED.value]
+    )
+
+
+def requests_per_comic(source: str, effort: str = Effort.BALANCED.value) -> int:
+    """
+    Return the API requests one comic costs against ``source`` at ``effort``.
+
+    ``effort`` is an :class:`~comicbox.config.online.settings.Effort` or its
+    value. Resolve it for the source it prices —
+    ``resolve_effort(settings.online, "comicvine")`` — because a per-source
+    override beats the global setting.
+    """
     if source == "metron":
         return METRON_REQUESTS_PER_COMIC
     if source == "comicvine":
-        return COMICVINE_REQUESTS_BY_MODE.get(mode, DEFAULT_REQUESTS_PER_COMIC)
+        return (
+            COMICVINE_DISCOVERY_REQUESTS
+            + _comicvine_issue_list_requests(effort)
+            + COMICVINE_FETCH_REQUESTS
+        )
     return DEFAULT_REQUESTS_PER_COMIC
 
 
-def _seconds_per_comic(source: str, mode: str) -> float:
+def _seconds_per_comic(source: str, effort: str) -> float:
     """
     Return the seconds one comic costs against ``source`` at its sustained pace.
 
     Comic Vine paces per resource pool, so its wall-clock cost is the busiest
     pool's share of the comic's requests over that pool's rate — not the
-    request total. Metron's per-minute cap paces the total directly.
+    request total. The per-volume issue lookups are that pool; everything
+    else a comic spends sits alone in its own. Metron's per-minute cap paces
+    the total directly.
     """
     if source == "comicvine":
-        pool_requests = COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE.get(mode, 1)
+        pool_requests = _comicvine_issue_list_requests(effort)
         return 60.0 * pool_requests / SOURCE_RATE_PER_MINUTE[source]
     rate = SOURCE_RATE_PER_MINUTE.get(source, DEFAULT_RATE_PER_MINUTE)
-    return 60.0 * requests_per_comic(source, mode) / rate
+    return 60.0 * requests_per_comic(source, effort) / rate
 
 
 def estimate_run(
     comics: int,
-    mode: str,
     sources: Sequence[str],
     *,
+    effort: str = Effort.BALANCED.value,
     merge_all_sources: bool = False,
 ) -> RunEstimate:
     """
     Project the request count and wall-clock seconds for a batch online-tag run.
 
-    ``comics`` is how many comics remain to look up, ``mode`` a
-    :class:`~comicbox.config.settings.MatchMode` value (``"auto"`` etc.), and
-    ``sources`` the enabled source names in priority order. ``merge_all_sources``
-    mirrors ``first_wins=False``: every source is queried per comic and their
+    ``comics`` is how many comics remain to look up and ``sources`` the
+    enabled source names in priority order. ``effort`` is an
+    :class:`~comicbox.config.online.settings.Effort` value (``"balanced"``
+    etc.), resolved for the source it prices. ``merge_all_sources`` mirrors
+    ``first_wins=False``: every source is queried per comic and their
     per-comic costs summed, instead of stopping at the first match.
+
+    The projection assumes the effort it is handed. A CLI run can
+    auto-engage a lower Comic Vine effort for a large unattended batch,
+    which this cannot see.
     """
     sources = tuple(sources)
     if comics <= 0 or not sources:
         return RunEstimate(requests=0, seconds=0.0)
-    per_source = [requests_per_comic(source, mode) for source in sources]
+    per_source = [requests_per_comic(source, effort) for source in sources]
     # Merge sums every source's per-comic cost; first-match-wins bills the
     # costliest single source the run might hit.
     per_comic = sum(per_source) if merge_all_sources else max(per_source)
     requests = comics * per_comic
     # Merge pays every source per comic; first-match-wins isn't done until
     # the binding (slowest) source answers.
-    paces = [_seconds_per_comic(source, mode) for source in sources]
+    paces = [_seconds_per_comic(source, effort) for source in sources]
     seconds_per_comic = sum(paces) if merge_all_sources else max(paces)
     return RunEstimate(requests=requests, seconds=comics * seconds_per_comic)

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -274,6 +274,14 @@ class OnlineSession:
     ``ids`` pins an issue id per source for a single-comic session: a
     pinned source fetches that id directly while the unpinned sources
     search, so one run can mix id retrieval and search and merge both.
+
+    ``config`` supplies the settings the session layers its tagging
+    preferences over. An embedder that already holds configured
+    ``ComicboxSettings`` — naming its own cache directory or effort,
+    neither of which an ``OnlineSession`` keyword covers — passes them
+    here instead of exporting environment variables for the settings
+    loader to find. Omitted, the session reads config files and the
+    environment itself.
     """
 
     def __init__(  # noqa: PLR0913
@@ -290,6 +298,7 @@ class OnlineSession:
         first_wins: bool = True,
         defer_prompts: bool = False,
         series_batching: bool = True,
+        config: ComicboxSettings | None = None,
     ) -> None:
         """Validate inputs, build per-session state. See class docstring."""
         # Order is run priority: the first source runs first and, under
@@ -316,8 +325,12 @@ class OnlineSession:
         # Read config files / env exactly once per session. _build_config
         # used to call get_config() per file — wasted disk I/O on big
         # batches plus a behavioral surprise where a config-file edit
-        # mid-batch changed settings for the remaining files.
-        self._base_settings: ComicboxSettings = get_config()
+        # mid-batch changed settings for the remaining files. A caller
+        # that passes its own settings skips the read entirely: they are
+        # already the answer this would have gone looking for.
+        self._base_settings: ComicboxSettings = (
+            config if config is not None else get_config()
+        )
         # Nothing in the settings tree varies per file: the mutable
         # policy lives in _state and each box overlays it for itself.
         self._settings: ComicboxSettings = self._build_config()

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, runtime_che
 from comicbox.box import Comicbox
 from comicbox.config import get_config
 from comicbox.config.online.settings import (
+    Effort,
     MatchMode,
     OnlineAuthSettings,
     OnlineLookupSettings,
@@ -67,6 +68,7 @@ __all__ = (
     "SOURCE_RATE_PER_MINUTE",
     "BatchedPromptHandler",
     "DeferredPrompt",
+    "Effort",
     "MatchMode",
     "OnlineConfigurationError",
     "OnlineCredentials",

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -74,6 +74,10 @@ romanizations, variant spellings — and map to `series.alternative_names`. A
 reprint's `name` is stored as the file wrote it; the series, volume and issue
 read out of that name are a convenience.
 
+A Reprint's `id` attribute is the reprinted issue's id. An AlternativeName's
+`id` is a series id, and comicbox records `id_type: series` on it, because an
+alternative name is a name rather than a series and implies no type of its own.
+
 ### ComicBookInfo Schema v1.0 (Comic Book Lover)
 
 The schema used by the defunct

--- a/tasks/codex-5-upstream-followups.md
+++ b/tasks/codex-5-upstream-followups.md
@@ -1,0 +1,161 @@
+# Comicbox 5.0 — Upstream Follow-ups Found While Adopting It in Codex
+
+**Audience:** an agent working in [comicbox](https://github.com/ajslater/comicbox).
+This document is self-contained: it does not assume you saw the codex
+conversation or PRs. It is the return leg of `tasks/codex-v3-handoff.md`.
+
+**Status:** one item is already implemented on the branch
+`online-session-config-hook` and needs merging before the 5.0 release. The rest
+are observations codex worked around; each says what codex did instead, so
+nothing here is blocking.
+
+## Context
+
+Codex was migrated to comicbox 5.0.0 (schema v3.0) over three commits on its
+`comicbox-5` branch. The migration is straightforward and the v3 design holds
+up well in practice. What follows is only the friction: places where codex had
+to reach around an API, accept a lossy round trip, or duplicate something
+comicbox already knows.
+
+The codex side is on branch `comicbox-5`, pinned to `comicbox[pdf]~=5.0.0`.
+
+---
+
+## 1. `OnlineSession` could not be given settings (DONE, needs merge)
+
+**Branch:** `online-session-config-hook`, commit `33a369a`.
+
+`OnlineSession.__init__` read its base `ComicboxSettings` from `get_config()`
+(`comicbox/online_session.py:320`). Every other comicbox entry point lets a
+caller pass settings in, but this one did not, so an embedder holding
+configured settings had no way to hand them over.
+
+That mattered to codex twice:
+
+- **Cache directory.** Codex keeps comicbox's online sqlite caches under its
+  own `/config` volume, because comicbox's platformdirs default is thrown away
+  when a Docker container is recreated. It travelled as
+  `COMICBOX_ONLINE_CACHE_DIR`, which 5.0 stops reading — correctly, since env
+  vars now nest with `__`. Codex could have switched to
+  `COMICBOX_ONLINE__CACHE__DIR`, but that puts the setting back on a name
+  comicbox is free to rename again.
+- **Effort.** `Effort` has no `OnlineSession` keyword, so an embedder wanting
+  anything but the default has only the environment to reach it through.
+
+The fix adds a `config` keyword. Passing it also skips the config-file and
+environment read, which is pure waste when the caller's settings are already
+the answer that read would find. Tests are in
+`tests/unit/test_online_session.py`; `NEWS.md`'s 5.0.0 Features section has an
+entry.
+
+**Action:** merge before releasing 5.0.0. Codex's `comicbox-5` branch depends
+on it — `session_manager.py` passes `config=COMICBOX_ONLINE_CONFIG`.
+
+---
+
+## 2. The run estimator still models unbounded Comic Vine fan-out
+
+`comicbox/online_estimate.py:117` `requests_per_comic()` keys Comic Vine's cost
+off `MatchMode` alone. Since 5.0 bounds Comic Vine's per-candidate fan-out by
+default and `Effort.THOROUGH` restores the unbounded search, the estimate no
+longer describes what a default run actually costs.
+
+Codex surfaces this estimate directly: the online-tag launcher shows a
+projected duration before a scan and a live countdown during it
+(`codex/librarian/onlinetag/estimate.py`, `codex/choices/onlinetag.py`). Under
+the new default those numbers read high, and under `thorough` they read low.
+
+**Suggested shape:** `requests_per_comic(source, mode, effort)` and
+`estimate_run(..., effort=...)`, with `COMICVINE_REQUESTS_BY_MODE` becoming a
+mode-by-effort table. Codex would pass the admin's configured effort, which it
+already threads into the session.
+
+---
+
+## 3. The credit primary flag reaches no format codex writes
+
+`credits.<person>.roles.<role>.primary` persists to ComicBookInfo only
+(`comicbox/formats/comicbox/schema/__init__.py:150` marks it "CBI ONLY"; the
+only writer is `comicbox/formats/comic_book_info/transform/credits.py:145`).
+MetronInfo v1.1's schema has `primary` attributes on `URL` and `ID` but none on
+a credit, and ComicInfo has no notion of one.
+
+Codex writes ComicInfo and MetronInfo. It reads the flag, stores it on the
+person-and-role pairing, and shows primaries first in the metadata panel — but
+it deliberately ships **no editor control**, because a control whose value
+could never be written back would be a lie. The flag survives only as long as
+nothing rewrites the file.
+
+**Not obviously actionable** — it is a limitation of the format specs, not of
+comicbox. Worth knowing that the field is, in practice, read-only for the two
+formats most tools use. If MetronInfo ever gains the attribute, codex's field
+support map derives itself from the transforms and the control would light up
+on its own.
+
+---
+
+## 4. Metron publishes no URL for several id types
+
+`IDENTIFIER_PARTS_MAP[IdSources.METRON]`
+(`comicbox/identifiers/identifiers.py:238`) notes that genre, location,
+reprint, role, story and tag have no public web page, so `unparse_url` returns
+`""` for them.
+
+That is correct, and codex now derives its `Identifier.url` column through
+`get_identifier_url` and stores the empty string. Two observations:
+
+- An id on one of a series' `alternative_names` is a **series** id, but where
+  it sits no longer implies that. Codex has to inject `id_type: series` when it
+  folds those names in among its reprints, or the derived link is empty. If
+  comicbox stated the type on those identifiers itself — the way it does for a
+  top-level id that isn't an issue — the positional rule would carry through
+  and no consumer would need to know this.
+- `reprint` as an id type can never build a Metron URL, so any identifier
+  comicbox files under it is linkless by construction.
+
+---
+
+## 5. `MergeMode` note — no action, just confirmation
+
+The `MergeMode` docstring (`comicbox/config/settings.py:81`) is the clearest
+statement of the tradeoff and it is accurate: `update` replaces top-level keys
+wholesale and drops siblings, while `replace` recurses into dicts and replaces
+only the leaves.
+
+Codex writes with `update`, so a patch that carried only
+`series.alternative_names` would drop the series' `name`. Codex compensates by
+sending the whole series object it knows about. Switching codex to `replace`
+for these writes would be the cleaner fix and is a codex-side decision;
+recorded here only so the next person does not read the compensation as a
+comicbox bug.
+
+---
+
+## Things that worked well, for what it's worth
+
+- **The new skip warning earned its keep immediately.** Two codex test fixtures
+  had been malformed for as long as they had existed — a null team value that
+  voided the entire `teams` field, and a credit role's identifier keyed by
+  `key` instead of by its source. 4.8.7 dropped both as silently as an absent
+  tag. 5.0 named them, and both were repaired.
+- **Deriving links from keys rather than storing them** removed a whole class
+  of disagreement. Codex kept its url column and now fills it through
+  `get_identifier_url`, which also fixed a latent mismatch: the column stores
+  `""` for a linkless type, and the aggregate now carries `""` too rather than
+  `None`.
+- **`id_type` on a top-level identifier** let codex file a stated series or
+  volume id correctly instead of assuming every comic-level id was an issue id.
+- **Splitting manga from reading direction** was clean to adopt. The two facts
+  land in two columns and two editor fields, and the format support map derives
+  which format can store which without anything hand-written.
+
+## Where the codex work lives
+
+| Branch | Commit | What |
+|---|---|---|
+| `comicbox-5` | `1f1c593` | Moved and renamed APIs, derived identifier urls, v3 fixtures |
+| `comicbox-5` | `07188d9` | Identifier type vocabulary bridge, reprint name fallback |
+| `comicbox-5` | `0db3cf0` | manga, manga_volume, urls, Credit.primary, Reprint.alternative_name |
+
+Remaining codex phases: online extras (effort setting, Comic Vine rate-limit
+display), the one-time re-read migration, and docs.

--- a/tasks/codex-5-upstream-followups.md
+++ b/tasks/codex-5-upstream-followups.md
@@ -1,74 +1,116 @@
 # Comicbox 5.0 — Upstream Follow-ups Found While Adopting It in Codex
 
-**Audience:** an agent working in [comicbox](https://github.com/ajslater/comicbox).
-This document is self-contained: it does not assume you saw the codex
-conversation or PRs. It is the return leg of `tasks/codex-v3-handoff.md`.
+**Audience:** an agent working in
+[comicbox](https://github.com/ajslater/comicbox). This document is
+self-contained: it does not assume you saw the codex conversation or PRs. It is
+the return leg of `tasks/codex-v3-handoff.md`.
 
-**Status:** one item is already implemented on the branch
-`online-session-config-hook` and needs merging before the 5.0 release. The rest
-are observations codex worked around; each says what codex did instead, so
-nothing here is blocking.
+**Status:** items 1, 2 and 4 are done. Item 1 is
+[PR #203](https://github.com/ajslater/comicbox/pull/203); items 2 and 4 are
+[PR #204](https://github.com/ajslater/comicbox/pull/204), stacked on it. Items 3
+and 5 need no comicbox change. Sections below record what shipped and what codex
+has to change to match; the checklist at the end is codex's.
+
+Two of the three fixes change comicbox's public surface, so codex's `comicbox-5`
+branch does not build against them unchanged. Nothing here is urgent — none of
+it is a regression — but all of it lands before 5.0.0 ships.
 
 ## Context
 
 Codex was migrated to comicbox 5.0.0 (schema v3.0) over three commits on its
-`comicbox-5` branch. The migration is straightforward and the v3 design holds
-up well in practice. What follows is only the friction: places where codex had
-to reach around an API, accept a lossy round trip, or duplicate something
-comicbox already knows.
+`comicbox-5` branch. The migration is straightforward and the v3 design holds up
+well in practice. What follows is only the friction: places where codex had to
+reach around an API, accept a lossy round trip, or duplicate something comicbox
+already knows.
 
 The codex side is on branch `comicbox-5`, pinned to `comicbox[pdf]~=5.0.0`.
 
 ---
 
-## 1. `OnlineSession` could not be given settings (DONE, needs merge)
+## 1. `OnlineSession` could not be given settings (DONE, PR #203)
 
 **Branch:** `online-session-config-hook`, commit `33a369a`.
 
 `OnlineSession.__init__` read its base `ComicboxSettings` from `get_config()`
-(`comicbox/online_session.py:320`). Every other comicbox entry point lets a
-caller pass settings in, but this one did not, so an embedder holding
-configured settings had no way to hand them over.
+(now the `config` keyword at `comicbox/online_session.py:302` and the read it
+skips at `:333-335`). Every other comicbox entry point lets a caller pass
+settings in, but this one did not, so an embedder holding configured settings
+had no way to hand them over.
 
 That mattered to codex twice:
 
-- **Cache directory.** Codex keeps comicbox's online sqlite caches under its
-  own `/config` volume, because comicbox's platformdirs default is thrown away
-  when a Docker container is recreated. It travelled as
-  `COMICBOX_ONLINE_CACHE_DIR`, which 5.0 stops reading — correctly, since env
-  vars now nest with `__`. Codex could have switched to
-  `COMICBOX_ONLINE__CACHE__DIR`, but that puts the setting back on a name
-  comicbox is free to rename again.
+- **Cache directory.** Codex keeps comicbox's online sqlite caches under its own
+  `/config` volume, because comicbox's platformdirs default is thrown away when
+  a Docker container is recreated. It travelled as `COMICBOX_ONLINE_CACHE_DIR`,
+  which 5.0 stops reading — correctly, since env vars now nest with `__`. Codex
+  could have switched to `COMICBOX_ONLINE__CACHE__DIR`, but that puts the
+  setting back on a name comicbox is free to rename again.
 - **Effort.** `Effort` has no `OnlineSession` keyword, so an embedder wanting
   anything but the default has only the environment to reach it through.
 
 The fix adds a `config` keyword. Passing it also skips the config-file and
-environment read, which is pure waste when the caller's settings are already
-the answer that read would find. Tests are in
-`tests/unit/test_online_session.py`; `NEWS.md`'s 5.0.0 Features section has an
-entry.
+environment read, which is pure waste when the caller's settings are already the
+answer that read would find. Tests are in `tests/unit/test_online_session.py`;
+`NEWS.md`'s 5.0.0 Features section has an entry.
 
-**Action:** merge before releasing 5.0.0. Codex's `comicbox-5` branch depends
-on it — `session_manager.py` passes `config=COMICBOX_ONLINE_CONFIG`.
+**Action:** none for codex. `session_manager.py`'s
+`config=COMICBOX_ONLINE_CONFIG` works as written.
 
 ---
 
-## 2. The run estimator still models unbounded Comic Vine fan-out
+## 2. The run estimator still models unbounded Comic Vine fan-out (DONE)
 
-`comicbox/online_estimate.py:117` `requests_per_comic()` keys Comic Vine's cost
-off `MatchMode` alone. Since 5.0 bounds Comic Vine's per-candidate fan-out by
-default and `Effort.THOROUGH` restores the unbounded search, the estimate no
-longer describes what a default run actually costs.
+Right, and worse than reported: the estimate was keyed on an axis that moves
+nothing. `MatchMode` branches only in the matcher, deciding how a verdict is
+applied — no match mode changes a single Comic Vine request. The shipped table
+`{eager 2, auto 3, careful 5}` had no recorded provenance and priced `careful`
+above `eager`, which is backwards even for the one mode-dependent cost there is
+(a declined match skips the two-call accept fetch).
 
-Codex surfaces this estimate directly: the online-tag launcher shows a
-projected duration before a scan and a live countdown during it
-(`codex/librarian/onlinetag/estimate.py`, `codex/choices/onlinetag.py`). Under
-the new default those numbers read high, and under `thorough` they read low.
+So the mode axis is gone rather than joined by a second one. `Effort` is the
+axis, and the numbers are now anchored to a measurement rather than asserted:
 
-**Suggested shape:** `requests_per_comic(source, mode, effort)` and
-`estimate_run(..., effort=...)`, with `COMICVINE_REQUESTS_BY_MODE` becoming a
-mode-by-effort table. Codex would pass the admin's configured effort, which it
-already threads into the session.
+```python
+requests_per_comic(source, effort="balanced") -> int
+estimate_run(comics, sources, *, effort="balanced", merge_all_sources=False)
+```
+
+`mode` is no longer a parameter of either. `sources` moves up to second
+positional. `effort` is keyword-only on `estimate_run` and takes an `Effort` or
+its value; an unrecognized one is priced as `balanced`.
+
+Comic Vine's cost is now built from three constants instead of a mode table:
+`COMICVINE_DISCOVERY_REQUESTS` (2), `COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT`
+(`{minimal 1, balanced 3, thorough 4}`) and `COMICVINE_FETCH_REQUESTS` (2).
+`COMICVINE_REQUESTS_BY_MODE` and `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE` are
+removed. Only the middle table paces the run: those calls all stack in one
+resource pool while everything else sits alone in its own.
+
+| Effort   | Requests/comic | Seconds/comic |
+| -------- | -------------- | ------------- |
+| minimal  | 5              | 20            |
+| balanced | 7              | 60            |
+| thorough | 8              | 80            |
+
+**The default projection triples**, from 20 s to 60 s per comic, so codex's
+countdown numbers jump. That is the estimate becoming honest about a cold
+search, not the run getting slower. Provenance is in
+`tasks/online-tagging/calibration-notes/2026-09-08-estimator-cold-search-cost.md`.
+
+Two things that estimate cannot see, both worth a word in codex's UI copy if the
+numbers ever look wrong:
+
+- **A batch beats the projection.** Every comic is priced as a cold search, but
+  a run batches by series: one search answers for a whole series and the issues
+  after it cost about one call each. This is the real reason a library finishes
+  early, and a series-aware estimate is the obvious next lever if the gap annoys
+  anyone.
+- **Per-source effort.** `resolve_effort(settings.online, "comicvine")` is the
+  value to pass. A per-source override beats the global one, and a global
+  `effort` read straight off the settings misses it.
+
+`Effort` is now exported from `comicbox.online_session` alongside `MatchMode`,
+so the estimator and the enum it takes come off the same facade.
 
 ---
 
@@ -82,36 +124,57 @@ a credit, and ComicInfo has no notion of one.
 
 Codex writes ComicInfo and MetronInfo. It reads the flag, stores it on the
 person-and-role pairing, and shows primaries first in the metadata panel — but
-it deliberately ships **no editor control**, because a control whose value
-could never be written back would be a lie. The flag survives only as long as
-nothing rewrites the file.
+it deliberately ships **no editor control**, because a control whose value could
+never be written back would be a lie. The flag survives only as long as nothing
+rewrites the file.
 
 **Not obviously actionable** — it is a limitation of the format specs, not of
 comicbox. Worth knowing that the field is, in practice, read-only for the two
 formats most tools use. If MetronInfo ever gains the attribute, codex's field
-support map derives itself from the transforms and the control would light up
-on its own.
+support map derives itself from the transforms and the control would light up on
+its own.
 
 ---
 
-## 4. Metron publishes no URL for several id types
+## 4. Metron publishes no URL for several id types (DONE)
 
-`IDENTIFIER_PARTS_MAP[IdSources.METRON]`
-(`comicbox/identifiers/identifiers.py:238`) notes that genre, location,
-reprint, role, story and tag have no public web page, so `unparse_url` returns
-`""` for them.
+Both observations were symptoms of comicbox filing ids by position when the
+position said nothing. Both are fixed; the workarounds can come out.
 
-That is correct, and codex now derives its `Identifier.url` column through
-`get_identifier_url` and stores the empty string. Two observations:
+**Alternative names now state their type.** An id on a series
+`alternative_names` entry is stored as `{"key": "3333", "id_type": "series"}`
+and `get_url_from_identifier` builds `https://metron.cloud/series/3333` from it
+with no help. The rule that made it bare was right in general and unchanged: a
+type is recorded only when it differs from the one its position implies. What
+was wrong was treating an alternative name as implying `series` — a name is not
+the thing it names, so it implies nothing, and the id states its type the way a
+top-level non-issue id does. Codex can drop its `id_type: series` injection.
 
-- An id on one of a series' `alternative_names` is a **series** id, but where
-  it sits no longer implies that. Codex has to inject `id_type: series` when it
-  folds those names in among its reprints, or the derived link is empty. If
-  comicbox stated the type on those identifiers itself — the way it does for a
-  top-level id that isn't an issue — the positional rule would carry through
-  and no consumer would need to know this.
-- `reprint` as an id type can never build a Metron URL, so any identifier
-  comicbox files under it is linkless by construction.
+Note the old behavior was worse than the empty string codex saw: a consumer that
+applied the documented default got `metron.cloud/issue/3333`, a live link to the
+wrong page.
+
+**Reprint ids are issue ids.** A MetronInfo `<Reprint id>` is the reprinted
+issue's Metron id — mokkari's `Reprint.id` is the same thing, and the online
+transform already filed it as `issue`. The MetronInfo transform called it
+`reprint`, a type no database publishes a page for, which is why it was linkless
+by construction. It now files `issue`, so `get_url_from_identifier` returns
+`https://metron.cloud/issue/4444`.
+
+The stored shape does not change (`{"key": "4444"}`; the type is implied and so
+not recorded), which means **codex sees no data change here and must change its
+bridge anyway**: whatever maps a reprint identifier to a type for the url column
+has to say `issue`, not `reprint`, or use `get_url_from_identifier`, whose
+default is `issue`.
+
+Neither change touches written XML. The MetronInfo writer reads only the key.
+
+`reprint` remains in the id-type vocabulary for hand-tagged keys that name it,
+and still builds no url. The online-API path needs nothing: it already files
+reprint ids as issues, and it attaches no identifiers to alternative names at
+all, because mokkari and Comic Vine both return those as bare strings. If
+mokkari ever returns alternative-name ids, `build_identifier` will need the same
+treatment.
 
 ---
 
@@ -124,10 +187,9 @@ only the leaves.
 
 Codex writes with `update`, so a patch that carried only
 `series.alternative_names` would drop the series' `name`. Codex compensates by
-sending the whole series object it knows about. Switching codex to `replace`
-for these writes would be the cleaner fix and is a codex-side decision;
-recorded here only so the next person does not read the compensation as a
-comicbox bug.
+sending the whole series object it knows about. Switching codex to `replace` for
+these writes would be the cleaner fix and is a codex-side decision; recorded
+here only so the next person does not read the compensation as a comicbox bug.
 
 ---
 
@@ -135,11 +197,11 @@ comicbox bug.
 
 - **The new skip warning earned its keep immediately.** Two codex test fixtures
   had been malformed for as long as they had existed — a null team value that
-  voided the entire `teams` field, and a credit role's identifier keyed by
-  `key` instead of by its source. 4.8.7 dropped both as silently as an absent
-  tag. 5.0 named them, and both were repaired.
-- **Deriving links from keys rather than storing them** removed a whole class
-  of disagreement. Codex kept its url column and now fills it through
+  voided the entire `teams` field, and a credit role's identifier keyed by `key`
+  instead of by its source. 4.8.7 dropped both as silently as an absent tag. 5.0
+  named them, and both were repaired.
+- **Deriving links from keys rather than storing them** removed a whole class of
+  disagreement. Codex kept its url column and now fills it through
   `get_identifier_url`, which also fixed a latent mismatch: the column stores
   `""` for a linkless type, and the aggregate now carries `""` too rather than
   `None`.
@@ -149,12 +211,31 @@ comicbox bug.
   land in two columns and two editor fields, and the format support map derives
   which format can store which without anything hand-written.
 
+## What codex should change
+
+- [ ] `estimate_run(comics, mode, sources, ...)` ->
+      `estimate_run(comics, sources, *, effort=...)` at
+      `codex/librarian/onlinetag/estimate.py` and `codex/choices/onlinetag.py`.
+      Same for `requests_per_comic(source, mode)` ->
+      `requests_per_comic(source, effort)`.
+- [ ] Pass `resolve_effort(settings.online, "comicvine")`, not the global
+      `tuning.effort`, so a per-source override reaches the estimate.
+- [ ] Import `Effort` from `comicbox.online_session` if you want it off the same
+      facade as `estimate_run`.
+- [ ] Drop any import of `COMICVINE_REQUESTS_BY_MODE` or
+      `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE`; they are gone.
+- [ ] Expect the default projection to triple (20 s -> 60 s per comic) and
+      decide whether the launcher's copy needs to say a batch beats it.
+- [ ] Drop the `id_type: series` injection for series `alternative_names`.
+- [ ] Map a reprint identifier to `issue` (or call `get_url_from_identifier`) so
+      reprint links stop coming back empty.
+
 ## Where the codex work lives
 
-| Branch | Commit | What |
-|---|---|---|
-| `comicbox-5` | `1f1c593` | Moved and renamed APIs, derived identifier urls, v3 fixtures |
-| `comicbox-5` | `07188d9` | Identifier type vocabulary bridge, reprint name fallback |
+| Branch       | Commit    | What                                                                |
+| ------------ | --------- | ------------------------------------------------------------------- |
+| `comicbox-5` | `1f1c593` | Moved and renamed APIs, derived identifier urls, v3 fixtures        |
+| `comicbox-5` | `07188d9` | Identifier type vocabulary bridge, reprint name fallback            |
 | `comicbox-5` | `0db3cf0` | manga, manga_volume, urls, Credit.primary, Reprint.alternative_name |
 
 Remaining codex phases: online extras (effort setting, Comic Vine rate-limit

--- a/tasks/online-tagging/calibration-notes/2026-09-08-estimator-cold-search-cost.md
+++ b/tasks/online-tagging/calibration-notes/2026-09-08-estimator-cold-search-cost.md
@@ -1,0 +1,95 @@
+# 2026-09-08 — per-comic cold-search cost for the run estimator
+
+Where `comicbox/online_estimate.py`'s Comic Vine numbers come from. No API calls
+were made for this note: it re-reads the 2026-05-17 bigmedia outcomes still on
+disk (`tests/calibration/fixtures-bigmedia.outcomes.json`, gitignored and
+per-developer, so the aggregates are recorded here instead of cited by path).
+
+## What the estimator got wrong
+
+`requests_per_comic()` keyed Comic Vine's cost off `MatchMode` alone, with a
+table of `{eager 2, auto 3, careful 5}` whose provenance no comment records.
+Match mode never reaches the search path: it branches only in `matcher.py`,
+deciding how a verdict is applied. The axis that does move Comic Vine's request
+count is `Effort`, which since 5.0 bounds the per-candidate fan-out
+(`series_filter.max_calls_for`) and, at `thorough`, turns the bound off. So the
+shipped estimate described neither a default run nor a thorough one. Codex,
+which shows the projection before a scan and mirrors it in a live countdown,
+reported the numbers reading high by default and low under `thorough`.
+
+## The measurement
+
+494 outcome records, 247 of them Comic Vine, one per fixture, each carrying the
+per-endpoint `api_call_counts` delta the harness snapshots around a search. The
+run predates the name pre-filter (`series_filter.py`, `39dd54c`) and the bounded
+fan-out (`98a548e`, PR #191), so it measures an unfiltered, unbounded search:
+the `thorough` shape.
+
+| Endpoint         | Pool    | Mean | Median | p90 | Max | Present in |
+| ---------------- | ------- | ---- | ------ | --- | --- | ---------- |
+| `search_volumes` | search  | 1.00 | 1      | 1   | 1   | 247/247    |
+| `filter_volumes` | volumes | 1.00 | 1      | 1   | 1   | 247/247    |
+| `list_issues`    | issues  | 3.48 | 2      | 7   | 16  | 246/247    |
+
+Totals per fixture: mean 5.47, median 4, p90 9, max 18.
+
+The harness stops at the search, so the two accept-time calls (`get_issue` +
+`get_volume`, `online_source.get()`) are not in the table. They are one request
+each and land in their own pools.
+
+## What the constants say
+
+Discovery is a flat 2 (`search_volumes`, plus the year-narrowed `list_volumes`
+when the comic names a year — the fixtures all did). The accept fetch is a
+flat 2. Only the issue-list fan-out varies, and it is also the only part that
+stacks in one pool, so it sets both the bulk of the cost and the pace.
+
+Scaling the measured 3.48 by the call reductions `series_filter`'s threshold
+comments record for each effort:
+
+| Effort   | Filter effect        | Scaled | Constant |
+| -------- | -------------------- | ------ | -------- |
+| minimal  | -60.5% (0.7 cutoff)  | 1.37   | 1        |
+| balanced | -18% (0.4 cutoff)    | 2.85   | 3        |
+| thorough | none (0.0, measured) | 3.48   | 4        |
+
+`thorough` rounds up rather than to the nearest integer: rounding to 3 would tie
+it with `balanced` and reproduce the "thorough reads low" complaint the change
+exists to fix. Its true tail is much longer than 4 — the p90 is 7 and the max
+16, and with the fan-out unbounded the ceiling is the discovery cap of 20
+volumes times a year-window retry each. The estimate is a projection an operator
+reads before a run, not a worst case.
+
+Per comic that gives `2 + n + 2` requests and `60 * n / 3` seconds (Comic Vine's
+200/hour pool cap spread over the minute):
+
+| Effort   | Requests | Seconds |
+| -------- | -------- | ------- |
+| minimal  | 5        | 20      |
+| balanced | 7        | 60      |
+| thorough | 8        | 80      |
+
+The default projection therefore rises from 20 s to 60 s per comic.
+
+## Two known under-counts, both still open
+
+- **simyan pagination.** `Comicvine._offset` loops until it gets an empty page,
+  so every fan-out `list_issues` spends two of the 200/hour `issues` budget
+  rather than one. `tasks/simyan-4-plan.md` documents this and defers the
+  correction to the upstream fix, on the grounds that doubling the numbers to
+  describe a bug being fixed elsewhere makes them wrong again as soon as the fix
+  lands. That decision stands; the constants above are therefore a floor for
+  wall clock.
+- **Metron.** `_record_api_call` counts one call where mokkari may follow `next`
+  pages inside it. The production filters keep results under a page, so the flat
+  2 holds in practice.
+
+## What a calibration run should settle
+
+- The post-#191 fan-out at each effort, measured rather than scaled. The -18%
+  and -60.5% figures come from the Phase B experiment whose raw data is not in
+  the tree; this note scales them rather than re-deriving them.
+- Whether `balanced` at 3 is right once the series-batch path is included. A
+  library run pays a full search once per series and about one issue-list call
+  per issue after that, so the per-comic average across a real batch is well
+  under the cold-search number this estimate uses.

--- a/tasks/simyan-4-plan.md
+++ b/tasks/simyan-4-plan.md
@@ -189,12 +189,16 @@ stays open until a tag ships.
 - [ ] When it ships: `simyan>=4.1.0,<5` (or whatever the tag is), `uv lock`,
       NEWS (Dev): "Require simyan ≥ 4.1.0."
 - [ ] Re-run the fake-transport probe to confirm one request per short page.
-- [ ] Decide then whether to re-derive `COMICVINE_REQUESTS_BY_MODE` and
-      `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE` in `comicbox/online_estimate.py`
-      with the 2× list cost. Deliberately not done now: those numbers are a
-      projection shown to an operator before a run, and doubling them to
-      describe a bug we are fixing upstream would make them wrong again as soon
-      as the floor bumps. Revisit only if comicbox 5.0.0 ships first.
+- [ ] Decide then whether to re-derive `COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT`
+      in `comicbox/online_estimate.py` with the 2× list cost. (It replaced
+      `COMICVINE_REQUESTS_BY_MODE` and
+      `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE`, and its values were re-anchored
+      to a measured cold search — see
+      `tasks/online-tagging/calibration-notes/2026-09-08-estimator-cold-search-cost.md`
+      — which does not settle this question.) Deliberately not done now: those
+      numbers are a projection shown to an operator before a run, and doubling
+      them to describe a bug we are fixing upstream would make them wrong again
+      as soon as the floor bumps. Revisit only if comicbox 5.0.0 ships first.
 - [ ] No interim client-side workaround: shrinking `_MAX_VOLUMES_PER_SEARCH` to
       10 would save the second `/search/` page but changes calibrated recall,
       and nothing else can stop a short page early.

--- a/tests/unit/test_metron_id_attribute_fallback.py
+++ b/tests/unit/test_metron_id_attribute_fallback.py
@@ -17,6 +17,7 @@ Every id was then filed under a ``None`` key and dropped by schema load.
 
 from __future__ import annotations
 
+from argparse import Namespace
 from collections.abc import Iterator, Mapping
 from types import MappingProxyType
 from typing import Any
@@ -24,10 +25,12 @@ from typing import Any
 import pytest
 from glom import glom
 
+from comicbox.box import Comicbox
 from comicbox.enums.comicbox import IdSources
-from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY
+from comicbox.formats.comicbox.schema import IDENTIFIERS_KEY, ComicboxSchemaMixin
 from comicbox.formats.metron_info.transform import MetronInfoTransform
-from comicbox.identifiers import ID_KEY_KEY
+from comicbox.identifiers import ID_KEY_KEY, ID_TYPE_KEY
+from comicbox.identifiers.identifiers import get_url_from_identifier
 from tests.const import TEST_METADATA_DIR
 
 NO_PRIMARY_FN = "metroninfo-no-primary-id.xml"
@@ -103,17 +106,48 @@ def test_tag_id_attribute_survives_and_is_attributed_to_metron(
 
 
 def test_reprint_id_attribute_survives() -> None:
+    """A Reprint's id names the reprinted issue, so its type is implied."""
     reprints = _to_comicbox()["reprints"]
     assert len(reprints) == 1
     identifiers = reprints[0][IDENTIFIERS_KEY]
     assert identifiers == {METRON: {ID_KEY_KEY: "4444"}}
+    assert (
+        get_url_from_identifier(METRON, identifiers[METRON])
+        == "https://metron.cloud/issue/4444"
+    )
 
 
 def test_alternative_name_id_attribute_survives() -> None:
+    """
+    An alternative name's id states that it names a series.
+
+    A name is not the thing it names, so where the id sits implies nothing
+    about it. Without the stated type a reader takes it for an issue id and
+    builds a url to the wrong page.
+    """
     alternative_names = _to_comicbox()["series"]["alternative_names"]
     assert len(alternative_names) == 1
     identifiers = alternative_names[0][IDENTIFIERS_KEY]
-    assert identifiers == {METRON: {ID_KEY_KEY: "3333"}}
+    assert identifiers == {METRON: {ID_KEY_KEY: "3333", ID_TYPE_KEY: "series"}}
+    assert (
+        get_url_from_identifier(METRON, identifiers[METRON])
+        == "https://metron.cloud/series/3333"
+    )
+
+
+def test_alternative_name_id_type_survives_the_whole_read() -> None:
+    """The stated type has to reach the metadata a library reads, not just the transform."""
+    cns = Namespace(
+        convert=Namespace(import_paths=[TEST_METADATA_DIR / NO_PRIMARY_FN]),
+        print=Namespace(phases="ncp"),
+    )
+    with Comicbox(config=Namespace(comicbox=cns)) as car:
+        md = car.get_internal_metadata()
+    alternative_names = md[ComicboxSchemaMixin.ROOT_TAG]["series"]["alternative_names"]
+    assert alternative_names[0][IDENTIFIERS_KEY][METRON] == {
+        ID_KEY_KEY: "3333",
+        ID_TYPE_KEY: "series",
+    }
 
 
 def test_sourced_id_tag_keeps_its_own_source() -> None:
@@ -151,3 +185,8 @@ def test_roundtrip_writes_the_id_attributes_back() -> None:
     assert metron["Publisher"]["@id"] == "11"
     assert metron["Publisher"]["Imprint"]["@id"] == "222"
     assert metron["Series"]["@id"] == "2222"
+    # A stated type is comicbox's own note about the key. It must not
+    # disturb the attribute it was read from.
+    alternative_name = metron["Series"]["AlternativeNames"]["AlternativeName"][0]
+    assert alternative_name["@id"] == "3333"
+    assert metron["Reprints"]["Reprint"][0]["@id"] == "4444"

--- a/tests/unit/test_online_estimate.py
+++ b/tests/unit/test_online_estimate.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import pytest
 
+from comicbox.config.online.settings import Effort
 from comicbox.online_estimate import (
-    COMICVINE_REQUESTS_BY_MODE,
+    COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT,
     METRON_REQUESTS_PER_COMIC,
     SOURCE_RATE_PER_MINUTE,
     RunEstimate,
     estimate_run,
     requests_per_comic,
 )
+
+MINIMAL = Effort.MINIMAL.value
+BALANCED = Effort.BALANCED.value
+THOROUGH = Effort.THOROUGH.value
 
 
 def test_rates_track_documented_limits() -> None:
@@ -23,53 +28,75 @@ def test_rates_track_documented_limits() -> None:
 
 def test_zero_comics_is_empty() -> None:
     """No comics means no requests and no time."""
-    assert estimate_run(0, "auto", ("metron",)) == RunEstimate(requests=0, seconds=0.0)
+    assert estimate_run(0, ("metron",)) == RunEstimate(requests=0, seconds=0.0)
 
 
 def test_no_sources_is_empty() -> None:
     """No enabled sources means no requests and no time."""
-    assert estimate_run(10, "auto", ()) == RunEstimate(requests=0, seconds=0.0)
+    assert estimate_run(10, ()) == RunEstimate(requests=0, seconds=0.0)
 
 
-def test_metron_auto() -> None:
+def test_metron_balanced() -> None:
     """Metron's flat two-step search: 10 comics x 2 requests / 20 per-minute."""
-    est = estimate_run(10, "auto", ("metron",))
+    est = estimate_run(10, ("metron",))
     assert est.requests == 20
     assert est.seconds == 60.0
 
 
-def test_metron_requests_are_mode_independent() -> None:
-    """Match mode does not change Metron's fixed two-step request count."""
-    auto = estimate_run(10, "auto", ("metron",))
-    careful = estimate_run(10, "careful", ("metron",))
-    eager = estimate_run(10, "eager", ("metron",))
-    assert auto == careful == eager
-    assert auto.requests == 20
+def test_metron_requests_are_effort_independent() -> None:
+    """Metron does not fan out, so no effort changes its two-step count."""
+    estimates = [estimate_run(10, ("metron",), effort=e.value) for e in Effort]
+    assert len(set(estimates)) == 1
+    assert estimates[0].requests == 20
 
 
-def test_comicvine_requests_scale_with_mode() -> None:
-    """Comic Vine's per-comic requests scale with match mode; pacing per pool."""
-    careful = estimate_run(10, "careful", ("comicvine",))
-    eager = estimate_run(10, "eager", ("comicvine",))
-    assert careful.requests == 50  # 10 x 5
-    assert eager.requests == 20  # 10 x 2
-    # Wall-clock tracks the busiest resource pool (careful 2, eager 1) over
-    # the 3/min per-pool rate, not the request total.
-    assert careful.seconds == pytest.approx(400.0)  # 10 x 60 x 2/3
-    assert eager.seconds == pytest.approx(200.0)  # 10 x 60 x 1/3
+def test_comicvine_requests_scale_with_effort() -> None:
+    """Effort bounds Comic Vine's fan-out, which is most of what a comic costs."""
+    minimal = estimate_run(10, ("comicvine",), effort=MINIMAL)
+    balanced = estimate_run(10, ("comicvine",), effort=BALANCED)
+    thorough = estimate_run(10, ("comicvine",), effort=THOROUGH)
+    # 10 x (2 discovery + fan-out + 2 fetch).
+    assert minimal.requests == 50
+    assert balanced.requests == 70
+    assert thorough.requests == 80
+    # Wall-clock tracks the issue-list pool alone, over the 3/min per-pool
+    # rate: 10 x 60 x fan-out / 3.
+    assert minimal.seconds == pytest.approx(200.0)
+    assert balanced.seconds == pytest.approx(600.0)
+    assert thorough.seconds == pytest.approx(800.0)
+
+
+def test_more_effort_costs_more() -> None:
+    """Both halves of the estimate rise with effort, in order."""
+    estimates = [
+        estimate_run(10, ("comicvine",), effort=e)
+        for e in (MINIMAL, BALANCED, THOROUGH)
+    ]
+    requests = [est.requests for est in estimates]
+    seconds = [est.seconds for est in estimates]
+    assert requests == sorted(requests)
+    assert seconds == sorted(seconds)
+    assert len(set(requests)) == len(set(seconds)) == len(Effort)
+
+
+def test_every_effort_is_priced() -> None:
+    """No Effort member may fall through to the fallback."""
+    for effort in Effort:
+        assert effort.value in COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT
 
 
 def test_comicvine_pacing_binds_on_busiest_pool_not_total() -> None:
     """
     Simyan paces per resource pool (CV's per-resource limit).
 
-    Auto costs more requests than eager, but the extras land in different
-    pools, so both sustain the same pace.
+    Discovery and the accept fetch each sit alone in their own pool, so
+    they cost requests without costing time; only the issue-list fan-out
+    stacks, and it alone sets the pace.
     """
-    eager = estimate_run(10, "eager", ("comicvine",))
-    auto = estimate_run(10, "auto", ("comicvine",))
-    assert auto.requests > eager.requests
-    assert auto.seconds == eager.seconds
+    est = estimate_run(10, ("comicvine",), effort=BALANCED)
+    fan_out = COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT[BALANCED]
+    assert est.requests == 10 * (fan_out + 4)
+    assert est.seconds == pytest.approx(10 * 60.0 * fan_out / 3)
 
 
 def test_slowest_source_binds_the_rate() -> None:
@@ -77,38 +104,53 @@ def test_slowest_source_binds_the_rate() -> None:
     Comic Vine is slower than Metron and binds the pace.
 
     First-match-wins bills the costliest source's requests
-    (max(metron 2, comicvine 3) = 3) and the slowest source's pace
-    (comicvine: 60s x 1-pool-request / 3-per-minute = 20s/comic).
+    (max(metron 2, comicvine 7) = 7) and the slowest source's pace
+    (comicvine: 60s x 3 pool requests / 3-per-minute = 60s/comic).
     """
-    est = estimate_run(10, "auto", ("metron", "comicvine"))
-    assert est.requests == 30
-    assert est.seconds == pytest.approx(200.0)
+    est = estimate_run(10, ("metron", "comicvine"))
+    assert est.requests == 70
+    assert est.seconds == pytest.approx(600.0)
 
 
 def test_merge_sums_per_source_requests() -> None:
     """Merging queries every source per comic: requests and paces both sum."""
-    est = estimate_run(10, "auto", ("metron", "comicvine"), merge_all_sources=True)
-    assert est.requests == 50  # 10 x (metron 2 + comicvine 3)
-    # 10 x (metron 6s + comicvine 20s)
-    assert est.seconds == pytest.approx(260.0)
+    est = estimate_run(10, ("metron", "comicvine"), merge_all_sources=True)
+    assert est.requests == 90  # 10 x (metron 2 + comicvine 7)
+    # 10 x (metron 6s + comicvine 60s)
+    assert est.seconds == pytest.approx(660.0)
 
 
 def test_merge_single_source_is_noop() -> None:
     """With one source there is nothing to merge, so the estimate is unchanged."""
-    first_wins = estimate_run(10, "auto", ("metron",))
-    merged = estimate_run(10, "auto", ("metron",), merge_all_sources=True)
+    first_wins = estimate_run(10, ("metron",))
+    merged = estimate_run(10, ("metron",), merge_all_sources=True)
     assert merged == first_wins
 
 
-def test_unknown_mode_and_source_use_defaults() -> None:
-    """Unknown mode -> 3 requests/comic; unknown source -> 10/min default rate."""
-    est = estimate_run(10, "bogus", ("unknown",))
+def test_default_effort_is_balanced() -> None:
+    """Omitting the effort prices the shipped default."""
+    assert estimate_run(10, ("comicvine",)) == estimate_run(
+        10, ("comicvine",), effort=BALANCED
+    )
+
+
+def test_unknown_effort_is_priced_as_balanced() -> None:
+    """An effort this version doesn't know falls back to the default."""
+    assert estimate_run(10, ("comicvine",), effort="bogus") == estimate_run(
+        10, ("comicvine",), effort=BALANCED
+    )
+
+
+def test_unknown_source_uses_defaults() -> None:
+    """Unknown source -> 3 requests/comic and the 10/min default rate."""
+    est = estimate_run(10, ("unknown",))
     assert est.requests == 30  # 10 x 3 default
     assert est.seconds == 180.0  # 30 / 10 default per-minute
 
 
 def test_requests_per_comic_helper() -> None:
     """The per-source per-comic request count is exposed directly."""
-    assert requests_per_comic("metron", "careful") == METRON_REQUESTS_PER_COMIC
-    assert requests_per_comic("comicvine", "auto") == COMICVINE_REQUESTS_BY_MODE["auto"]
-    assert requests_per_comic("unknown", "auto") == 3
+    assert requests_per_comic("metron", THOROUGH) == METRON_REQUESTS_PER_COMIC
+    assert requests_per_comic("comicvine", MINIMAL) == 5
+    assert requests_per_comic("comicvine") == 7
+    assert requests_per_comic("unknown") == 3

--- a/tests/unit/test_online_session.py
+++ b/tests/unit/test_online_session.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+from pathlib import Path
+
 import pytest
 
 from comicbox.box import Comicbox
-from comicbox.config.online.settings import MatchMode, Prompts
+from comicbox.config import get_config
+from comicbox.config.online.settings import Effort, MatchMode, Prompts
 from comicbox.online_session import (
     OnlineConfigurationError,
     OnlineCredentials,
@@ -184,6 +188,39 @@ def test_only_enabled_sources_appear_in_auth() -> None:
     cfg = session._build_config()
     assert "metron" in cfg.online.auth.sources
     assert "comicvine" not in cfg.online.auth.sources
+
+
+def test_supplied_config_is_the_base_the_session_layers_over() -> None:
+    """Settings an embedder passes in survive into every per-file config."""
+    base = get_config()
+    cache = replace(base.online.cache, dir=Path("/tmp/codex-cache"))
+    tuning = replace(base.online.tuning, effort=Effort.THOROUGH)
+    supplied = replace(base, online=replace(base.online, cache=cache, tuning=tuning))
+
+    session = OnlineSession(
+        sources={"metron"}, credentials=VALID_METRON, config=supplied
+    )
+
+    cfg = session._build_config()
+    assert cfg.online.cache.dir == Path("/tmp/codex-cache")
+    assert cfg.online.tuning.effort is Effort.THOROUGH
+    # The session's own preferences still win over what it was handed.
+    assert cfg.online.lookup.sources == ("metron",)
+    assert cfg.online.lookup.enabled is True
+
+
+def test_supplied_config_skips_the_settings_read(monkeypatch) -> None:
+    """A caller with settings in hand pays no config-file or env read."""
+
+    def _fail() -> None:
+        msg = "get_config() should not be called when config= is supplied"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("comicbox.online_session.get_config", _fail)
+    session = OnlineSession(
+        sources={"metron"}, credentials=VALID_METRON, config=get_config()
+    )
+    assert session._build_config().online.lookup.sources == ("metron",)
 
 
 # --- cancellation -------------------------------------------------------------


### PR DESCRIPTION
The actionable half of `tasks/codex-5-upstream-followups.md`, items 2 and 4.

**Stacked on [#203](https://github.com/ajslater/comicbox/pull/203).** Its two commits appear in this diff until that merges; rebase then leaves the three commits below. Review from `d279ec7`.

## The run estimate was keyed on an axis that moves nothing

`MatchMode` branches only in the matcher, deciding how a verdict is applied. No match mode changes a single Comic Vine request. The shipped table of `{eager 2, auto 3, careful 5}` recorded no provenance and priced `careful` above `eager`, which is backwards even for the one mode-dependent cost there is: a declined match skips the two-call accept fetch.

`Effort` is the axis that moves the count, and 5.0 made it bite. So the mode parameter is gone rather than joined by a second one:

```python
requests_per_comic(source, effort="balanced") -> int
estimate_run(comics, sources, *, effort="balanced", merge_all_sources=False)
```

Comic Vine's cost is now built from what a search does: flat discovery, an effort-bounded issue-list fan-out, and the accept fetch. Only the fan-out paces the run, because those calls stack in one resource pool while everything else sits alone in its own. `COMICVINE_REQUESTS_BY_MODE` and `COMICVINE_BUSIEST_POOL_REQUESTS_BY_MODE` are replaced by `COMICVINE_DISCOVERY_REQUESTS`, `COMICVINE_ISSUE_LIST_REQUESTS_BY_EFFORT` and `COMICVINE_FETCH_REQUESTS`.

| Effort | Requests/comic | Seconds/comic |
|---|---|---|
| minimal | 5 | 20 |
| balanced | 7 | 60 |
| thorough | 8 | 80 |

The numbers are anchored to a measured cold search rather than asserted, which triples the default projection from 20s to 60s per comic. That is the estimate becoming honest, not the run getting slower: a real batch tags by series and beats it. The measurement, the scaling, and what a future calibration run should settle are in a new note under `tasks/online-tagging/calibration-notes/`.

`Effort` joins `MatchMode` on the `online_session` facade so a batch caller takes the estimator and its enum from one place.

## Two MetronInfo ids that could not build a url

Both because comicbox filed an id by its position when the position said nothing.

An id on a series `AlternativeName` is a series id, but a name is not the thing it names, so its position implies no type. Filing it as an implied series id stored a bare key, and a reader applying the documented default read it as an issue id and built a live link to the wrong page. It now states its type, the way a top-level non-issue id does.

A `Reprint`'s id is the reprinted issue's Metron id, which is what the online API transform has always filed it as. The MetronInfo transform called it a `reprint` id, a type no database publishes a page for, so it was linkless by construction. It now files an issue id: same stored key, right url.

Neither changes what comicbox writes. The MetronInfo writer reads only the key.

## Also

Two stale comments that the new derivation would have contradicted: `online_source.py` still said the balanced filter was a dormant no-op with a placeholder threshold, and `series_filter.py`'s docstring still promised Phase B would pick the real numbers. Comment-only, no behaviour change.

## Verification

CI's lint/test job is skipped on a `develop` PR (it gates on `main` or a `pre-release` head), so this ran locally on macOS:

- `make fix` — no diff
- `make lint` — all checks passed, 0 errors, 0 warnings, 0 notes
- `make ty` — all checks passed
- `make complexity` — no functions over 15, radon silent
- `make test` — 2073 passed, 1 skipped, 15 warnings (warning count unchanged; 2068 before)

Hands-on:

```
minimal  RunEstimate(requests=50, seconds=200.0)
balanced RunEstimate(requests=70, seconds=600.0)
thorough RunEstimate(requests=80, seconds=800.0)

{'metron': {'key': '3333', 'id_type': 'series'}} https://metron.cloud/series/3333
{'metron': {'key': '4444'}}                      https://metron.cloud/issue/4444
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)