### PR TITLE
fix(cli): flags that exist, enum-derived choices, and an effort that pins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,17 +48,19 @@
     - Online tagging reports a match only when metadata was really applied, and
       a lone mediocre match no longer auto-writes without a prompt. Prompts hold
       up under batch and parallel runs.
+    - `--effort balanced` is honored; a large unattended run no longer quietly
+      downgrades it to `minimal` for Comic Vine.
     - `-c/--config` loads the file it names instead of being ignored, and an
       unknown `--online` source is an error rather than a silent widening: a
       typo like `--online metrn` queried every configured database.
-    - The hint printed when no TTY is detected told you to pass `--unattended`,
-      a flag comicbox has never had. It names `--prompts never` now.
     - Reading metadata no longer depends on write settings, so
       `--online --write … --rename` no longer names the file from stale data.
     - A comic that can't be read no longer ends the batch, and `comicbox` exits
       non-zero whenever any file failed.
     - MetronInfo alternative name ids link to their series, and reprint ids to
       the issue they reprint, instead of to pages that don't exist.
+    - The no-TTY hint names `--prompts never` instead of `--unattended`, which
+      never existed.
     - Many smaller repairs to credit roles, tag coverage, identifiers, urls and
       odd data that used to cost a whole comic. Metadata comicbox skips is now
       named in a warning instead of dropped silently.

--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@
     - `-c/--config` loads the file it names instead of being ignored, and an
       unknown `--online` source is an error rather than a silent widening: a
       typo like `--online metrn` queried every configured database.
+    - The hint printed when no TTY is detected told you to pass `--unattended`,
+      a flag comicbox has never had. It names `--prompts never` now.
     - Reading metadata no longer depends on write settings, so
       `--online --write … --rename` no longer names the file from stale data.
     - A comic that can't be read no longer ends the batch, and `comicbox` exits

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,12 @@
       format.
     - Removed `--replace`; use `--merge-mode update`. The write API takes
       `merge_mode` instead of `mode`, and `WriteMode` is now `MergeMode`.
+    - `OnlineSession` takes `match` and `prompts` instead of `mode` and
+      `unattended`, matching `--match` and `--prompts`. `set_mode` and
+      `set_unattended` are `set_match` and `set_prompts`, the prompt objects
+      carry `match` and `prompts`, and the `set_unattended` selector action is
+      `set_prompts`, which names the policy it sets and so can turn prompts back
+      on.
     - Environment variables nest with `__`, and every config key can be set that
       way: `COMICBOX_ONLINE__AUTH__METRON__KEY`. Old flat names warn.
     - `estimate_run()` and `requests_per_comic()` take an `effort` instead of a

--- a/comicbox/box/online_lookup.py
+++ b/comicbox/box/online_lookup.py
@@ -2,22 +2,23 @@
 Online metadata lookup mixin.
 
 Sits between `ComicboxNormalize` and `ComicboxMerge` in the box chain.
-For M2 the only path implemented is ``--id <db>:<id>`` — exact-issue
-fetch. Search and ranking land in M3.
 
 The mixin runs once per box instance, gated on
 ``settings.online.lookup.enabled``. For each active source (one whose
 required credentials resolve and whose name is in
-``selected_sources`` if that filter is set), it:
+``selected_sources`` if that filter is set), it takes the first path
+that applies:
 
-1. Checks ``--ignore-existing`` against any source data already
-   carrying an identifier from this source's name (we don't re-tag if
-   the user has already done so, even from a different source).
-2. Calls ``source.get(issue_id)`` for every ``explicit_id`` mapped to
-   that source.
-3. Wraps the response under the schema's root tag and pushes it via
-   ``add_source(source.metadata_source, ...)`` so the existing load
-   → normalize → merge pipeline picks it up.
+1. ``--id <db>:<id>`` — fetch that exact issue, skipping every search.
+2. A stored upstream id from a prior tag — refresh via
+   ``source.get(id)``. ``--rematch`` suppresses this.
+3. The session's series cache — ask the source for "issue N in volume
+   V" without searching. ``--rematch`` suppresses this too.
+4. A full search, ranked and resolved under ``--match``.
+
+Whichever path answers, the response is wrapped under the schema's root
+tag and pushed via ``add_source(source.metadata_source, ...)`` so the
+existing load → normalize → merge pipeline picks it up.
 """
 
 from __future__ import annotations
@@ -112,8 +113,9 @@ def _online_source_enums() -> frozenset[MetadataSources]:
     """
     Derive the set of online MetadataSources from per-format REGISTRATIONs.
 
-    Used to skip self when checking for existing identifiers under
-    `--ignore-existing`.
+    Used to skip online sources when scanning normalized metadata for a
+    stored identifier or for profile fields, so a previous online tag
+    can't feed itself back into this run's search.
     """
     online_source_names = {
         source_name
@@ -190,7 +192,7 @@ class _NoTtyHintGuard:
             self._shown = True
         logger.info(
             "online: no TTY detected and no prompt callback registered; "
-            "pass --unattended if you don't expect to see prompts "
+            "pass --prompts never if you don't expect to see prompts "
             "(interactive mode without a TTY will hang on the first "
             "PROMPT decision)."
         )
@@ -451,20 +453,6 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             source.retry_sleep = self._retry_sleep
             active.append(source)
         return active
-
-    def _has_existing_identifier(self, source_name: str) -> bool:
-        """Return True if any non-online source's data already has this source's id."""
-        keypath = f"comicbox.identifiers.{source_name}"
-        for src in MetadataSources:
-            if src in _ONLINE_SOURCE_ENUMS:
-                continue
-            normalized = self.get_normalized_metadata(src)
-            if not normalized:
-                continue
-            for loaded in normalized:
-                if glom(dict(loaded.metadata), keypath, default=None):
-                    return True
-        return False
 
     def _stored_identifier(self, source_name: str) -> int | None:
         """

--- a/comicbox/box/online_lookup.py
+++ b/comicbox/box/online_lookup.py
@@ -129,7 +129,7 @@ def _online_source_enums() -> frozenset[MetadataSources]:
 _ONLINE_SOURCE_ENUMS: frozenset[MetadataSources] = _online_source_enums()
 
 # Hard cap on selector round-trips for a single prompt. Only the two
-# session-level actions (`set_unattended` / `set_policy`) re-prompt, and a
+# session-level actions (`set_prompts` / `set_policy`) re-prompt, and a
 # user needs at most one of each before landing on a terminal answer, so
 # anything past this is a selector that never terminates -- a buggy or
 # hostile programmatic callback, not a person. Not a match-quality
@@ -286,7 +286,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
 
     # Session-supplied owner of the two mutable lookup settings (match and
     # prompts). A Runner or OnlineSession shares one across every box it
-    # spawns so a `set_policy` / `set_unattended` answered on one file is
+    # spawns so a `set_policy` / `set_prompts` answered on one file is
     # in force for the next. Unset for a standalone Comicbox: the lazy
     # fallback below then makes a private one seeded from this box's
     # config, keeping single-file use self-contained.
@@ -345,7 +345,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         Register the session-level owner of match mode and prompt policy.
 
         Share one across every box of a batch so a `set_policy` /
-        `set_unattended` answered at a prompt outlives the file it was
+        `set_prompts` answered at a prompt outlives the file it was
         answered on. A sibling worker already resolving a file finishes it
         under the policy it started with and picks the change up on its
         next file.
@@ -760,7 +760,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         Acquires the class-level `_PROMPT_LOCK` around the selector call
         so concurrent worker threads (when `-j N > 1`) don't garble each
         other's prompts. Re-resolves and re-prompts when the selector
-        requests a session-level setting change (`set_unattended` /
+        requests a session-level setting change (`set_prompts` /
         `set_policy`), reading the session state back so the new setting
         takes effect on the current candidate set immediately.
 
@@ -788,7 +788,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
                     action=action,
                 )
             )
-            if action in {"set_unattended", "set_policy"}:
+            if action in {"set_prompts", "set_policy"}:
                 if not self._apply_session_action(source.name, action, payload):
                     return False
                 resolution = self._resolve_existing(
@@ -804,7 +804,7 @@ class ComicboxOnlineLookup(ComicboxNormalize):
             return self._dispatch_terminal_prompt_action(
                 source, current, action, payload
             )
-        # Only `set_unattended` / `set_policy` reach here; every other
+        # Only `set_prompts` / `set_policy` reach here; every other
         # action returned above. A selector that keeps asking for session
         # changes without ever deciding would have spun forever.
         logger.warning(
@@ -834,37 +834,43 @@ class ComicboxOnlineLookup(ComicboxNormalize):
         self, source_name: str, action: str, payload: int | str | None
     ) -> bool:
         """
-        Apply a `set_unattended` / `set_policy` action to the session.
+        Apply a `set_prompts` / `set_policy` action to the session.
 
         The single validator for these two actions: the session reads the
         state this writes, so there is no second implementation to keep in
-        step. Returns True on success, False if the payload was malformed
-        (in which case the prompt has been recorded as declined and the
-        caller should bail out).
+        step. Both name their new value as a string payload, so both parse
+        it the same way. Returns True on success, False if the payload was
+        malformed (in which case the prompt has been recorded as declined
+        and the caller should bail out).
         """
-        if action == "set_unattended":
-            self._get_online_session_state().set_prompts(Prompts.NEVER)
-            logger.info(f"online {source_name}: session set to unattended via prompt")
-            return True
+        enum_class: type[Prompts | MatchMode] = (
+            Prompts if action == "set_prompts" else MatchMode
+        )
+        noun = "prompt policy" if action == "set_prompts" else "match mode"
         if not isinstance(payload, str):
             logger.warning(
-                f"online {source_name}: set_policy requires a policy name; "
+                f"online {source_name}: {action} requires a {noun} name; "
                 f"got {payload!r}"
             )
             outcome_stats.record_prompt_declined(source_name)
             return False
         try:
-            new_match = MatchMode(payload)
+            new_value = enum_class(payload)
         except ValueError:
+            expected = " | ".join(member.value for member in enum_class)
             logger.warning(
-                f"online {source_name}: unknown match mode {payload!r}; "
-                "expected one of ask | careful | auto | eager"
+                f"online {source_name}: unknown {noun} {payload!r}; "
+                f"expected one of {expected}"
             )
             outcome_stats.record_prompt_declined(source_name)
             return False
-        self._get_online_session_state().set_match(new_match)
+        state = self._get_online_session_state()
+        if isinstance(new_value, Prompts):
+            state.set_prompts(new_value)
+        else:
+            state.set_match(new_value)
         logger.info(
-            f"online {source_name}: session match mode set to {new_match.value} via prompt"
+            f"online {source_name}: session {noun} set to {new_value.value} via prompt"
         )
         return True
 

--- a/comicbox/cli/parser.py
+++ b/comicbox/cli/parser.py
@@ -21,7 +21,13 @@ from rich_argparse import RichHelpFormatter
 from typing_extensions import override
 
 from comicbox._pdf import PAGE_FORMAT_VALUES, PDF_ENABLED
-from comicbox.config.online.settings import DEFAULT_AUTO_THRESHOLD
+from comicbox.config.online.settings import (
+    DEFAULT_AUTO_THRESHOLD,
+    CacheMode,
+    Effort,
+    MatchMode,
+    Prompts,
+)
 from comicbox.config.settings import MergeMode
 
 if TYPE_CHECKING:
@@ -517,7 +523,7 @@ def _add_online_lookup_group(parser: ArgumentParser) -> None:
         "--match",
         action="store",
         default=None,
-        choices=("ask", "careful", "auto", "eager"),
+        choices=tuple(mode.value for mode in MatchMode),
         metavar="MODE",
         dest="match",
         help=(
@@ -531,7 +537,7 @@ def _add_online_lookup_group(parser: ArgumentParser) -> None:
         "--prompts",
         action="store",
         default=None,
-        choices=("ask", "never"),
+        choices=tuple(prompts.value for prompts in Prompts),
         metavar="MODE",
         dest="prompts",
         help=(
@@ -596,7 +602,7 @@ def _add_online_cache_group(parser: ArgumentParser) -> None:
         "--cache",
         action="store",
         default=None,
-        choices=("on", "off", "refresh"),
+        choices=tuple(mode.value for mode in CacheMode),
         metavar="MODE",
         dest="cache",
         help=(
@@ -642,7 +648,7 @@ def _add_online_tuning_group(parser: ArgumentParser) -> None:
         "--effort",
         action="store",
         default=None,
-        choices=("minimal", "balanced", "thorough"),
+        choices=tuple(effort.value for effort in Effort),
         metavar="MODE",
         dest="effort",
         help=(

--- a/comicbox/config/online/build.py
+++ b/comicbox/config/online/build.py
@@ -386,7 +386,7 @@ def _resolve_runtime_sources(
     online_arg: Any, explicit_id_sources: tuple[str, ...]
 ) -> tuple[bool, tuple[str, ...] | None]:
     """
-    Decide (enabled, selected) from --online-sources + explicit-id presence.
+    Decide (enabled, selected) from --online + explicit-id presence.
 
     ``selected`` is ordered (run priority). None = the CLI didn't choose,
     so selection falls through to env/config; ALL_SOURCES = an explicit

--- a/comicbox/config/online/build.py
+++ b/comicbox/config/online/build.py
@@ -310,11 +310,12 @@ def _build_tuning(
         if auto_threshold_raw is not None
         else DEFAULT_AUTO_THRESHOLD
     )
+    # Left None when no layer named an effort. Defaulting it to
+    # BALANCED here is what made an explicit `--effort balanced`
+    # indistinguishable from silence, so auto-engagement overrode it.
     effort_raw = _coalesce(cli("effort"), online_block.tuning.effort)
     effort_value = (
-        parse_enum(Effort, "--effort", str(effort_raw))
-        if effort_raw
-        else Effort.BALANCED
+        parse_enum(Effort, "--effort", str(effort_raw)) if effort_raw else None
     )
     retry_budget = int(_coalesce(online_block.tuning.retry_budget, 5))
     per_source = _build_per_source_tuning(online_block)

--- a/comicbox/config/online/settings.py
+++ b/comicbox/config/online/settings.py
@@ -205,9 +205,13 @@ class OnlineSourceTuning:
 class OnlineTuningSettings:
     """Global tuning defaults plus per-source overrides."""
 
-    # Global defaults.
+    # Global defaults. ``effort`` is None when no layer named one:
+    # it resolves to ``Effort.BALANCED`` either way, but only an unset
+    # effort may be auto-engaged down to ``MINIMAL`` for a large
+    # unattended run (see ``auto_engage``). Collapsing the two states
+    # meant an explicit ``--effort balanced`` was silently downgraded.
     auto_threshold: float = DEFAULT_AUTO_THRESHOLD
-    effort: Effort = Effort.BALANCED
+    effort: Effort | None = None
     retry_budget: int = 5
 
     # Per-source overrides (keyed by source name).
@@ -243,9 +247,11 @@ def resolve_auto_threshold(settings: OnlineSettings, source_name: str) -> float:
 
 
 def resolve_effort(settings: OnlineSettings, source_name: str) -> Effort:
-    """Per-source effort override > global default."""
+    """Per-source effort override > global setting > ``BALANCED``."""
     override = _tuning_for(settings, source_name).effort
-    return override if override is not None else settings.tuning.effort
+    if override is not None:
+        return override
+    return settings.tuning.effort or Effort.BALANCED
 
 
 def resolve_min_confidence(settings: OnlineSettings, source_name: str) -> float:

--- a/comicbox/config/online/template.py
+++ b/comicbox/config/online/template.py
@@ -79,7 +79,7 @@ ONLINE_TEMPLATE = MappingTemplate(
         "tuning": MappingTemplate(
             {
                 "auto_threshold": Number(),
-                "effort": String(),
+                "effort": Optional(String()),
                 "retry_budget": Integer(),
                 "per_source": Optional(dict),
             }

--- a/comicbox/config_default.yaml
+++ b/comicbox/config_default.yaml
@@ -105,7 +105,11 @@ comicbox:
       auto_threshold: 0.95
       # Per-comic API effort for fan-out sources (ComicVine): minimal,
       # balanced, thorough. Metron doesn't fan out, so it ignores this.
-      effort: balanced
+      # null = unset, which resolves to balanced and lets a large
+      # unattended run auto-engage minimal for ComicVine. Naming a value
+      # here (or with --effort / COMICBOX_ONLINE__TUNING__EFFORT) pins
+      # it: an explicit `balanced` is honored, not auto-engaged away.
+      effort: null
       # Retry budget for transient API failures.
       retry_budget: 5
       # Per-source overrides — keyed by source name (metron, comicvine).

--- a/comicbox/formats/base/online/auto_engage.py
+++ b/comicbox/formats/base/online/auto_engage.py
@@ -26,10 +26,12 @@ foreground wait:
   bar so manual `xargs` pipelines don't surprise the user)
 
 When either fires, the resolved `OnlineSettings` gets a per-source
-override pinning `effort=minimal` for the matching source(s). The
-user can suppress with a YAML per-source override
-(`online.tuning.per_source.<source>.effort`) or with `--effort`
-(`online.tuning.effort`) set globally to anything non-default.
+override pinning `effort=minimal` for the matching source(s). The user
+can suppress with a YAML per-source override
+(`online.tuning.per_source.<source>.effort`) or by naming any global
+effort at all — `--effort`, `COMICBOX_ONLINE__TUNING__EFFORT`, or
+`online.tuning.effort` in a config file. `--effort balanced` is a
+choice, not silence, and is honored as one.
 
 Thresholds are placeholders from `06-api-budget-spec.md`; Phase B's
 calibration data validated the per-source-cap reasoning but didn't pin
@@ -118,15 +120,13 @@ def resolve_auto_engaged_budget(
       expansion. Pass 0 or 1 to disable auto-engagement.
 
     Behavior: walks each known source; for each, if the user did NOT
-    set a per-source override AND the global effort is `BALANCED`
-    (today's default, also what we want to upgrade FROM), check the
+    set a per-source override AND named no global effort, check the
     triggers in order. Per-source override pinned only when at least
     one trigger fires.
 
     User-set per-source overrides — even to `BALANCED` — block
-    auto-engagement for that source. Setting the global `--effort`
-    to a non-default also blocks auto-engagement (the user has
-    spoken).
+    auto-engagement for that source. Any global effort blocks it
+    everywhere, `balanced` included: the user has spoken.
 
     Logs an INFO line per source the engagement fires for, so the user
     sees what's happening and knows how to override.
@@ -134,9 +134,10 @@ def resolve_auto_engaged_budget(
     if batch_size <= 1:
         return online
 
-    # User pinned the global effort to anything non-default → respect it,
-    # auto-engagement is for "user didn't choose, we should help" cases.
-    if online.tuning.effort is not Effort.BALANCED:
+    # Any global effort at all means the user named one — on the command
+    # line, in the environment, or in a config file. Auto-engagement is
+    # for the "user didn't choose, we should help" case only.
+    if online.tuning.effort is not None:
         return online
 
     from comicbox.config.online.settings import OnlineSourceTuning

--- a/comicbox/formats/base/online/auto_engage.py
+++ b/comicbox/formats/base/online/auto_engage.py
@@ -20,7 +20,7 @@ This module's `resolve_auto_engaged_budget` watches for two signals,
 both of which indicate the user is unlikely to want a multi-hour
 foreground wait:
 
-- `--unattended` + batch size ≥ per-source `_UNATTENDED_THRESHOLD`
+- `--prompts never` + batch size ≥ per-source `_UNATTENDED_THRESHOLD`
 - stdin is not a TTY + batch size ≥ per-source `_NON_TTY_THRESHOLD`
   (4x looser — cron-shaped invocations get the suggestion at a higher
   bar so manual `xargs` pipelines don't surprise the user)
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
 
 # Batch-size threshold at which to auto-engage `minimal` for a source
-# under `--unattended`. Keyed by source and intentionally listing only
+# under `--prompts never`. Keyed by source and intentionally listing only
 # FAN-OUT sources — the ones where `minimal` actually reduces per-comic API
 # calls. Metron is excluded: its single-call search (PR #143) costs the
 # same at any effort, so auto-engaging `minimal` for it would be a
@@ -72,8 +72,8 @@ _UNATTENDED_THRESHOLDS: Final[MappingProxyType[str, int]] = MappingProxyType(
 # 4x the unattended thresholds. The conservative bar for "stdin is not
 # a TTY but the user didn't explicitly say unattended" — could be a
 # cron job, could be a manual xargs pipeline. Bump the threshold so
-# manual invocations don't surprise users; explicit `--unattended` is
-# the cleaner signal of intent.
+# manual invocations don't surprise users; explicit `--prompts never`
+# is the cleaner signal of intent.
 _NON_TTY_THRESHOLDS: Final[MappingProxyType[str, int]] = MappingProxyType(
     {source: count * 4 for source, count in _UNATTENDED_THRESHOLDS.items()}
 )

--- a/comicbox/formats/base/online/outcome_stats.py
+++ b/comicbox/formats/base/online/outcome_stats.py
@@ -73,7 +73,7 @@ class _OutcomeStats:
             self._bucket_for(source_name).prompt_declined += 1
 
     def record_skip(self, source_name: str) -> None:
-        """Record a SKIP (matcher declined under `--unattended`)."""
+        """Record a SKIP (matcher declined under `--prompts never`)."""
         with self._lock:
             self._counts.skip += 1
             self._bucket_for(source_name).skip += 1

--- a/comicbox/formats/base/online/prompt.py
+++ b/comicbox/formats/base/online/prompt.py
@@ -41,6 +41,8 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from comicbox.config.online.settings import Prompts
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -271,7 +273,7 @@ def _ask_session_options() -> SelectorResult | None:
         if s in {"b", "back", ""}:
             return None
         if s in {"u", "unattended"}:
-            return ("set_unattended", None)
+            return ("set_prompts", Prompts.NEVER.value)
         if s in {"p", "policy"}:
             sub = _ask_policy_choice()
             if sub is not None:

--- a/comicbox/formats/base/online/selector.py
+++ b/comicbox/formats/base/online/selector.py
@@ -9,10 +9,10 @@ A `SelectorCallback` receives a profile and a list of ranked
 - `("manual", "<source>:<id>")` — re-tag from an explicit id; falls
   through to the explicit-id code path.
 - `("abort", None)` — abort the entire run.
-- `("set_unattended", None)` — switch the rest of the session to
-  unattended mode. The box re-resolves the current candidates (which
-  collapses to SKIP under unattended) without auto-writing this
-  prompt's selection.
+- `("set_prompts", "<name>")` — switch the rest of the session's
+  prompt policy to `ask` or `never` (a :class:`Prompts` value). The box
+  re-resolves the current candidates (which collapses to SKIP under
+  `never`) without auto-writing this prompt's selection.
 - `("set_policy", "<name>")` — switch the rest of the session's match
   policy to one of `ask | careful | auto | eager` (a
   :class:`MatchMode` value). The box re-resolves the current
@@ -48,7 +48,7 @@ SelectorAction: TypeAlias = Literal[
     "skip",
     "manual",
     "abort",
-    "set_unattended",
+    "set_prompts",
     "set_policy",
 ]
 SelectorResult: TypeAlias = tuple[SelectorAction, "int | str | None"]

--- a/comicbox/formats/base/online/session_state.py
+++ b/comicbox/formats/base/online/session_state.py
@@ -2,7 +2,7 @@
 One owner for the online session's mutable lookup policy.
 
 Two settings change mid-run when a selector answers ``set_policy`` or
-``set_unattended``: ``match`` and ``prompts``. Everything else in
+``set_prompts``: ``match`` and ``prompts``. Everything else in
 ``OnlineSettings`` is resolved once at config time and never moves.
 
 This module owns that pair for the whole run. Readers take a
@@ -22,13 +22,15 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
 
-from comicbox.config.online.settings import (
-    MatchMode,
-    OnlineLookupSettings,
-    OnlineSettings,
-    Prompts,
-)
+if TYPE_CHECKING:
+    from comicbox.config.online.settings import (
+        MatchMode,
+        OnlineLookupSettings,
+        OnlineSettings,
+        Prompts,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,11 +39,6 @@ class LookupPolicy:
 
     match: MatchMode
     prompts: Prompts
-
-    @property
-    def unattended(self) -> bool:
-        """Whether comicbox may not prompt."""
-        return self.prompts is Prompts.NEVER
 
 
 class OnlineSessionState:

--- a/comicbox/formats/base/online/sources/base.py
+++ b/comicbox/formats/base/online/sources/base.py
@@ -42,7 +42,7 @@ def refresh_cache_unlink_once(cache_path: Path) -> None:
     an unguarded unlink wiped the response cache between calls — e.g.
     between search() and get() of the same file — defeating the
     +1-API-call-per-unique-volume amortization get() relies on and
-    re-spending API budget on every file of a --refresh-cache batch.
+    re-spending API budget on every file of a `--cache refresh` batch.
     """
     with _refresh_lock:
         if str(cache_path) in _refreshed_cache_paths:

--- a/comicbox/online_session.py
+++ b/comicbox/online_session.py
@@ -77,6 +77,7 @@ __all__ = (
     "OnlineSession",
     "PromptHandler",
     "PromptResponse",
+    "Prompts",
     "RunEstimate",
     "SourceName",
     "estimate_run",
@@ -115,8 +116,8 @@ class OnlinePrompt:
     source: str
     profile_summary: dict[str, Any]
     candidates: tuple[Candidate, ...]
-    mode: MatchMode
-    unattended: bool
+    match: MatchMode
+    prompts: Prompts
 
 
 @dataclass(frozen=True, slots=True)
@@ -126,11 +127,12 @@ class PromptResponse:
 
     ``action`` mirrors :data:`SelectorAction`; ``payload`` is the index for
     ``choose``, the ``"<source>:<id>"`` string for ``manual``, the new
-    :class:`MatchMode` value (e.g. ``"auto"``) for ``set_policy``, or
+    :class:`MatchMode` value (e.g. ``"auto"``) for ``set_policy``, the new
+    :class:`Prompts` value (e.g. ``"never"``) for ``set_prompts``, or
     ``None`` otherwise.
     """
 
-    action: Literal["choose", "skip", "manual", "abort", "set_unattended", "set_policy"]
+    action: Literal["choose", "skip", "manual", "abort", "set_prompts", "set_policy"]
     payload: int | str | None = None
 
 
@@ -222,7 +224,7 @@ class DeferredPrompt:
     A prompt the session skipped under defer_prompts mode.
 
     Captures everything Codex needs to render the prompt later in a
-    review-tagging UI: the file it came from, source, candidates, mode
+    review-tagging UI: the file it came from, source, candidates, match
     context, and the fingerprint used to key the dedup cache. Codex
     feeds the user's resolution back via :meth:`OnlineSession.preload_resolution`.
     """
@@ -232,8 +234,8 @@ class DeferredPrompt:
     fingerprint: str
     profile_summary: dict[str, Any]
     candidates: tuple[Candidate, ...]
-    mode: MatchMode
-    unattended: bool
+    match: MatchMode
+    prompts: Prompts
 
 
 # --- session ---------------------------------------------------------------
@@ -267,7 +269,7 @@ class OnlineSession:
 
     Construction validates per-source credentials and pre-computes the
     ComicboxSettings layer that each per-file Comicbox instance will see.
-    Mutable state — the lookup policy (``mode`` / ``unattended``) and the
+    Mutable state — the lookup policy (``match`` / ``prompts``) and the
     cancel token — lives on the instance and may be updated from any
     thread. The policy lives in an ``OnlineSessionState`` shared with
     every box the session spawns, so a change made at a prompt needs no
@@ -292,8 +294,8 @@ class OnlineSession:
         sources: Iterable[str] = ("metron", "comicvine"),
         ids: Mapping[str, int] | None = None,
         credentials: OnlineCredentials | None = None,
-        mode: MatchMode = MatchMode.AUTO,
-        unattended: bool = False,
+        match: MatchMode = MatchMode.AUTO,
+        prompts: Prompts = Prompts.ASK,
         prompt_handler: PromptHandler | None = None,
         on_event: EventHandler | None = None,
         rematch: bool = False,
@@ -315,8 +317,8 @@ class OnlineSession:
         self._credentials = credentials or OnlineCredentials()
         self._validate_credentials(self._sources, self._credentials)
         self._state = OnlineSessionState(
-            match=self._validate_mode(mode),
-            prompts=Prompts.NEVER if unattended else Prompts.ASK,
+            match=self._validate_match(match),
+            prompts=prompts,
         )
         self._prompt_handler = prompt_handler
         self._on_event = on_event
@@ -372,28 +374,28 @@ class OnlineSession:
     # -- mutable session state ----------------------------------------------
 
     @property
-    def mode(self) -> MatchMode:
+    def match(self) -> MatchMode:
         """
-        Current session mode (read-only; mutate via set_mode()).
+        Current session match mode (read-only; mutate via set_match()).
 
-        May report ``MatchMode.ASK`` even though ``set_mode`` rejects it:
-        a prompt handler answering ``set_policy: "ask"`` can put the
+        May report ``MatchMode.ASK`` even though ``set_match`` rejects
+        it: a prompt handler answering ``set_policy: "ask"`` can put the
         session there, since that path has a handler to do the asking.
         """
         return self._state.snapshot().match
 
     @property
-    def unattended(self) -> bool:
-        """Current session unattended flag."""
-        return self._state.snapshot().unattended
+    def prompts(self) -> Prompts:
+        """Current session prompt policy."""
+        return self._state.snapshot().prompts
 
-    def set_mode(self, mode: MatchMode) -> None:
-        """Change the session mode for subsequent file lookups."""
-        self._state.set_match(self._validate_mode(mode))
+    def set_match(self, match: MatchMode) -> None:
+        """Change the session match mode for subsequent file lookups."""
+        self._state.set_match(self._validate_match(match))
 
-    def set_unattended(self, *, unattended: bool) -> None:
-        """Toggle the unattended flag for subsequent file lookups."""
-        self._state.set_prompts(Prompts.NEVER if unattended else Prompts.ASK)
+    def set_prompts(self, prompts: Prompts) -> None:
+        """Change the session prompt policy for subsequent file lookups."""
+        self._state.set_prompts(prompts)
 
     def cancel(self) -> None:
         """Stop accepting new files. In-flight lookup runs to completion."""
@@ -670,12 +672,12 @@ class OnlineSession:
                 source=ctx.source,
                 profile_summary=_summarise_profile(profile),
                 candidates=cand_tuple,
-                mode=policy.match,
-                unattended=policy.unattended,
+                match=policy.match,
+                prompts=policy.prompts,
             )
             response = handler.request(prompt)
             # No session-state sync here: the box applies set_policy /
-            # set_unattended to the OnlineSessionState this session shares
+            # set_prompts to the OnlineSessionState this session shares
             # with it, so the change is already ours.
             self._store_prompt_resolution(fingerprint, response, cand_tuple)
             return (response.action, response.payload)
@@ -697,8 +699,8 @@ class OnlineSession:
             fingerprint=fingerprint,
             profile_summary=_summarise_profile(profile),
             candidates=candidates,
-            mode=policy.match,
-            unattended=policy.unattended,
+            match=policy.match,
+            prompts=policy.prompts,
         )
         with self._deferred_lock:
             self._deferred.append(deferred)
@@ -749,9 +751,9 @@ class OnlineSession:
                 chosen_volume_id = candidates[response.payload].volume_id
             except IndexError:
                 chosen_volume_id = None
-        # Session-level actions (set_unattended / set_policy / abort) are
+        # Session-level actions (set_prompts / set_policy / abort) are
         # not cached: they apply once, not as a deferred decision.
-        if response.action in {"set_unattended", "set_policy", "abort"}:
+        if response.action in {"set_prompts", "set_policy", "abort"}:
             return
         entry = _CachedResolution(
             action=response.action,
@@ -851,18 +853,18 @@ class OnlineSession:
             raise OnlineConfigurationError(msg)
 
     @staticmethod
-    def _validate_mode(mode: MatchMode) -> MatchMode:
-        if not isinstance(mode, MatchMode):  # pyright: ignore[reportUnnecessaryIsInstance]
-            msg = f"OnlineSession.mode must be a MatchMode enum value; got {mode!r}."  # pyright: ignore[reportUnreachable]
+    def _validate_match(match: MatchMode) -> MatchMode:
+        if not isinstance(match, MatchMode):  # pyright: ignore[reportUnnecessaryIsInstance]
+            msg = f"OnlineSession.match must be a MatchMode enum value; got {match!r}."  # pyright: ignore[reportUnreachable]
             raise OnlineConfigurationError(msg)
-        if mode is MatchMode.ASK:
+        if match is MatchMode.ASK:
             msg = (
-                "OnlineSession.mode does not accept MatchMode.ASK; "
+                "OnlineSession.match does not accept MatchMode.ASK; "
                 "the session has no built-in prompt resolver. Use a "
                 "PromptHandler or defer_prompts=True instead."
             )
             raise OnlineConfigurationError(msg)
-        return mode
+        return match
 
 
 def _summarise_profile(profile: ComicProfile) -> dict[str, Any]:

--- a/comicbox/run.py
+++ b/comicbox/run.py
@@ -62,7 +62,7 @@ class Runner:
         #: `in` / `__setitem__` to stay consistent between them.
         self._series_cache = SeriesCache()
         #: Batch-wide owner of the two mutable lookup settings. Seeded from
-        #: the config-resolved values; a `set_policy` / `set_unattended`
+        #: the config-resolved values; a `set_policy` / `set_prompts`
         #: answered at any file's prompt applies to the rest of the batch.
         #: Built here rather than after `_maybe_auto_engage_effort`
         #: because that only rewrites per-source effort, never match or

--- a/tests/unit/test_auto_engage.py
+++ b/tests/unit/test_auto_engage.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 def _settings(
     *,
-    effort: Effort = Effort.BALANCED,
+    effort: Effort | None = None,
     per_source: dict[str, OnlineSourceTuning] | None = None,
     unattended: bool = False,
 ) -> OnlineSettings:
@@ -71,12 +71,29 @@ def test_no_op_when_batch_size_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result is settings
 
 
-def test_no_op_when_global_effort_not_balanced(
+def test_no_op_when_global_effort_is_thorough(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """User pinned --effort thorough → respect, never auto-engage."""
     _force_tty(monkeypatch, is_tty=False)
     settings = _settings(effort=Effort.THOROUGH, unattended=True)
+    result = resolve_auto_engaged_budget(settings, batch_size=500)
+    assert result is settings
+
+
+def test_no_op_when_global_effort_is_explicitly_balanced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An explicit `--effort balanced` is a choice, not silence.
+
+    `balanced` is also what an unset effort resolves to, so while the
+    two shared one representation this run was downgraded to `minimal`
+    against the user's stated wish — silently, and only on big batches.
+    An unset effort is None now, so naming the default still pins it.
+    """
+    _force_tty(monkeypatch, is_tty=False)
+    settings = _settings(effort=Effort.BALANCED, unattended=True)
     result = resolve_auto_engaged_budget(settings, batch_size=500)
     assert result is settings
 

--- a/tests/unit/test_cli_choices_enum_drift.py
+++ b/tests/unit/test_cli_choices_enum_drift.py
@@ -1,0 +1,107 @@
+"""
+Every enum-backed CLI flag's ``choices`` must be its enum's values.
+
+``--merge-mode`` always built its choices from ``MergeMode``; the four
+online flags spelled theirs out as literal tuples instead, so what
+argparse accepted and what the value parsed into were two separately
+maintained lists. Nothing caught a divergence: the dest/template test
+pins a flag to its config key and the defaults test pins the YAML to the
+dataclass, but neither looks at the accepted values. Adding a level to
+``Effort`` or renaming a ``MatchMode`` would have left the flag
+rejecting a value its own parser understands.
+
+The flags now derive ``choices`` from the enums. This test keeps them
+derived, keeps the help text listing every value, and fails on any *new*
+choices-taking flag until it is either mapped to its enum here or listed
+as deliberately not enum-backed — so neither map below can rot into a
+permanent excuse.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from comicbox.cli.parser import build_parser
+from comicbox.config.online.settings import CacheMode, Effort, MatchMode, Prompts
+from comicbox.config.settings import MergeMode
+
+if TYPE_CHECKING:
+    from argparse import Action, ArgumentParser
+    from enum import Enum
+
+# Flag -> the enum whose values it accepts.
+_ENUM_BACKED: dict[str, type[Enum]] = {
+    "--merge-mode": MergeMode,
+    "--match": MatchMode,
+    "--prompts": Prompts,
+    "--cache": CacheMode,
+    "--effort": Effort,
+}
+
+# Choices that legitimately come from somewhere other than a comicbox
+# enum: --pdf-pages takes its values from the installed pdffile.
+_NOT_ENUM_BACKED = frozenset({"--pdf-pages"})
+
+_PARSER: ArgumentParser = build_parser()
+
+
+def _choices_actions() -> list[Action]:
+    """Every parser action that constrains its value to a fixed set."""
+    return [action for action in _PARSER._actions if action.choices is not None]
+
+
+def _action_for(flag: str) -> Action:
+    for action in _choices_actions():
+        if flag in action.option_strings:
+            return action
+    reason = f"{flag} is not a choices-taking parser option"
+    raise AssertionError(reason)
+
+
+@pytest.mark.parametrize(("flag", "enum_class"), _ENUM_BACKED.items())
+def test_choices_are_the_enum_values(flag: str, enum_class: type[Enum]) -> None:
+    """A flag accepts exactly its enum's values, in the enum's order."""
+    assert tuple(_action_for(flag).choices or ()) == tuple(
+        member.value for member in enum_class
+    )
+
+
+@pytest.mark.parametrize(("flag", "enum_class"), _ENUM_BACKED.items())
+def test_help_lists_every_choice(flag: str, enum_class: type[Enum]) -> None:
+    """
+    The help text names every value the flag accepts.
+
+    Deriving ``choices`` stops argparse from rejecting a new enum
+    member, but the help string is still hand-written prose; without
+    this, a new member is accepted and undocumented.
+    """
+    help_text = _action_for(flag).help or ""
+    missing = [
+        member.value
+        for member in enum_class
+        if not re.search(rf"\b{re.escape(str(member.value))}\b", help_text)
+    ]
+    assert not missing, f"{flag} help does not mention {missing}"
+
+
+def test_every_choices_flag_declares_where_its_values_come_from() -> None:
+    """A new choices-taking flag must be mapped to an enum or exempted."""
+    accounted = set(_ENUM_BACKED) | _NOT_ENUM_BACKED
+    unaccounted = [
+        action.option_strings
+        for action in _choices_actions()
+        if not accounted.intersection(action.option_strings)
+    ]
+    assert not unaccounted, (
+        f"{unaccounted} take choices but name no source for them; "
+        "map the flag to its enum or add it to _NOT_ENUM_BACKED."
+    )
+
+
+def test_the_exemption_list_is_not_stale() -> None:
+    """An exempted flag that gained an enum (or vanished) must be re-filed."""
+    for flag in _NOT_ENUM_BACKED:
+        assert _action_for(flag).choices, f"{flag} no longer takes choices"

--- a/tests/unit/test_online_prompt_loops.py
+++ b/tests/unit/test_online_prompt_loops.py
@@ -165,11 +165,11 @@ def test_ask_policy_choice_none_reply_aborts(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.parametrize("reply", ["u", "unattended", "U"])
-def test_ask_session_options_unattended(
+def test_ask_session_options_prompts(
     monkeypatch: pytest.MonkeyPatch, reply: str
 ) -> None:
     monkeypatch.setattr(prompt, "_prompt_line", ScriptedPrompt(reply))
-    assert prompt._ask_session_options() == ("set_unattended", None)
+    assert prompt._ask_session_options() == ("set_prompts", "never")
 
 
 @pytest.mark.parametrize("reply", ["p", "policy"])
@@ -186,7 +186,7 @@ def test_ask_session_options_policy_back_unwinds_one_level(
     """`b` in the policy submenu returns to session options, not the top."""
     scripted = ScriptedPrompt("p", "b", "u")
     monkeypatch.setattr(prompt, "_prompt_line", scripted)
-    assert prompt._ask_session_options() == ("set_unattended", None)
+    assert prompt._ask_session_options() == ("set_prompts", "never")
     assert scripted.messages == ["Option:", "Policy:", "Option:"]
 
 
@@ -203,7 +203,7 @@ def test_ask_session_options_reprompts_on_garbage(
 ) -> None:
     scripted = ScriptedPrompt("nope", "u")
     monkeypatch.setattr(prompt, "_prompt_line", scripted)
-    assert prompt._ask_session_options() == ("set_unattended", None)
+    assert prompt._ask_session_options() == ("set_prompts", "never")
     assert len(scripted.messages) == 2
     assert "unrecognized: 'nope'" in capsys.readouterr().out
 
@@ -258,7 +258,7 @@ def test_resolve_cli_selector_input_options_delegates(
 ) -> None:
     monkeypatch.setattr(prompt, "_prompt_line", ScriptedPrompt("u"))
     result = prompt._resolve_cli_selector_input("o", [make_candidate()], "metron")
-    assert result == ("set_unattended", None)
+    assert result == ("set_prompts", "never")
 
 
 def test_resolve_cli_selector_input_options_back_reprompts(

--- a/tests/unit/test_online_result_contract.py
+++ b/tests/unit/test_online_result_contract.py
@@ -420,7 +420,7 @@ def test_prompt_loop_caps_repeated_session_changes(monkeypatch) -> None:
     """
     A selector that only ever asks for session changes must terminate.
 
-    ``set_policy`` / ``set_unattended`` re-resolve and re-prompt, so a
+    ``set_policy`` / ``set_prompts`` re-resolve and re-prompt, so a
     callback that never returns a terminal action span the loop forever.
     """
     instances = _patch_metron(

--- a/tests/unit/test_online_selector.py
+++ b/tests/unit/test_online_selector.py
@@ -166,9 +166,9 @@ def test_manual_id_for_other_source_skipped(patched_metron) -> None:
     assert patched_metron[0].get_calls == []
 
 
-def test_set_unattended_changes_session_state_and_skips(patched_metron) -> None:
+def test_set_prompts_changes_session_state_and_skips(patched_metron) -> None:
     def selector(profile, candidates, ctx):
-        return ("set_unattended", None)
+        return ("set_prompts", "never")
 
     cb = _build_cb()
     state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
@@ -264,7 +264,7 @@ def test_session_state_carries_across_boxes(patched_metron) -> None:
     state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
 
     def selector(profile, candidates, ctx):
-        return ("set_unattended", None)
+        return ("set_prompts", "never")
 
     first = _build_cb()
     first.set_online_session_state(state)
@@ -284,7 +284,7 @@ def test_standalone_box_gets_its_own_state(patched_metron) -> None:
     """No injected state: the box seeds a private one from its own config."""
 
     def selector(profile, candidates, ctx):
-        return ("set_unattended", None)
+        return ("set_prompts", "never")
 
     first = _build_cb()
     first.set_online_selector(selector)

--- a/tests/unit/test_online_session.py
+++ b/tests/unit/test_online_session.py
@@ -30,8 +30,8 @@ VALID_BOTH = OnlineCredentials(metron_user="u", metron_password="p", comicvine_k
 def test_construct_with_valid_creds() -> None:
     """Construction works when every enabled source has its required fields."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    assert session.mode is MatchMode.AUTO
-    assert session.unattended is False
+    assert session.match is MatchMode.AUTO
+    assert session.prompts is Prompts.ASK
     assert session.cancelled is False
 
 
@@ -48,7 +48,7 @@ def test_rejects_empty_sources() -> None:
 def test_construct_with_metron_token_only() -> None:
     """An API token authenticates Metron without a username or password."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON_TOKEN)
-    assert session.mode is MatchMode.AUTO
+    assert session.match is MatchMode.AUTO
 
 
 def test_rejects_metron_without_creds() -> None:
@@ -69,21 +69,21 @@ def test_rejects_comicvine_without_key() -> None:
         OnlineSession(sources={"comicvine"}, credentials=VALID_METRON)
 
 
-def test_rejects_non_enum_mode() -> None:
+def test_rejects_non_enum_match() -> None:
     with pytest.raises(OnlineConfigurationError, match="must be a MatchMode"):
         OnlineSession(
             sources={"metron"},
             credentials=VALID_METRON,
-            mode="normal",  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
+            match="normal",  # pyright: ignore[reportArgumentType], # ty: ignore[invalid-argument-type]
         )
 
 
-def test_rejects_ask_mode() -> None:
+def test_rejects_ask_match() -> None:
     with pytest.raises(OnlineConfigurationError, match=r"MatchMode\.ASK"):
         OnlineSession(
             sources={"metron"},
             credentials=VALID_METRON,
-            mode=MatchMode.ASK,
+            match=MatchMode.ASK,
         )
 
 
@@ -119,21 +119,21 @@ def test_rejects_ids_for_a_source_not_in_the_session() -> None:
 
 
 @pytest.mark.parametrize(
-    "mode",
+    "match",
     [MatchMode.CAREFUL, MatchMode.AUTO, MatchMode.EAGER],
 )
-def test_mode_propagates_to_match_setting(mode: MatchMode) -> None:
+def test_match_propagates_to_match_setting(match: MatchMode) -> None:
     session = OnlineSession(
         sources={"metron"},
         credentials=VALID_METRON,
-        mode=mode,
+        match=match,
     )
-    assert session._settings.online.lookup.match is mode
+    assert session._settings.online.lookup.match is match
 
 
-def test_unattended_maps_to_prompts_never() -> None:
+def test_prompts_propagates_to_prompts_setting() -> None:
     session = OnlineSession(
-        sources={"metron"}, credentials=VALID_METRON, unattended=True
+        sources={"metron"}, credentials=VALID_METRON, prompts=Prompts.NEVER
     )
     assert session._settings.online.lookup.prompts == Prompts.NEVER
 
@@ -143,19 +143,19 @@ def _live_lookup(session: OnlineSession):
     return session._state.overlay(session._settings.online).lookup
 
 
-def test_set_mode_changes_subsequent_lookups() -> None:
+def test_set_match_changes_subsequent_lookups() -> None:
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
     assert _live_lookup(session).match == MatchMode.AUTO
-    session.set_mode(MatchMode.EAGER)
+    session.set_match(MatchMode.EAGER)
     assert _live_lookup(session).match == MatchMode.EAGER
 
 
-def test_set_unattended_changes_subsequent_lookups() -> None:
+def test_set_prompts_changes_subsequent_lookups() -> None:
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
     assert _live_lookup(session).prompts == Prompts.ASK
-    session.set_unattended(unattended=True)
+    session.set_prompts(Prompts.NEVER)
     assert _live_lookup(session).prompts == Prompts.NEVER
-    session.set_unattended(unattended=False)
+    session.set_prompts(Prompts.ASK)
     assert _live_lookup(session).prompts == Prompts.ASK
 
 
@@ -292,31 +292,49 @@ def test_set_policy_via_handler_persists_across_files() -> None:
     """A handler's set_policy must outlive the in-flight file."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
     assert _apply_via_box(session, "set_policy", "eager") is True
-    assert session.mode is MatchMode.EAGER
+    assert session.match is MatchMode.EAGER
 
 
-def test_set_unattended_via_handler_persists_across_files() -> None:
+def test_set_prompts_via_handler_persists_across_files() -> None:
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
-    assert _apply_via_box(session, "set_unattended", None) is True
-    assert session.unattended is True
+    assert _apply_via_box(session, "set_prompts", "never") is True
+    assert session.prompts is Prompts.NEVER
+
+
+def test_set_prompts_via_handler_is_reversible() -> None:
+    """The action names its new value, so it goes back the way it came."""
+    session = OnlineSession(
+        sources={"metron"}, credentials=VALID_METRON, prompts=Prompts.NEVER
+    )
+    assert _apply_via_box(session, "set_prompts", "ask") is True
+    assert session.prompts is Prompts.ASK
 
 
 def test_set_policy_ask_persists() -> None:
-    """ASK sticks when a handler asks for it, though set_mode still refuses it."""
+    """ASK sticks when a handler asks for it, though set_match still refuses it."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
     assert _apply_via_box(session, "set_policy", "ask") is True
-    assert session.mode is MatchMode.ASK
+    assert session.match is MatchMode.ASK
     with pytest.raises(OnlineConfigurationError):
-        session.set_mode(MatchMode.ASK)
+        session.set_match(MatchMode.ASK)
 
 
-def test_malformed_set_policy_declines_and_leaves_mode() -> None:
+def test_malformed_set_policy_declines_and_leaves_match() -> None:
     """Bad payloads are declined, loudly, and don't move the session."""
     session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
     assert _apply_via_box(session, "set_policy", "bogus") is False
-    assert session.mode is MatchMode.AUTO
+    assert session.match is MatchMode.AUTO
     assert _apply_via_box(session, "set_policy", 7) is False
-    assert session.mode is MatchMode.AUTO
+    assert session.match is MatchMode.AUTO
+
+
+def test_malformed_set_prompts_declines_and_leaves_prompts() -> None:
+    """set_prompts validates its payload the same way set_policy does."""
+    session = OnlineSession(sources={"metron"}, credentials=VALID_METRON)
+    assert _apply_via_box(session, "set_prompts", "bogus") is False
+    assert session.prompts is Prompts.ASK
+    assert _apply_via_box(session, "set_prompts", None) is False
+    assert session.prompts is Prompts.ASK
 
 
 # --- prompt-handler bridging --------------------------------------------------

--- a/tests/unit/test_online_session_state.py
+++ b/tests/unit/test_online_session_state.py
@@ -27,20 +27,14 @@ def test_from_lookup_seeds_both_fields() -> None:
     assert policy.prompts is Prompts.NEVER
 
 
-def test_unattended_is_derived_from_prompts() -> None:
-    assert LookupPolicy(MatchMode.AUTO, Prompts.NEVER).unattended is True
-    assert LookupPolicy(MatchMode.AUTO, Prompts.ASK).unattended is False
-
-
 def test_setters_move_only_their_own_field() -> None:
     state = OnlineSessionState(match=MatchMode.AUTO, prompts=Prompts.ASK)
     state.set_match(MatchMode.CAREFUL)
     assert state.snapshot() == LookupPolicy(MatchMode.CAREFUL, Prompts.ASK)
     state.set_prompts(Prompts.NEVER)
     assert state.snapshot() == LookupPolicy(MatchMode.CAREFUL, Prompts.NEVER)
-    # Unattended is reversible, unlike the one-way prompt action.
     state.set_prompts(Prompts.ASK)
-    assert state.snapshot().unattended is False
+    assert state.snapshot() == LookupPolicy(MatchMode.CAREFUL, Prompts.ASK)
 
 
 def test_overlay_replaces_the_policy_and_nothing_else() -> None:

--- a/tests/unit/test_prompt_dedup.py
+++ b/tests/unit/test_prompt_dedup.py
@@ -127,8 +127,10 @@ def test_different_fingerprint_re_prompts() -> None:
 
 
 def test_session_actions_are_not_cached() -> None:
-    """set_unattended / set_policy / abort should not be cached — they're once-off."""
-    recorder = _Recorder(response=PromptResponse(action="set_unattended"), seen=[])
+    """set_prompts / set_policy / abort should not be cached — they're once-off."""
+    recorder = _Recorder(
+        response=PromptResponse(action="set_prompts", payload="never"), seen=[]
+    )
     session = OnlineSession(
         sources={"metron"}, credentials=VALID, prompt_handler=recorder
     )


### PR DESCRIPTION
Audit of the `--match` / `--merge-mode` / `--effort` CLI surface after
v5.0.0's option changes, plus the two follow-ups it turned up.

The flags themselves were correct — they line up with their enums, the
config template, `config_default.yaml`, the `COMICBOX_ONLINE__*` env
names and the rendered `-h`. What was wrong was prose pointing at flags
that don't exist, one silent behavioral gap, and a public API that
never followed the rename the rest of v5.0.0 made.

## Flags that don't exist (`db76298`)

The no-TTY hint told users to *"pass `--unattended`"*. Checked against
`v4.8.7`: that message shipped, and the parser there had no such flag
either, so it is a released bug rather than an in-flight typo. It names
`--prompts never` now. The same ghost ran through `auto_engage` and
`outcome_stats` prose, along with `--refresh-cache` (it is
`--cache refresh`) and `--online-sources` (the argparse dest, not the
flag). A scan over every `--flag` string in `comicbox/` now reports
none.

The `online_lookup` module docstring still described an M2 milestone
where `--id` was the only path, and gated step 1 on `--ignore-existing`,
a flag that was never implemented. It now describes the four paths the
mixin actually takes. `_has_existing_identifier`, left behind by that
feature, had no callers and is gone.

## Choices derived from their enums (`db76298`)

`--merge-mode` always built its `choices` from `MergeMode`, but
`--match`, `--prompts`, `--cache` and `--effort` spelled theirs out as
literal tuples — so what argparse accepted and what the value parsed
into were two separately maintained lists, with no test looking at the
pair. All four derive now. Values and order are byte-identical to the
old literals, so nothing user-visible moved.

`tests/unit/test_cli_choices_enum_drift.py` pins `choices` to the enum,
pins the help text to every member (deriving `choices` stops argparse
rejecting a new member, but the help is still hand-written prose), and
fails on any new choices-taking flag until it declares where its values
come from. Verified it bites: temporarily dropping `thorough` from
`--effort` fails both assertions.

## `--effort balanced` is honored (`5b6f9ed`)

`config_default.yaml` shipped `effort: balanced`, so the resolved global
effort was `Effort.BALANCED` whether the user typed `--effort balanced`
or typed nothing. That identity was `auto_engage`'s only "the user has
spoken" signal, so a >=50 file `--prompts never` run silently pinned
Comic Vine to `minimal` over an explicit request for `balanced`.

Fixed by making "unset" representable instead of inferred: the YAML
default is `null`, `OnlineTuningSettings.effort` is `Effort | None`,
`resolve_effort()` supplies `BALANCED`, and auto-engagement fires only
on `None`. One change covers all three layers — naming an effort on the
command line, in `COMICBOX_ONLINE__TUNING__EFFORT`, or in a config file
is a choice at every one of them.

## `OnlineSession` speaks match / prompts (`74ee73a`)

v5.0.0 renamed the write API's `mode` to `merge_mode`. The online side
made the same move everywhere except its public façade. Renamed:
`mode` -> `match`, `set_mode` -> `set_match`, `unattended: bool` ->
`prompts: Prompts` (so the enum the config models reaches the public
surface), `set_unattended` -> `set_prompts`, and `OnlinePrompt` /
`DeferredPrompt` carry `.match` / `.prompts`.

The `set_unattended` selector action becomes `set_prompts` and names the
policy it sets, mirroring `set_policy`. That makes it reversible: it
previously hard-coded `Prompts.NEVER` and ignored its payload, so a
handler could turn prompting off but never back on. Both session actions
now parse their payload through one validator.

**Codex needs a paired change.** The kwargs and properties fail loudly,
but a `PromptResponse` still saying `"set_unattended"` is an unknown
action rather than an error.

## Verification

`make fix`, `make lint`, `make ty` and `make complexity` clean;
2087 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
